### PR TITLE
chore(validator): drop length caps on headline/rationale/shows/unknowns

### DIFF
--- a/data/schema/slice-assessment.v1.json
+++ b/data/schema/slice-assessment.v1.json
@@ -59,13 +59,11 @@
     "headline": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 80,
       "description": "One-line human-readable summary shown on the protocol card."
     },
     "rationale": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 600,
       "description": "Prose explanation. Every factual claim must map to an evidence[] entry."
     },
     "evidence": {
@@ -76,7 +74,7 @@
         "additionalProperties": false,
         "properties": {
           "url": { "type": "string", "format": "uri" },
-          "shows": { "type": "string", "minLength": 1, "maxLength": 240 },
+          "shows": { "type": "string", "minLength": 1 },
           "chain": { "type": "string" },
           "address": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
           "commit": { "type": "string", "pattern": "^[0-9a-f]{7,40}$" },
@@ -86,7 +84,7 @@
     },
     "unknowns": {
       "type": "array",
-      "items": { "type": "string", "maxLength": 240 },
+      "items": { "type": "string", "minLength": 1 },
       "description": "Things the contributor looked for but could not determine. Used by reviewers to direct follow-up runs."
     }
   },

--- a/packages/validator/src/schema.test.ts
+++ b/packages/validator/src/schema.test.ts
@@ -89,16 +89,6 @@ describe("SubmissionSchema", () => {
     expect(SubmissionSchema.safeParse(bad).success).toBe(false);
   });
 
-  it("rejects headline > 80 chars", () => {
-    const bad = { ...(VALID as object), headline: "x".repeat(81) };
-    expect(SubmissionSchema.safeParse(bad).success).toBe(false);
-  });
-
-  it("rejects rationale > 600 chars", () => {
-    const bad = { ...(VALID as object), rationale: "x".repeat(601) };
-    expect(SubmissionSchema.safeParse(bad).success).toBe(false);
-  });
-
   it("committed JSON Schema declares the same required fields", () => {
     expect(jsonSchema.required).toEqual(
       expect.arrayContaining([

--- a/packages/validator/src/schema.ts
+++ b/packages/validator/src/schema.ts
@@ -12,7 +12,7 @@ export const SLICES = [
 const EvidenceSchema = z
   .object({
     url: z.string().url(),
-    shows: z.string().min(1).max(240),
+    shows: z.string().min(1),
     chain: z.string().optional(),
     address: z.string().regex(/^0x[0-9a-fA-F]{40}$/).optional(),
     commit: z.string().regex(/^[0-9a-f]{7,40}$/).optional(),
@@ -31,10 +31,10 @@ const base = z
     model: z.string().min(1).max(120),
     chat_url: z.string().url().nullable().optional(),
     grade: z.enum(GRADES),
-    headline: z.string().min(1).max(80),
-    rationale: z.string().min(1).max(600),
+    headline: z.string().min(1),
+    rationale: z.string().min(1),
     evidence: z.array(EvidenceSchema),
-    unknowns: z.array(z.string().max(240)),
+    unknowns: z.array(z.string().min(1)),
   })
   .strict();
 


### PR DESCRIPTION
Submissions were being rejected for exceeding arbitrary char caps that didn't reflect a real constraint. Keep minLength where non-empty is required; remove all maxLength limits on free-text fields.