### PR TITLE
quorum: forward ANTHROPIC_API_KEY in workflow, keep --json stdout clean

### DIFF
--- a/.github/workflows/quorum.yml
+++ b/.github/workflows/quorum.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Run quorum
         id: quorum
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           pnpm --silent --filter @defipunkd/validator run quorum -- --json > quorum-report.json
           cat quorum-report.json

--- a/packages/validator/src/cli/quorum.ts
+++ b/packages/validator/src/cli/quorum.ts
@@ -228,7 +228,7 @@ type SynthesizeInput = {
 
 async function synthesizeShortHeadline(input: SynthesizeInput): Promise<string | null> {
   if (!process.env.ANTHROPIC_API_KEY) {
-    console.warn(`[quorum] ${input.slug}/${input.slice}: ANTHROPIC_API_KEY not set, skipping short_headline synthesis`);
+    console.error(`[quorum] ${input.slug}/${input.slice}: ANTHROPIC_API_KEY not set, skipping short_headline synthesis`);
     return null;
   }
   const prompt = buildShortHeadlinePrompt({
@@ -254,7 +254,7 @@ async function synthesizeShortHeadline(input: SynthesizeInput): Promise<string |
       console.warn(`[quorum] ${input.slug}/${input.slice}: LLM output rejected (empty after sanitize): ${JSON.stringify(text)}`);
       return null;
     }
-    console.log(`[quorum] ${input.slug}/${input.slice}: synthesized short_headline = "${cleaned}"`);
+    console.error(`[quorum] ${input.slug}/${input.slice}: synthesized short_headline = "${cleaned}"`);
     return cleaned;
   } catch (err) {
     const e = err as { message?: string; status?: number };


### PR DESCRIPTION
The quorum workflow step didn't pass the repo secret through, so short_headline synthesis was silently skipped in CI. Also route synthesis log lines to stderr so they don't corrupt the --json report piped to quorum-report.json.