### PR TITLE
fix(validator): quorum CLI skips unparseable submissions

### DIFF
--- a/packages/validator/src/cli/quorum.ts
+++ b/packages/validator/src/cli/quorum.ts
@@ -46,7 +46,13 @@ async function main(): Promise<number> {
       const entries = files
         .map((f) => {
           const fullPath = join(sliceDir, f);
-          const raw = JSON.parse(readFileSync(fullPath, "utf8"));
+          let raw: unknown;
+          try {
+            raw = JSON.parse(readFileSync(fullPath, "utf8"));
+          } catch (err) {
+            console.error(`skipping unparseable submission ${slug}/${sliceId}/${f}: ${(err as Error).message}`);
+            return null;
+          }
           const parsed = SubmissionSchema.safeParse(raw);
           if (!parsed.success) {
             console.error(`skipping invalid submission ${slug}/${sliceId}/${f}`);


### PR DESCRIPTION

Previously a single submission file with invalid JSON would throw from JSON.parse and abort the entire quorum workflow — one bad submission blocked quorum for all slices across all protocols. Now mirrors the validate CLI behavior: log the parse error and skip the file.