### PR TITLE
Add Curve Finance metadata overlay

### DIFF
--- a/data/overlays/curve-finance.json
+++ b/data/overlays/curve-finance.json
@@ -1,5 +1,4 @@
 {
-  "slug": "curve-finance",
   "github": [
     "https://github.com/curvefi/curve-contract",
     "https://github.com/curvefi/curve-stablecoin",
@@ -7,14 +6,5 @@
     "https://github.com/curvefi/curve-aragon-voting",
     "https://github.com/curvefi/curve-js",
     "https://github.com/curvefi/security-incident-reports"
-  ],
-  "docs_url": "https://docs.curve.finance/",
-  "governance_forum": "https://gov.curve.finance/",
-  "voting_token": {
-    "chain": "Ethereum",
-    "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
-    "symbol": "CRV"
-  },
-  "audits_index_url": "https://docs.curve.finance/user/security/audits",
-  "security_contact": "https://github.com/curvefi/security-incident-reports"
+  ]
 }

--- a/data/overlays/curve-finance.json
+++ b/data/overlays/curve-finance.json
@@ -1,0 +1,20 @@
+{
+  "slug": "curve-finance",
+  "github": [
+    "https://github.com/curvefi/curve-contract",
+    "https://github.com/curvefi/curve-stablecoin",
+    "https://github.com/curvefi/curve-dao-contracts",
+    "https://github.com/curvefi/curve-aragon-voting",
+    "https://github.com/curvefi/curve-js",
+    "https://github.com/curvefi/security-incident-reports"
+  ],
+  "docs_url": "https://docs.curve.finance/",
+  "governance_forum": "https://gov.curve.finance/",
+  "voting_token": {
+    "chain": "Ethereum",
+    "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+    "symbol": "CRV"
+  },
+  "audits_index_url": "https://docs.curve.finance/user/security/audits",
+  "security_contact": "https://github.com/curvefi/security-incident-reports"
+}


### PR DESCRIPTION
Adds `data/overlays/curve-finance.json` with verified metadata for Curve Finance:

- 6 monorepo URLs (curve-contract, curve-stablecoin, curve-dao-contracts, curve-aragon-voting, curve-js, security-incident-reports)
- docs.curve.finance, gov.curve.finance, audits index, security contact
- voting token: CRV at `0xD533a949740bb3306d119CC777fa900bA034cd52` (Ethereum)

No grade assessments — pure overlay metadata to fix the empty `/protocol/curve-finance` page.

Follow-up PR will add 5 Claude submissions (verifiability/control/ability-to-exit/autonomy/open-access).