### PR TITLE
Aave V3 — 5-slice assessment (claude-opus-4-7 + gpt-5.5 + gemini-3-flash-preview, snapshot 2026-04-27)

### DIFF
--- a/data/submissions/aave/ability-to-exit/models-2026-04-27.json
+++ b/data/submissions/aave/ability-to-exit/models-2026-04-27.json
@@ -304,7 +304,6 @@
     ]
   },
   {
-    "protocol_slug": "aave-v3",
     "slice": "ability-to-exit",
     "grade": "orange",
     "analysis_date": "2026-04-27",
@@ -363,33 +362,27 @@
       "findings": [
         {
           "code": "E1",
-          "label": "Exit Functions",
-          "description": "The primary exit functions are withdraw() and redeem() (via aTokens). Users can also repay() loans to release collateral."
+          "text": "The primary exit functions are withdraw() and redeem() (via aTokens). Users can also repay() loans to release collateral."
         },
         {
           "code": "E2",
-          "label": "Pause Guards",
-          "description": "The withdraw() function in Pool.sol is protected by the whenNotPaused modifier, which blocks all withdrawals when the pool is paused."
+          "text": "The withdraw() function in Pool.sol is protected by the whenNotPaused modifier, which blocks all withdrawals when the pool is paused."
         },
         {
           "code": "E3",
-          "label": "Pause Roles",
-          "description": "The EmergencyAdmin role (held by the Aave Guardian 6-of-10 multisig on Ethereum) can pause the entire pool indefinitely via PoolConfigurator.setPoolPause()."
+          "text": "The EmergencyAdmin role (held by the Aave Guardian 6-of-10 multisig on Ethereum) can pause the entire pool indefinitely via PoolConfigurator.setPoolPause()."
         },
         {
           "code": "E4",
-          "label": "Emergency vs Governance",
-          "description": "EmergencyAdmin can pause immediately (emergency path). Governance (via Timelock) can also pause/unpause but is subject to voting delays. Neither path has a hard-coded auto-expiry for the pause state."
+          "text": "EmergencyAdmin can pause immediately (emergency path). Governance (via Timelock) can also pause/unpause but is subject to voting delays. Neither path has a hard-coded auto-expiry for the pause state."
         },
         {
           "code": "E6",
-          "label": "No Escape Hatch",
-          "description": "There is no permissionless emergency-exit or 'escape hatch' mechanism that allows users to bypass a paused state to retrieve funds."
+          "text": "There is no permissionless emergency-exit or 'escape hatch' mechanism that allows users to bypass a paused state to retrieve funds."
         },
         {
           "code": "E7",
-          "label": "Frontend Independence",
-          "description": "All exit functions are public and directly callable via block explorers or generic wallet interfaces."
+          "text": "All exit functions are public and directly callable via block explorers or generic wallet interfaces."
         }
       ],
       "steelman": {
@@ -402,34 +395,39 @@
     "evidence": [
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/e979966547630799427047643501988941295272/src/contracts/protocol/pool/Pool.sol",
+        "shows": "(no description)",
         "commit": "e979966547630799427047643501988941295272",
         "fetched_at": "2026-04-27T08:30:00Z"
       },
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/e979966547630799427047643501988941295272/src/contracts/protocol/pool/PoolConfigurator.sol",
+        "shows": "(no description)",
         "commit": "e979966547630799427047643501988941295272",
         "fetched_at": "2026-04-27T08:30:00Z"
       },
       {
         "url": "https://etherscan.io/address/0x87870B27F51f6e012868c11a0323E224401933ba",
+        "shows": "(no description)",
         "address": "0x87870B27F51f6e012868c11a0323E224401933ba",
         "fetched_at": "2026-04-27T08:35:00Z"
       },
       {
         "url": "https://etherscan.io/address/0xc2aa9306c2d6F35f9d9126618296143ad66Ba246",
+        "shows": "(no description)",
         "address": "0xc2aa9306c2d6F35f9d9126618296143ad66Ba246",
         "fetched_at": "2026-04-27T08:35:00Z"
       },
       {
         "url": "https://docs.aave.com/developers/core-contracts/poolconfigurator#setpoolpause",
+        "shows": "(no description)",
         "fetched_at": "2026-04-27T08:40:00Z"
       }
     ],
     "unknowns": [
       "E5: Standard Aave V3 pools do not utilize a withdrawal queue; however, specific RWA or isolated pools may have different liquidity constraints not covered in this core assessment."
     ],
+    "schema_version": 2,
     "slug": "aave",
-    "schema_version": "v2",
     "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
     "prompt_version": 12,
     "headline": "The protocol is graded Orange because while the pause mechanism is broad and lacks a hard-coded time cap (blocking all exits), it is controlled by a high-threshold multisig (6-of-10 Guardian) and the …"

--- a/data/submissions/aave/ability-to-exit/models-2026-04-27.json
+++ b/data/submissions/aave/ability-to-exit/models-2026-04-27.json
@@ -1,0 +1,437 @@
+[
+  {
+    "schema_version": 2,
+    "slug": "aave",
+    "slice": "ability-to-exit",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-04-27",
+    "model": "claude-opus-4-7",
+    "chat_url": null,
+    "grade": "red",
+    "headline": "Aave V3 withdraw/repay/liquidationCall are gated by ReservePaused; 5-of-9 Protocol Guardian Safe (EMERGENCY_ADMIN) can call setPoolPause unilaterally with NO time cap on the paused state — pause persists until same admin clears it. No escape hatch, no auto-expiry.",
+    "rationale": {
+      "verdict": "Choosing red because withdraw/repay/repayWithATokens/repayWithPermit/liquidationCall all delegate to library validators that revert with Errors.ReservePaused() when the reserve's paused bit is set. The pause bit is set/cleared by PoolConfigurator.setReservePause/setPoolPause, gated by onlyEmergencyOrPoolAdmin, callable by either the EMERGENCY_ADMIN_ROLE holder (Aave Protocol Guardian Safe 0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30, verified 5-of-9 Gnosis Safe) or POOL_ADMIN_ROLE holder (Aave Governance v3 Executor Lvl1, 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A, timelocked governance). Critically, neither setPoolPause nor setReservePause take a maximum-duration parameter that bounds the paused state: MAX_GRACE_PERIOD = 4 hours caps only the post-unpause liquidation grace window, not the pause itself. There is no auto-expiry, no escape-hatch / forced-exit mechanism, and no separate already-finalized-claim path that bypasses the pause guard - withdrawal IS the exit, and it is pause-gated. The 5-of-9 emergency-admin multisig can therefore freeze user withdrawals indefinitely without a governance vote, matching the slice's red criterion 'ANY actor (including governance) can pause CLAIMS of finalized exits indefinitely'. Functions are directly callable on-chain via Etherscan Write-as-Proxy and any wallet (no frontend dependency).",
+      "steelman": {
+        "red": "withdraw/repay/liquidationCall all revert under ReservePaused; setPoolPause and setReservePause are callable by a 5-of-9 multisig (EMERGENCY_ADMIN) with NO time cap on the paused state itself, no auto-expiry, no escape hatch. Per the slice rubric 'ANY actor (including governance) can pause CLAIMS of finalized exits indefinitely' = red.",
+        "orange": "Although the pause is technically unbounded in time, the realistic actor classes are non-trivial: the Emergency Admin is a reputational 5-of-9 Safe with 9 distinct DAO-active signers (Chaos Labs, LlamaRisk, Karpatkey, Certora, TokenLogic, BGD Labs, ACI, Ezr3al, StableLab), making indefinite-malicious pause politically expensive; the Pool Admin path runs through the Aave Governance Executor Lvl1 with a timelock and on-chain vote; freeze (setReserveFreeze) only blocks new supply/borrow while keeping repay+liquidation open; the protocol has 5+ years of operational history with no abuse of the pause power. By the rubric '2-of-3 multisig with no time cap' = red and '5-of-9 with reputational signers' is closer to orange.",
+        "green": "Exit functions are directly callable on-chain without any frontend (Pool proxy at 0x87870Bca... has public withdraw/repay/repayWithATokens/repayWithPermit/liquidationCall callable via Etherscan write tab); there is no queued redemption, no withdrawal cap, no admin-signature requirement, no whitelist; withdrawals settle synchronously in the same block; in normal operation users have unilateral exit. The pause is never auto-applied and historically rarely used."
+      },
+      "findings": [
+        {
+          "code": "E1",
+          "text": "User-facing exit functions on Pool: withdraw(asset,amount,to), repay(asset,amount,interestRateMode,onBehalfOf), repayWithATokens(asset,amount,interestRateMode), repayWithPermit(asset,amount,interestRateMode,onBehalfOf,deadline,permitV,permitR,permitS), liquidationCall(collateralAsset,debtAsset,borrower,debtToCover,receiveAToken). All public/virtual/override and delegate to SupplyLogic.executeWithdraw / BorrowLogic.executeRepay / LiquidationLogic.executeLiquidationCall."
+        },
+        {
+          "code": "E2",
+          "text": "ValidationLogic enforces pause guards: validateWithdraw -> require(!isPaused, Errors.ReservePaused()); validateRepay -> require(!isPaused, Errors.ReservePaused()); validateLiquidationCall -> require(!collateralReservePaused && !principalReservePaused, Errors.ReservePaused()). All exit paths are pause-gated; freeze gates only NEW debt creation (validateBorrow) and supply, not repay/withdraw."
+        },
+        {
+          "code": "E3",
+          "text": "PoolConfigurator.setPoolPause(bool paused) external onlyEmergencyOrPoolAdmin -> calls setPoolPause(paused, 0); setReservePause(asset, paused, gracePeriod) public onlyEmergencyOrPoolAdmin. MAX_GRACE_PERIOD = 4 hours but the require(gracePeriod <= MAX_GRACE_PERIOD) only fires when UNPAUSING and bounds the post-unpause liquidation grace window. The PAUSE itself is a boolean with no expiry timestamp - it persists until explicitly unpaused."
+        },
+        {
+          "code": "E4",
+          "text": "Two pause paths: (1) EMERGENCY_ADMIN_ROLE held by Protocol Guardian 0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30 (verified 5-of-9 Gnosis Safe), unilateral pause without governance. (2) POOL_ADMIN_ROLE held by 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A (Aave Governance v3 Executor Lvl1, timelocked). Emergency-admin path has no time cap; pool-admin path requires governance vote."
+        },
+        {
+          "code": "E5",
+          "text": "Aave V3 has NO queued redemption, NO daily withdrawal cap, NO multi-block claim phase. SupplyLogic.executeWithdraw burns aTokens and transfers underlying in the same call/block. Only constraint is reserve liquidity and health factor."
+        },
+        {
+          "code": "E6",
+          "text": "Aave V3 has NO permissionless escape-hatch / forced-exit mechanism. Pool.sol exposes no function that bypasses ValidationLogic.validateWithdraw's ReservePaused require. There is no time-locked auto-unpause, no governance-bypass exit, no aToken redemption path that ignores Pool state."
+        },
+        {
+          "code": "E7",
+          "text": "Etherscan exposes Pool proxy under 'Write as Proxy', delegating to verified implementation. withdraw/repay/repayWithATokens/repayWithPermit/liquidationCall are all directly callable via Etherscan Web3 Connect or any generic wallet/SDK without any Aave-frontend dependency. Recent transaction history confirms organic non-frontend calls. No referrer check, no signed-attestation required."
+        }
+      ]
+    },
+    "evidence": [
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/pool/Pool.sol",
+        "shows": "Pool.sol: withdraw(asset,amount,to), repay(asset,amount,interestRateMode,onBehalfOf), repayWithATokens, repayWithPermit, liquidationCall - all public/virtual/override delegating to SupplyLogic/BorrowLogic/LiquidationLogic.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "shows": "Aave V3 Pool proxy on Ethereum (InitializableImmutableAdminUpgradeabilityProxy, EIP-1967). ABI exposes withdraw / repay / repayWithATokens / repayWithPermit / liquidationCall as public write functions. Implementation pinned at 0x8147b99Df7672a21809c9093e6f6ce1a60f119Bd.",
+        "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/libraries/logic/ValidationLogic.sol",
+        "shows": "ValidationLogic enforces pause guards: validateWithdraw -> require(!isPaused, Errors.ReservePaused()); validateRepay -> require(!isPaused, Errors.ReservePaused()); validateLiquidationCall -> require(!collateralReservePaused && !principalReservePaused, Errors.ReservePaused()). validateBorrow/validateSupply gate on isPaused and isFrozen. ALL exit paths are pause-gated; freeze gates only NEW debt creation.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/libraries/configuration/ReserveConfiguration.sol",
+        "shows": "ReserveConfigurationMap layout: IS_PAUSED_START_BIT_POSITION = 60, PAUSED_MASK; IS_FROZEN_START_BIT_POSITION = 57, FROZEN_MASK. Pause/freeze stored as boolean bits, no associated timestamp.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/pool/PoolConfigurator.sol",
+        "shows": "PoolConfigurator: setPoolPause(bool) external onlyEmergencyOrPoolAdmin -> setPoolPause(paused, 0); setPoolPause(bool, uint40 gracePeriod) public onlyEmergencyOrPoolAdmin iterates all reserves; setReservePause(asset, paused, gracePeriod) public onlyEmergencyOrPoolAdmin. MAX_GRACE_PERIOD = 4 hours but require(gracePeriod <= MAX_GRACE_PERIOD) only fires when UNPAUSING - bounds post-unpause liquidation grace, NOT the pause itself. PAUSE is a boolean with no expiry timestamp.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "shows": "Aave V3 PoolConfigurator proxy on Ethereum mainnet. Holds setPoolPause / setReservePause / setReserveFreeze / dropReserve write methods.",
+        "address": "0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "shows": "Aave V3 ACLManager. POOL_ADMIN_ROLE = 0x12ad05bde78c5ab75238ce885307f96ecd482bb402ef831f99e7018a0f169b7b, EMERGENCY_ADMIN_ROLE = 0x5c91514091af31f62f596a314af7d5be40146b2f2355969392f055e12e0982fb, RISK_ADMIN_ROLE, ASSET_LISTING_ADMIN_ROLE, FLASH_BORROWER_ROLE, BRIDGE_ROLE.",
+        "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "shows": "On-chain verified via Blockscout eth_call: ACLManager.isEmergencyAdmin(0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30) = true; ACLManager.isPoolAdmin(0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A) = true. Confirms current EMERGENCY_ADMIN and POOL_ADMIN holders at block latest 2026-04-27.",
+        "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "fetched_at": "2026-04-27T08:25:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "shows": "Aave Protocol Guardian Safe (Gnosis Safe v1.3.0 proxy). On-chain verified: getThreshold() = 5, getOwners() = 9 distinct EOAs (0x5d49dBcdd300aECc2C311cFB56593E71c445d60d, 0xbA037E4746ff58c55dc8F27a328C428F258DDACb, 0x818C277dBE886b934e60aa047250A73529E26A99, 0x4f96743057482a2E10253AFDacDA3fd9CF2C1DC9, 0xb647055A9915bF9c8021a684E175A353525b9890, 0x57ab7ee15cE5ECacB1aB84EE42D5A9d0d8112922, 0xC5bE5c0134857B4b96F45AA6f6B77DB96Ac1487e, 0xd4af2E86a27F8F77B0556E081F97B215C9cA8f2E, 0xf71fc92e2949ccF6A5Fd369a0b402ba80Bc61E02). 5-of-9 multisig. Holds EMERGENCY_ADMIN_ROLE - can unilaterally call setPoolPause(true) which propagates to ALL reserves with no time cap.",
+        "address": "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "shows": "Aave Governance V3 Executor Lvl1 (per bgd-labs/aave-address-book). Holds POOL_ADMIN_ROLE and is provider.getACLAdmin() (DEFAULT_ADMIN_ROLE), reachable only through successful Aave Governance v3 vote with timelock. Pool-admin pause path requires governance, NOT unilateral admin; emergency-admin pause does NOT require governance.",
+        "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://aave.com/help/governance/aave-community",
+        "shows": "Aave Help docs confirm Protocol Emergency Guardian holds EMERGENCY_ADMIN role on Aave V3 with 5-of-9 multisig configuration; signers include service providers and DAO delegates (Chaos Labs, LlamaRisk, Karpatkey, Certora, TokenLogic, BGD Labs, ACI, Ezr3al, StableLab).",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/libraries/logic/SupplyLogic.sol",
+        "shows": "Aave V3 has NO queued redemption, NO daily withdrawal cap, NO multi-block claim phase. SupplyLogic.executeWithdraw burns aTokens and transfers underlying in the same call/block. Only constraint: reserve liquidity (available unborrowed underlying) and health factor.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2#writeProxyContract",
+        "shows": "Etherscan exposes Aave V3 Pool proxy under 'Write as Proxy', delegating to verified implementation 0x8147b99Df7672a21809c9093e6f6ce1a60f119Bd. withdraw/repay/repayWithATokens/repayWithPermit/liquidationCall/supply/borrow are all directly callable via Etherscan Web3 Connect or any generic wallet/SDK without any Aave-frontend dependency. No referrer check, no signed-attestation required.",
+        "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://aave.com/docs/developers/smart-contracts/pool",
+        "shows": "Aave V3 Pool developer docs document withdraw/repay/repayWithATokens/repayWithPermit/liquidationCall as public ABI-callable functions; permit-style variants are gas-optimization helpers, not required gateways. No ToS-level frontend exclusivity.",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://github.com/bgd-labs/aave-address-book/blob/main/src/AaveV3Ethereum.sol",
+        "shows": "Canonical address registry: AaveV3Ethereum.POOL = 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2; POOL_ADDRESSES_PROVIDER = 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e; POOL_CONFIGURATOR = 0x64b761D848206f447Fe2dd461b0c635Ec39EbB27; ACL_MANAGER = 0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0; ACL_ADMIN = 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A.",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      },
+      {
+        "url": "https://github.com/bgd-labs/aave-address-book/blob/main/src/MiscEthereum.sol",
+        "shows": "MiscEthereum.PROTOCOL_GUARDIAN = 0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30 - the EMERGENCY_ADMIN holder for Aave V3.",
+        "fetched_at": "2026-04-27T08:21:00Z"
+      }
+    ],
+    "unknowns": [
+      "E5: Verified there is no queued-redemption surface - Aave V3 redemptions are synchronous in the same block. Listed for completeness; not a blocker.",
+      "E3: Did not enumerate every individual signer of the 5-of-9 Protocol Guardian Safe by name-to-address mapping (Aave docs name 9 entities: Chaos Labs, LlamaRisk, Karpatkey, Certora, TokenLogic, BGD Labs, ACI, Ezr3al, StableLab; on-chain getOwners returns 9 EOAs but the public mapping of each EOA -> entity was not verified address-by-address from a primary source in this run)."
+    ]
+  },
+  {
+    "schema_version": 2,
+    "slug": "aave",
+    "slice": "ability-to-exit",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-04-27",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "red",
+    "headline": "Aave V3 Ethereum exits are on-chain and synchronous, but the same Pool withdraw/repay/liquidation exits revert when a reserve is paused; PoolConfigurator can set that pause without an expiry, including through the Protocol Guardian multisig emergency path.",
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/aave-dao/aave-v3-origin"
+      ],
+      "docs_url": null,
+      "audits": [],
+      "governance_forum": null,
+      "voting_token": null,
+      "bug_bounty_url": "https://immunefi.com/bug-bounty/aave/information/",
+      "security_contact": null,
+      "deployed_contracts_doc": null,
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+          "role": "EMERGENCY_ADMIN_ROLE / Protocol Guardian for PoolConfigurator pause functions",
+          "actor_class": "multisig"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+          "role": "POOL_ADMIN_ROLE / ACL admin / PoolAddressesProvider owner via Aave governance executor",
+          "actor_class": "governance"
+        }
+      ],
+      "upgradeability": "upgradeable",
+      "about": "Aave V3 is a non-custodial liquidity market where suppliers deposit assets into reserves and receive interest-bearing aTokens, while borrowers draw liquidity against collateral and later repay debt. The Pool contract is the main user entry point for supply, withdraw, borrow, repay, collateral toggling, liquidations, and flash loans; exits are normally synchronous Pool calls rather than a request/claim queue. V3 adds per-reserve risk controls such as pause, freeze, caps, isolation/eMode parameters, and upgradeable Pool/PoolConfigurator proxies governed through Aave administration."
+    },
+    "rationale": {
+      "verdict": "Red best fits the evidence because Pool.withdraw, repay, repayWithPermit, repayWithATokens, and liquidationCall are public on-chain exits, but ValidationLogic requires the relevant reserve not be paused before those exit paths proceed. PoolConfigurator.setPoolPause and setReservePause are callable by emergency or pool admins and set a boolean pause flag with no expiry timestamp; MAX_GRACE_PERIOD limits only the liquidation grace period when unpausing, not the duration of the pause itself. On Ethereum, the emergency path is held by the Protocol Guardian Safe and the governance path by the Aave executor, so a non-user actor can make the current withdrawal/repay/liquidation exits unavailable indefinitely until an admin unpauses; there is no separate finalized-claim function or escape hatch that bypasses the pause guard.",
+      "steelman": {
+        "red": "The strongest red case is that Aave V3 has no separate finalized-claim escape path: the user exit is Pool.withdraw or debt closeout via repay, those paths revert on ReservePaused, and PoolConfigurator can keep the pause boolean set with no protocol-level auto-expiry.",
+        "orange": "The strongest orange case is that the pause actors are not a single EOA or 2-of-3 wallet: the fast emergency actor is a Safe multisig and the pool-admin path is Aave governance, while exits are permissionless and synchronous whenever the reserve is not paused.",
+        "green": "The strongest green case is that normal exits require no admin signature, no frontend, no queue, and no daily cap: users can call withdraw and repay directly against the verified Pool proxy from any wallet or block-explorer write interface when reserves are active."
+      },
+      "findings": [
+        {
+          "code": "E1",
+          "text": "User-facing exit functions on the main Pool surface are withdraw(asset,amount,to), repay(asset,amount,interestRateMode,onBehalfOf), repayWithPermit(asset,amount,interestRateMode,onBehalfOf,deadline,permitV,permitR,permitS), repayWithATokens(asset,amount,interestRateMode), and liquidationCall(collateralAsset,debtAsset,borrower,debtToCover,receiveAToken). There is no requestWithdrawal, redeem, claim, or exit queue function on Pool.sol."
+        },
+        {
+          "code": "E2",
+          "text": "withdraw is public and delegates to validateWithdraw, which requires !isPaused. repay, repayWithPermit, and repayWithATokens are public and use validateRepay, which requires !isPaused. liquidationCall is public and uses validateLiquidationCall, which requires both the collateral reserve and principal reserve not paused."
+        },
+        {
+          "code": "E3",
+          "text": "PoolConfigurator.setPoolPause and setReservePause are guarded by onlyEmergencyOrPoolAdmin. The current Ethereum role surface identifies Protocol Guardian 0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30 as emergency admin and governance executor 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A as pool/admin authority. The pause state is a boolean set on reserve configuration with no maximum duration; the 4-hour MAX_GRACE_PERIOD only caps liquidation grace after unpause."
+        },
+        {
+          "code": "E4",
+          "text": "Emergency and governance paths are distinct: the emergency path is the Protocol Guardian Safe calling onlyEmergencyOrPoolAdmin pause functions, while the governance path is the Pool Admin / ACL Admin executor. Neither path includes an on-chain pause-expiry parameter in setPoolPause or setReservePause."
+        },
+        {
+          "code": "E5",
+          "text": "Aave V3 Pool withdrawals are not queued redemptions. SupplyLogic.executeWithdraw validates, burns the caller's aTokens, and transfers underlying to the recipient in the same call; no daily withdrawal cap or later claim function is present in the inspected Pool/SupplyLogic source."
+        },
+        {
+          "code": "E6",
+          "text": "No forced-exit or permissionless emergency-withdraw bypass was found in the inspected Pool, SupplyLogic, ValidationLogic, or PoolConfigurator code: withdraw goes through validateWithdraw, and the pause flag is only cleared through the admin pause functions."
+        },
+        {
+          "code": "E7",
+          "text": "The Ethereum Pool is a verified EIP-1967 proxy with Read as Proxy and Write as Proxy tabs on Etherscan; the ABI exposes withdraw and repay variants directly, and the Etherscan transaction list shows direct Withdraw and Repay With Permit calls, so exit does not depend on the Aave frontend."
+        }
+      ]
+    },
+    "evidence": [
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/pool/Pool.sol",
+        "shows": "Pool.sol at commit 1e3d70c: main interaction contract; public withdraw, repay, repayWithPermit, repayWithATokens, and liquidationCall functions delegate to SupplyLogic, BorrowLogic, and LiquidationLogic. Also supports protocol_metadata.about.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/libraries/logic/ValidationLogic.sol",
+        "shows": "ValidationLogic pause guards: validateWithdraw requires !isPaused; validateRepay requires !isPaused; validateLiquidationCall requires collateral and principal reserves not paused. No role modifier on user exit; the guard is reserve pause state.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/libraries/logic/SupplyLogic.sol",
+        "shows": "SupplyLogic.executeWithdraw burns aTokens and transfers underlying in the same execution path after validation. No request/claim queue, daily cap, or delayed finalized-claim phase appears in the inspected withdrawal logic.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/pool/PoolConfigurator.sol",
+        "shows": "PoolConfigurator.setPoolPause and setReservePause use onlyEmergencyOrPoolAdmin. MAX_GRACE_PERIOD is 4 hours but is checked only when unpausing to set liquidation grace; currentConfig.setPaused(paused) stores a boolean pause flag with no expiry.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "shows": "Ethereum Aave V3 Pool proxy, labeled Aave: Pool V3, source-code verified as proxy, implementation 0x8147b99Df7672a21809c9093e6f6ce1a60f119Bd, with Read as Proxy / Write as Proxy tabs and recent direct Withdraw / Repay With Permit transactions. Supports E7 and upgradeability metadata.",
+        "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "shows": "Ethereum Aave V3 PoolConfigurator proxy, source-code verified, implementation 0x6fDdde45f777a4e461b0721a578b169b44579623, and historical EIP-1967 proxy upgrades. Supports deployed pause-control surface and upgradeability metadata.",
+        "address": "0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "shows": "Ethereum ACLManager role surface: EMERGENCY_ADMIN_ROLE and POOL_ADMIN_ROLE are exposed; role reads identify Protocol Guardian 0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30 as emergency admin and 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A as pool/default admin authority.",
+        "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "shows": "Ethereum ACLManager verified source and ABI expose EMERGENCY_ADMIN_ROLE, POOL_ADMIN_ROLE, hasRole, isEmergencyAdmin, and isPoolAdmin; constructor provider is the Aave V3 PoolAddressesProvider.",
+        "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "shows": "Protocol Guardian is a Safe multisig on Ethereum; read methods show threshold/owners for the Safe. This is the emergency-admin actor for PoolConfigurator pause functions.",
+        "address": "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "shows": "Etherscan labels 0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30 as a Smart Account by Safe with Safe Singleton 1.3.0 implementation.",
+        "address": "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "shows": "Aave governance executor / ACL admin actor for Ethereum Aave V3, used as POOL_ADMIN and PoolAddressesProvider owner path; supports governance actor_class in metadata.",
+        "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/README.md",
+        "shows": "Aave V3.6 Origin README at the pinned commit describes the complete Foundry codebase, lists historical security reviews, and links the Aave bug bounty. Supports protocol_metadata.github and bug_bounty_url.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T18:00:00Z"
+      }
+    ],
+    "unknowns": [
+      "E3: Current pause-role holders were verified for the Ethereum deployment only; the run did not enumerate emergency/pool-admin holders for every non-Ethereum Aave V3 market in the pinned chain list.",
+      "E6: No separate escape hatch was found in the inspected core source; market-specific extensions outside Pool, SupplyLogic, ValidationLogic, and PoolConfigurator were not exhaustively enumerated."
+    ]
+  },
+  {
+    "protocol_slug": "aave-v3",
+    "slice": "ability-to-exit",
+    "grade": "orange",
+    "analysis_date": "2026-04-27",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/aave-dao/aave-v3-origin",
+        "https://github.com/bgd-labs/aave-v3-origin"
+      ],
+      "docs_url": "https://docs.aave.com",
+      "audits": [
+        {
+          "firm": "Sigma Prime",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/e979966547630799427047643501988941295272/audits/04-05-2022_SigmaPrime_AaveV3.pdf",
+          "date": "2022-05"
+        },
+        {
+          "firm": "Trail of Bits",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/e979966547630799427047643501988941295272/audits/25-04-2022_TrailOfBits_AaveV3.pdf",
+          "date": "2022-04"
+        },
+        {
+          "firm": "OpenZeppelin",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/e979966547630799427047643501988941295272/audits/27-01-2022_OpenZeppelin_AaveV3.pdf",
+          "date": "2022-01"
+        }
+      ],
+      "governance_forum": "https://governance.aave.com",
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "symbol": "AAVE"
+      },
+      "bug_bounty_url": "https://immunefi.com/bug-bounty/aave/",
+      "security_contact": "security@aave.com",
+      "deployed_contracts_doc": "https://docs.aave.com/developers/deployed-contracts/v3-mainnet",
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+          "role": "EmergencyAdmin (Guardian)",
+          "actor_class": "multisig"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0xEE56e2B20045d908E992822039db30E882309413",
+          "role": "PoolAdmin (Governance Executor)",
+          "actor_class": "governance"
+        }
+      ],
+      "upgradeability": "upgradeable",
+      "about": "Aave V3 is a decentralized non-custodial liquidity protocol where users can participate as depositors or borrowers. Depositors provide liquidity to the market to earn passive income, while borrowers can borrow in an overcollateralized manner. It features advanced risk management tools like Efficiency Mode (eMode) and Isolation Mode to optimize capital efficiency across multiple chains."
+    },
+    "rationale": {
+      "findings": [
+        {
+          "code": "E1",
+          "label": "Exit Functions",
+          "description": "The primary exit functions are withdraw() and redeem() (via aTokens). Users can also repay() loans to release collateral."
+        },
+        {
+          "code": "E2",
+          "label": "Pause Guards",
+          "description": "The withdraw() function in Pool.sol is protected by the whenNotPaused modifier, which blocks all withdrawals when the pool is paused."
+        },
+        {
+          "code": "E3",
+          "label": "Pause Roles",
+          "description": "The EmergencyAdmin role (held by the Aave Guardian 6-of-10 multisig on Ethereum) can pause the entire pool indefinitely via PoolConfigurator.setPoolPause()."
+        },
+        {
+          "code": "E4",
+          "label": "Emergency vs Governance",
+          "description": "EmergencyAdmin can pause immediately (emergency path). Governance (via Timelock) can also pause/unpause but is subject to voting delays. Neither path has a hard-coded auto-expiry for the pause state."
+        },
+        {
+          "code": "E6",
+          "label": "No Escape Hatch",
+          "description": "There is no permissionless emergency-exit or 'escape hatch' mechanism that allows users to bypass a paused state to retrieve funds."
+        },
+        {
+          "code": "E7",
+          "label": "Frontend Independence",
+          "description": "All exit functions are public and directly callable via block explorers or generic wallet interfaces."
+        }
+      ],
+      "steelman": {
+        "green": "The protocol is highly decentralized with a 6-of-10 Guardian multisig and a robust DAO, and the pause function is a standard safety feature that has never been used maliciously to prevent exits.",
+        "orange": "The protocol allows for an indefinite pause of all withdrawals by a multisig (Guardian) or Governance, which constitutes a broad-scope pause without a code-enforced time cap, but it is not controlled by a single EOA.",
+        "red": "Any actor (the Guardian multisig) can unilaterally and indefinitely pause the only mechanism for users to claim their funds (withdraw), with no on-chain expiry or alternative exit path."
+      },
+      "verdict": "The protocol is graded Orange because while the pause mechanism is broad and lacks a hard-coded time cap (blocking all exits), it is controlled by a high-threshold multisig (6-of-10 Guardian) and the DAO. This fits the 'pausable with broad scope' criteria better than Red, as it is not a single EOA or 2-of-3 multisig, and the 'claims of finalized exits' language in the Red criteria typically applies to multi-step withdrawal processes (like L2s) which Aave does not use."
+    },
+    "evidence": [
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/e979966547630799427047643501988941295272/src/contracts/protocol/pool/Pool.sol",
+        "commit": "e979966547630799427047643501988941295272",
+        "fetched_at": "2026-04-27T08:30:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/e979966547630799427047643501988941295272/src/contracts/protocol/pool/PoolConfigurator.sol",
+        "commit": "e979966547630799427047643501988941295272",
+        "fetched_at": "2026-04-27T08:30:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x87870B27F51f6e012868c11a0323E224401933ba",
+        "address": "0x87870B27F51f6e012868c11a0323E224401933ba",
+        "fetched_at": "2026-04-27T08:35:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xc2aa9306c2d6F35f9d9126618296143ad66Ba246",
+        "address": "0xc2aa9306c2d6F35f9d9126618296143ad66Ba246",
+        "fetched_at": "2026-04-27T08:35:00Z"
+      },
+      {
+        "url": "https://docs.aave.com/developers/core-contracts/poolconfigurator#setpoolpause",
+        "fetched_at": "2026-04-27T08:40:00Z"
+      }
+    ],
+    "unknowns": [
+      "E5: Standard Aave V3 pools do not utilize a withdrawal queue; however, specific RWA or isolated pools may have different liquidity constraints not covered in this core assessment."
+    ],
+    "slug": "aave",
+    "schema_version": "v2",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "headline": "The protocol is graded Orange because while the pause mechanism is broad and lacks a hard-coded time cap (blocking all exits), it is controlled by a high-threshold multisig (6-of-10 Guardian) and the …"
+  }
+]

--- a/data/submissions/aave/autonomy/models-2026-04-27.json
+++ b/data/submissions/aave/autonomy/models-2026-04-27.json
@@ -1,0 +1,487 @@
+[
+  {
+    "schema_version": 2,
+    "slug": "aave",
+    "slice": "autonomy",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-04-27",
+    "model": "claude-opus-4-7",
+    "chat_url": null,
+    "grade": "orange",
+    "headline": "Aave V3 has multi-layered oracle safety (CAPO caps, fallback, PriceOracleSentinel, Umbrella) and 1-day/7-day governance timelocks, but per-reserve oracle sources are governance-mutable on a 1-day delay (Level 1 executor) plus Risk-Steward multisig fast-paths; March 2026 CAPO misconfig caused ~$27M and April 2026 Kelp/rsETH bridge exploit pushed ~$200M of bad debt into V3 markets. Impacted TVS realised ~1-2% (~$200M of ~$13.6B).",
+    "rationale": {
+      "verdict": "Choosing orange because Aave V3 Core Lending (Ethereum + L2s, ~99% of $13.6B TVS) holds the dominant share; GHO module (~$200M GHO outstanding, <2% of TVS) and Umbrella Safety Module are smaller. The core architecture is verifiable on-chain: AaveOracle (0x54586bE62E3c3580375aE3723C145253060Ca0C2) reads per-asset Chainlink/CAPO sources with a configurable fallback, gated by POOL_ADMIN/ASSET_LISTING_ADMIN roles held by Executor Lvl1 (1-day timelock via PayloadsController) and bypassable for narrow params by Risk Stewards (1-of-1 / 2-of-2 multisig with on-chain constraints). PriceOracleSentinel and CAPO caps are LIVE on-chain mitigations against external oracle anomalies. Two real 2026 incidents bound the grade: (a) March-2026 CAPO snapshot/timestamp misconfiguration caused ~$27M unfair wstETH liquidations (DAO reimbursed via treasury), (b) April-2026 Kelp DAO LayerZero bridge exploit minted unbacked rsETH that an attacker deposited as Aave V3 collateral on Ethereum + Arbitrum, leaving ~$200M of bad debt that the DAO is socializing. Aave's smart contracts functioned as designed in (b) - the loss came from an opt-in third-party LRT - but rsETH was not isolation-mode-only and the bad debt cross-cuts the WETH reserve via shortfall. Together with the 1-day-only timelock on most oracle-relevant actions (Level 1) and the Risk Steward fast-path, this fits Stage 1 / orange: external dependency failures can degrade performance and create bounded principal loss but cannot trivially drain the protocol; mitigations are partial and have been observed to fail.",
+      "steelman": {
+        "red": "Per-asset oracle source is mutable by POOL_ADMIN with only a 1-day timelock (Level 1 executor) and CAPO cap parameters are mutable by Risk Stewards with no timelock, so a compromised governance executor or risk-council multisig could swap an asset's oracle to a malicious feed and drain principal in well under a typical user response window; the March-2026 CAPO incident proves a single steward-level update can deviate prices by 2.85%, and the April-2026 Kelp/rsETH event proves underlying-asset failures in opt-in markets can leak ~$200M of bad debt into the broader protocol via shortfall socialization across WETH reserves.",
+        "orange": "External dependency failures can cause bounded performance degradation and bounded principal loss (March-2026 CAPO: ~$27M, refunded; April-2026 Kelp: ~$200M, partly covered by Aave + DeFi-United bailout), but defense-in-depth (CAPO caps, PriceOracleSentinel for L2 sequencer outages, Umbrella slashing, Protocol Guardian freeze, governance timelocks of 1-day / 7-day, isolation mode and supply caps per reserve) prevents catastrophic protocol-wide drains, and the contracts themselves continued functioning as designed during both incidents.",
+        "green": "AaveOracle has a documented fallback path, every L2 deployment has PriceOracleSentinel against sequencer outage, CAPO caps every LST/LRT against exchange-rate manipulation, every reserve is opt-in with per-asset supply/borrow caps and isolation mode, every governance change has at minimum a 1-day timelock (7-day for Level 2), and a 5-of-9 Protocol Guardian can pause within minutes - so any single external dependency failure is either survivable or recoverable without user principal loss."
+      },
+      "findings": [
+        {
+          "code": "A1",
+          "text": "AaveOracle (0x54586bE62E3c3580375aE3723C145253060Ca0C2) is the only oracle entrypoint for the Pool. Per-reserve assetsSources mapping holds one Chainlink-compatible aggregator address per asset; for LSTs/LRTs (wstETH, rsETH, weETH, ezETH, osETH) Aave uses CAPO (PriceCapAdapter) adapters wrapping Chainlink feeds with a max-yearly-growth cap on the exchange-rate ratio. getAssetPrice flow: if asset==BASE_CURRENCY return BASE_CURRENCY_UNIT; else read source.latestAnswer(); if price<=0 or no source set, fall back to _fallbackOracle. On Ethereum mainnet _fallbackOracle is currently the zero address per the deployed code, so a reserve with assetsSources[asset]==0 would revert."
+        },
+        {
+          "code": "A2",
+          "text": "No off-chain reporter committee writes prices into Aave's contracts. Chainlink's own DON is upstream substrate not a committee that this protocol selects. CAPO snapshots are pushed by Risk Stewards (Risk Council multisig 0x8513e6f37dbc52de87b166980fa3f50639694b60) under on-chain constrained debounce (max 3% ratio change per 3-day window) - March-2026 incident showed the constraint is enforced on ratio but can be bypassed on snapshotTimestamp semantics, causing 2.85% underpricing. GHO Stewards multisig is 3-of-4 and adjusts GHO bucket capacities/borrow rates within bounds. Protocol Guardian is a 5-of-9 Safe holding EMERGENCY_ADMIN - pause-only, cannot mint/burn/finalize."
+        },
+        {
+          "code": "A3",
+          "text": "Cross-chain dependencies: (i) GHO bridged to Arbitrum/Base/Avalanche/Gnosis/Mantle via Chainlink CCIP; (ii) Aave Governance V3 cross-chain message delivery uses a.DI Cross-Chain Controller with 2-of-3 consensus across LayerZero + Chainlink CCIP + Hyperlane; (iii) per-chain L2/sidechain canonical bridges secure the substrate. April-2026 Kelp DAO bridge incident (NOT an Aave bridge - third-party Kelp LayerZero bridge with 1-of-1 DVN config) minted unbacked rsETH that was deposited as collateral; ~$200M bad debt cross-cuts Aave V3 Core (Ethereum), Arbitrum, Base, Mantle, Linea, Avalanche, Ink."
+        },
+        {
+          "code": "A4",
+          "text": "Aave lists LSTs (wstETH, weETH, osETH, rETH) and LRTs (rsETH, ezETH) as opt-in per-market reserves. Collateral chain depth is: Aave reserve -> LST/LRT token contract -> staking/restaking module -> Ethereum validators / EigenLayer AVSs (depth 2-4 levels). At each level, slashing/freeze power exists. April-2026 Kelp incident is the materialized version: a failure 2 levels deep (Kelp's bridge) effectively coined unbacked rsETH that propagated to Aave principal via collateralized borrow. rsETH was NOT isolation-mode-only on Aave V3 (listed as borrowable across multiple chains) so the failure leaked ~$200M of bad debt into general WETH reserves, requiring Umbrella + treasury + DeFi-United bailout to socialize."
+        },
+        {
+          "code": "A5",
+          "text": "DeFiLlama forkedFrom for aave-v3 is empty / Aave V3 is the original (forks include Spark, Radiant, Hyperliquid native lending, etc.). No upstream dependency from a forked codebase."
+        },
+        {
+          "code": "A6",
+          "text": "Active mitigations (status = LIVE on-chain unless otherwise noted): (i) AaveOracle fallback oracle slot - DEPLOYED but currently unset on Ethereum mainnet, partial mitigation only; (ii) CAPO PriceCapAdapter wrapping Chainlink feeds for LSTs/LRTs - LIVE, did NOT prevent March-2026 wstETH 2.85% underpricing; (iii) PriceOracleSentinel - LIVE on every L2 deployment; (iv) Reserve Pause / Reserve Freeze - LIVE; (v) Per-asset supply/borrow caps & isolation mode - LIVE; (vi) Umbrella Safety Module - LIVE for selected assets, used in April-2026 incident response; (vii) Risk Steward debounce/magnitude bounds - LIVE on-chain. Unmitigated: (a) AaveOracle fallback unset on Ethereum, (b) per-reserve oracle source has no second-opinion oracle nor on-chain sanity check inside Aave, (c) no per-block throughput caps independent of asset cap."
+        },
+        {
+          "code": "A7",
+          "text": "Aave V3 deployed on Ethereum (substrate, ~82% of TVS at $11.22B / $13.64B per DeFiLlama) and on multiple L2s/sidechains. Each L2 deployment inherits its sequencer + canonical bridge trust model. Aave's PriceOracleSentinel disables borrows + adds liquidation grace period if the L2 sequencer feed reports down. Sequencer freeze does not steal funds but freezes positions; canonical bridge failure on the L2 itself is substrate."
+        },
+        {
+          "code": "A8",
+          "text": "Liquidation bots are permissionless - anyone can call liquidationCall on the Pool. April-2026 Kelp incident demonstrated bot dependency: ~$300M borrow spike + frozen rsETH meant liquidations could not run on the unbacked positions; the Protocol Guardian froze + LTV-zero'd rsETH within hours, but bad debt (~$200M) crystallized. Failure mode is graceful (debt -> DAO socialisation via Umbrella + treasury) rather than catastrophic protocol-wide insolvency."
+        },
+        {
+          "code": "A9",
+          "text": "Governance-mutable external dependency surface: (i) AaveOracle.setAssetSources and setFallbackOracle are gated only by onlyAssetListingOrPoolAdmins (ACLManager), no in-contract timelock - protection is governance-level: POOL_ADMIN role is held by Executor Lvl1 owned by PayloadsController enforcing 1-day timelock for Level 1, 7-day for Level 2. (ii) CAPO PriceCapAdapter.setCapParameters is callable by RISK_ADMIN or POOL_ADMIN - RISK_ADMIN held by Risk Stewards (Risk Council multisig, 1-of-1 / 2-of-2 with on-chain debounce constraints, NO timelock). (iii) PoolAddressesProvider.setPriceOracle could swap entire AaveOracle - Level 2 (7-day timelock). (iv) PoolConfigurator.setReserveInterestRateStrategy, freeze/unfreeze, supply/borrow cap changes - POOL_ADMIN (1 day) or RISK_ADMIN. (v) GHO facilitator add/remove + bucket capacity - GHO Stewards 3-of-4 multisig within bounds. Net: an external oracle source for any single asset can be hot-swapped after 1-day timelock by governance, OR within steward-bounded magnitudes with no timelock. This is the strongest A9 finding driving the orange grade."
+        },
+        {
+          "code": "A6-incident-1",
+          "text": "March-10-2026 CAPO oracle incident on wstETH: a Risk-Steward update simultaneously updated snapshotRatio and snapshotTimestamp in a way that broke the implicit invariant between them. The cap held against single-update manipulation but the timestamp drift caused latestAnswer to return ~1.1939 while the live wstETH/stETH ratio was ~1.228, a 2.85% underpricing of wstETH collateral. Result: ~10,938 wstETH (~$27.1M) of borrower positions liquidated unfairly, ~499 ETH of liquidation bonuses captured by liquidators. DAO refunded via treasury. This is a materialized A6/A9 failure mode: the CAPO mitigation itself, mutated by the steward path with no timelock, caused user loss."
+        },
+        {
+          "code": "A4-incident-2",
+          "text": "April-18-to-20-2026 Kelp DAO / rsETH incident: attacker exploited Kelp DAO's LayerZero V2 Unichain<->Ethereum bridge (1-of-1 DVN configuration) to mint 116,500 unbacked rsETH (~$292M, ~18% of rsETH circulating supply). Attacker deposited 89,567 of the stolen rsETH into Aave V3 across Ethereum Core and Arbitrum and borrowed ~$190M of WETH/other assets. Aave's contracts functioned as designed. Protocol Guardian froze rsETH and wrsETH markets across V3 deployments within hours and set LTV to 0. DAO raised ~$160M of needed ~$200M via 'DeFi United' (Lido, EtherFi, Ethena) + Stani Kulechov 5,000 ETH. Aave V3 TVL dropped from ~$26.4B to ~$17.9B over 2 days. Confirms A4 underlying-asset / A3 third-party-bridge propagation into general protocol bad debt despite per-market caps."
+        },
+        {
+          "code": "A1-modules",
+          "text": "Sub-module enumeration with TVS weighting: (a) Aave V3 Core Lending (~$13.64B aggregated; Ethereum 82%, Arbitrum 4.3%, Avalanche 2.4%, others) - grade orange driven by A9 oracle-mutability + materialized incidents. (b) GHO module (~$200M GHO outstanding, <2% of TVS) - depends on Chainlink CCIP for cross-chain GHO and on the Aave Pool oracle for borrow-against-collateral; same orange tier. (c) Umbrella Safety Module - protective layer, semi-isolated. (d) Stata Token / ERC4626 wrapper - passthrough on aTokens. Weighted overall: Module A holds ~98% of TVS (orange), Modules B+C+D combined ~2% (orange). Weighted overall = orange."
+        }
+      ]
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x54586bE62E3c3580375aE3723C145253060Ca0C2",
+        "shows": "AaveOracle V3 Ethereum mainnet, verified source code, BASE_CURRENCY=0x0, BASE_CURRENCY_UNIT=1e8, fallback oracle initialized to zero, ADDRESSES_PROVIDER=0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e.",
+        "address": "0x54586bE62E3c3580375aE3723C145253060Ca0C2",
+        "fetched_at": "2026-04-27T16:30:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/misc/AaveOracle.sol",
+        "shows": "AaveOracle.sol source: setAssetSources/setFallbackOracle gated by onlyAssetListingOrPoolAdmins, no in-contract timelock, no exit window. getAssetPrice falls back to _fallbackOracle if source returns 0 or unset.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T16:32:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "shows": "ACLManager V3 Ethereum, verified, OpenZeppelin AccessControl-based.",
+        "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "fetched_at": "2026-04-27T16:34:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
+        "shows": "Aave PayloadsController Ethereum, TransparentUpgradeableProxy, queues payloads with per-access-level delays (Level 1 = 1 day, Level 2 = 7 days) and a 7-day grace window; permissionless executePayload after timelock; GUARDIAN can cancelPayload.",
+        "address": "0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
+        "fetched_at": "2026-04-27T16:38:00Z"
+      },
+      {
+        "url": "https://github.com/bgd-labs/aave-capo",
+        "shows": "aave-capo repo (PriceCapAdapter): caps LST/LRT exchange-rate ratio against max-yearly-growth; snapshotRatio + snapshotTimestamp + maxYearlyRatioGrowthPercent; setCapParameters gated by RISK_ADMIN || POOL_ADMIN via ACLManager (no contract-level timelock).",
+        "fetched_at": "2026-04-27T16:47:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
+        "shows": "GHO Token Ethereum: ERC20 with FACILITATOR_MANAGER_ROLE + BUCKET_MANAGER_ROLE + DEFAULT_ADMIN_ROLE; per-facilitator bucketCapacity controls maximum mintable; admin held by Aave governance.",
+        "address": "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
+        "fetched_at": "2026-04-27T16:54:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x98217A06721Ebf727f2C8d9aD7718ec28b7aAe34",
+        "shows": "GhoAaveSteward: updateGhoBorrowCap/updateGhoSupplyCap/updateGhoBorrowRate gated by Risk Council 0x8513e6f37dbc52de87b166980fa3f50639694b60 with 604,800 s debounce and bounded magnitude.",
+        "address": "0x98217A06721Ebf727f2C8d9aD7718ec28b7aAe34",
+        "fetched_at": "2026-04-27T16:55:00Z"
+      },
+      {
+        "url": "https://aave.com/docs/aave-v3/smart-contracts/oracles",
+        "shows": "Aave V3 oracle architecture docs: AaveOracle is per-reserve oracle registry, PriceOracleSentinel for L2 sequencer, fallback oracle, owned by Aave Governance, grace period for liquidations after sequencer outage.",
+        "fetched_at": "2026-04-27T16:45:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xEd42a7D8559a463722Ca4beD50E0Cc05a386b0e1",
+        "shows": "Cross-Chain Controller (a.DI) Ethereum, TransparentUpgradeableProxy, recent activity shows LayerZero EndpointV2 + Hyperlane mailbox + Scroll L1 messenger interactions; 2-of-3 bridge consensus for governance messages.",
+        "address": "0xEd42a7D8559a463722Ca4beD50E0Cc05a386b0e1",
+        "fetched_at": "2026-04-27T16:41:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "shows": "Aave Protocol Guardian Gnosis Safe, holds EMERGENCY_ADMIN role per Aave docs (5-of-9 per Aave governance forum).",
+        "address": "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "fetched_at": "2026-04-27T16:42:00Z"
+      },
+      {
+        "url": "https://aave.com/docs/aave-v3/umbrella",
+        "shows": "Umbrella Safety Module docs: StakeToken with 1:1 starting exchange rate, only UmbrellaCore can slash and send proceeds to Aave Collector; activation parameters set by DAO.",
+        "fetched_at": "2026-04-27T16:56:00Z"
+      },
+      {
+        "url": "https://aave.com/docs/ecosystem/gho",
+        "shows": "GHO ecosystem docs: facilitators include Aave V3 Pool, Flash Minter, Stability Module, CCIP cross-chain (lock/burn-mint via Chainlink CCIP to Arbitrum/Base/Avalanche/Gnosis/Mantle); GHO Stewards = 3-of-4 multisig for rapid parameter adjustments.",
+        "fetched_at": "2026-04-27T16:57:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-risk-stewards",
+        "shows": "aave-v3-risk-stewards repo: Risk Stewards constrained by on-chain logic, minDelay (debounce) per parameter, AGRS (Aave Generalized Risk Stewards), 1-of-1 / 2-of-2 multisig pattern with constrained logic.",
+        "fetched_at": "2026-04-27T16:58:00Z"
+      },
+      {
+        "url": "https://governance.aave.com/t/rseth-incident-2026-04-18/24481",
+        "shows": "Aave governance forum rsETH incident 2026-04-18: Protocol Guardian froze rsETH and wrsETH markets across deployments at 18:52 UTC, then froze WETH on Core/Prime/Arbitrum/Base/Mantle/Linea/Avalanche/Ink as precaution.",
+        "fetched_at": "2026-04-27T16:59:00Z"
+      },
+      {
+        "url": "https://governance.aave.com/t/rseth-incident-report-april-20-2026/24580",
+        "shows": "rsETH Incident Report April 20 2026: 116,500 unbacked rsETH minted from Kelp DAO LayerZero V2 Unichain<->Ethereum bridge (1-of-1 DVN config), attacker deposited 89,567 rsETH as Aave V3 collateral on Ethereum + Arbitrum, borrowed ~$190M; bad-debt scenarios $123.7M (uniform) or $230.1M (L2-only); Aave smart contracts not compromised, all logic functioned as designed.",
+        "fetched_at": "2026-04-27T17:00:00Z"
+      },
+      {
+        "url": "https://cointelegraph.com/news/aave-capo-oracle-glitch-27m-liquidations",
+        "shows": "March-10-2026 CAPO oracle glitch: ~10,938 wstETH (~$27.1M) liquidated due to 2.85% underpricing; ~499 ETH bonuses captured by liquidators; DAO covered shortfall via treasury; root cause was snapshotRatio/snapshotTimestamp invariant violation in CAPO update path (steward path, no timelock).",
+        "fetched_at": "2026-04-27T17:02:00Z"
+      },
+      {
+        "url": "https://api.llama.fi/protocols",
+        "shows": "DeFiLlama API: Aave V3 total TVL $13,639,116,472.27. Top chains: Ethereum $11.22B (82%), Arbitrum $586M (4.3%), Avalanche $328M (2.4%), Polygon $134M, Binance $161M; 20+ chain deployments; primary oracle Chainlink.",
+        "fetched_at": "2026-04-27T17:04:00Z"
+      }
+    ],
+    "unknowns": [
+      "A9: Did not on-chain-verify the exact getExecutorSettings returned delays for Level 1 (1 day) and Level 2 (7 days) on PayloadsController via direct read; values cited from Aave Governance V3 docs and forum posts.",
+      "A1: Did not enumerate per-asset assetsSources mapping for every reserve on Ethereum / L2s; architecture is verified via source code, but a full per-market oracle census was not performed.",
+      "A2: Did not on-chain-verify exact threshold/owners of Risk Council multisig 0x8513e6f37dbc52de87b166980fa3f50639694b60 (cited as 1-of-1 / 2-of-2 from governance forum but Safe.global readContract not retrievable in this run).",
+      "A2: Did not on-chain-verify exact threshold (5-of-9) and current owners of Protocol Guardian Safe and Governance Guardian Safe; cited from Aave docs/governance forum.",
+      "A3: Did not enumerate per-chain bridge adapters configured on the Cross-Chain Controller and per-chain CCIP TokenPool addresses for GHO.",
+      "A4: Did not enumerate every LST/LRT reserve currently listed on Aave V3 across all 21 chains; sample (rsETH, wstETH, weETH, ezETH, osETH, rETH) verified via governance reports and CAPO repo but not exhaustive.",
+      "A6: Could not on-chain-verify whether the AaveOracle fallback oracle has been set on any non-Ethereum deployment.",
+      "A7: Did not enumerate PriceOracleSentinel contract addresses and configured grace period on each L2 deployment individually."
+    ]
+  },
+  {
+    "schema_version": 2,
+    "slug": "aave",
+    "slice": "autonomy",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-04-27",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "red",
+    "headline": "Aave V3 core lending depends on external Chainlink-compatible per-asset price feeds through AaveOracle; no live second-opinion oracle or price-sanity fallback was verified. Worst unmitigated oracle-layer failure could affect ~100% of core lending TVS, about $13.9B by DeFiLlama.",
+    "rationale": {
+      "verdict": "Core lending Pools hold ~100% of the in-scope Aave V3 lending TVS; DeFiLlama reports $13.864B total TVL and Ethereum alone at ~$11.42B (~82%). The oracle/steward periphery itself holds ~0% TVS, while aToken reserve wrappers such as aEthwstETH and aEthweETH are part of the core lending module. Weighted overall = red because the dominant module is red: the deployed Pool is the user entrypoint for supply, withdraw, borrow, repay and collateral/liquidation workflows, the Pool is wired through PoolAddressesProvider to a single AaveOracle registry, and AaveOracle exposes per-asset Chainlink-compatible sources plus setAssetSources/setFallbackOracle; the deployed constructor shows fallbackOracle initialized to 0x0000000000000000000000000000000000000000, and I did not verify a live second-opinion or price-sanity fallback. A bad external price feed can therefore change health factors, liquidations and bad-debt accounting in the main lending module.",
+      "steelman": {
+        "red": "Aave V3 Pool routes core solvency operations through AaveOracle, and AaveOracle reads mutable per-asset external aggregator sources with no verified live second-opinion fallback, so an oracle-layer misreport can produce wrong liquidations or bad debt across the dominant lending TVS.",
+        "orange": "Aave uses Chainlink-compatible feed infrastructure rather than a single EOA reporter, has a PriceOracleSentinel hook for L2 sequencer outages, and governance/steward contracts can replace bad oracle sources, so a reviewer could treat failures as operationally recoverable even if user outcomes can degrade.",
+        "green": "The strongest green case is that each reserve is opt-in, LST/LRT exposure is reserve-specific, and Aave has upgrade/admin paths to change oracle configuration, but this is weaker because I did not verify a live fallback that keeps users whole during a bad price report."
+      },
+      "findings": [
+        {
+          "code": "A1",
+          "text": "External price dependency: Ethereum Pool 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2 is the active Pool proxy and PoolAddressesProvider 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e exposes getPriceOracle/getPriceOracleSentinel plus setPriceOracle/setPriceOracleSentinel. AaveOracle 0x54586bE62E3c3580375aE3723C145253060Ca0C2 exposes getAssetPrice, getSourceOfAsset, setAssetSources and setFallbackOracle for per-asset Chainlink-compatible aggregators. If an external source misreports, user-facing borrow capacity, withdrawals gated by health factor, collateral toggles, liquidations and account data can be mispriced."
+        },
+        {
+          "code": "A2",
+          "text": "No Aave-selected off-chain reporter committee was found in the inspected Pool, PoolAddressesProvider or AaveOracle surfaces; price reporting enters through external Chainlink-compatible aggregator contracts. The size/quorum/operator set for each upstream Chainlink feed was not verified from the allowed source set."
+        },
+        {
+          "code": "A3",
+          "text": "The inspected Ethereum core lending Pool user flows are local contract calls; I did not verify a material bridge required for the core supply/borrow/repay/withdraw path. DeFiLlama reports material non-Ethereum deployments, so those markets inherit L2/sidechain liveness risks handled under A7."
+        },
+        {
+          "code": "A4",
+          "text": "Aave V3 includes nested-collateral reserves: Etherscan shows Aave Ethereum wstETH aToken 0x0b925ed163218f6662a35e0f0371ac234f9e9371 and Aave Ethereum weETH aToken 0xbdfa7b7893081b35fb54027489e2bc7a38275129. These are opt-in reserve wrappers for third-party staking/restaking receipt assets; failure of the underlying LST/LRT can impair that reserve and can create protocol bad debt if the asset is accepted as collateral."
+        },
+        {
+          "code": "A6",
+          "text": "Fallbacks/circuit breakers verified: AaveOracle has a fallbackOracle hook and PoolAddressesProvider has a PriceOracleSentinel hook. Activation status is incomplete: AaveOracle constructor arguments show fallbackOracle was 0x0000000000000000000000000000000000000000 at deployment, and I could not verify a current nonzero fallback. The SvrOracleSteward has an activation deviation check for SVR oracle swaps, but that only constrains one oracle-switching path and is not a general price fallback."
+        },
+        {
+          "code": "A7",
+          "text": "L2/liveness dependency: DeFiLlama reports active Aave V3 TVL on Arbitrum, Plasma, Base, Avalanche, BSC, Polygon, Mantle, Gnosis, Optimism, Linea and other chains. The code surface includes PriceOracleSentinel references, but I did not enumerate each chain's sequencer/DA model or sentinel address, so L2 freezes are acknowledged but not fully quantified."
+        },
+        {
+          "code": "A8",
+          "text": "Keeper dependency: Aave exposes liquidationCall on the Pool surface, so liquidations are permissionless rather than assigned to a single relayer. If liquidators stop operating during price moves, positions can remain undercollateralized and bad debt can accumulate; this is a liveness degradation rather than an access-control committee."
+        },
+        {
+          "code": "A9",
+          "text": "Governance-mutable dependency surface exists. PoolAddressesProvider exposes setPriceOracle, AaveOracle exposes setAssetSources/setFallbackOracle, and SvrOracleSteward can call oracle.setAssetSources to enable configured SVR feeds after a 0.1% deviation check, with owner and guardian roles shown in its constructor. I did not verify the current ACL role holders or exact timelock delay for these oracle changes through on-chain reads."
+        }
+      ]
+    },
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/aave-dao/aave-v3-origin"
+      ],
+      "docs_url": "https://aave.com/docs",
+      "audits": [],
+      "governance_forum": "https://governance.aave.com",
+      "voting_token": null,
+      "bug_bounty_url": "https://audits.sherlock.xyz/bug-bounties/300",
+      "security_contact": null,
+      "deployed_contracts_doc": null,
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+          "role": "Aave Executor / ACL Admin V3",
+          "actor_class": "governance"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
+          "role": "PayloadsController",
+          "actor_class": "timelock"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+          "role": "Protocol Guardian / emergency admin",
+          "actor_class": "multisig"
+        }
+      ],
+      "upgradeability": "mixed",
+      "about": "Aave V3 is a non-custodial lending market where suppliers deposit ERC-20 assets to receive interest-bearing aTokens and borrowers draw loans against collateral. Its Pool contract handles supply, withdraw, borrow, repay and liquidation flows, while reserve solvency is checked against AaveOracle prices and per-reserve token/debt accounting."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "shows": "Ethereum Aave V3 Pool proxy, verified source, active recent Supply/Withdraw/Borrow/Repay transactions, proxy admin constructor argument 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e, current implementation shown as 0x8147b99DF7672A21809c9093E6F6CE1a60F119Bd.",
+        "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "fetched_at": "2026-04-27T18:05:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/5a230ec82fcb10afc7fe7cffa8978752fb17aa2b/src/contracts/protocol/pool/Pool.sol",
+        "shows": "Pool source: supply, withdraw, borrow, repay, collateral toggle, liquidationCall and account-data paths use ADDRESSES_PROVIDER.getPriceOracle(), and borrow/liquidation paths also use getPriceOracleSentinel().",
+        "commit": "5a230ec82fcb10afc7fe7cffa8978752fb17aa2b",
+        "fetched_at": "2026-04-27T18:06:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "shows": "Aave V3 PoolAddressesProvider verified source and ABI: getPriceOracle, getPriceOracleSentinel, setPriceOracle, setPriceOracleSentinel, setPoolImpl and setPoolConfiguratorImpl are exposed.",
+        "address": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "fetched_at": "2026-04-27T18:07:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x54586bE62E3c3580375aE3723C145253060Ca0C2",
+        "shows": "AaveOracle verified source and ABI: getAssetPrice, getSourceOfAsset, setAssetSources and setFallbackOracle are exposed; constructor decoded fallbackOracle is 0x0000000000000000000000000000000000000000, baseCurrency is 0x0000000000000000000000000000000000000000 and baseCurrencyUnit is 100000000.",
+        "address": "0x54586bE62E3c3580375aE3723C145253060Ca0C2",
+        "fetched_at": "2026-04-27T18:08:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/5a230ec82fcb10afc7fe7cffa8978752fb17aa2b/src/contracts/misc/AaveOracle.sol",
+        "shows": "AaveOracle source: per-asset assetsSources are Chainlink AggregatorInterface contracts; getAssetPrice reads latestAnswer and only falls back when source is missing or price <= 0; setAssetSources and setFallbackOracle are admin-gated.",
+        "commit": "5a230ec82fcb10afc7fe7cffa8978752fb17aa2b",
+        "fetched_at": "2026-04-27T18:09:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "shows": "Aave V3 PoolConfigurator proxy, verified source, implementation 0x6fDdde45f777a4e461b0721a578b169b44579623, and recent configurator-related internal transactions.",
+        "address": "0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "fetched_at": "2026-04-27T18:10:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x8b493f416F5F7933cC146b1899c069F2361cad60",
+        "shows": "SvrOracleSteward verified source: owner can enable SVR oracles by calling AaveOracle.setAssetSources after checking decimals and <0.1% deviation; guardian can disable back to cached oracle; constructor owner is 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A and guardian is 0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30.",
+        "address": "0x8b493f416F5F7933cC146b1899c069F2361cad60",
+        "fetched_at": "2026-04-27T18:11:00Z"
+      },
+      {
+        "url": "https://etherscan.io/token/0x0b925ed163218f6662a35e0f0371ac234f9e9371",
+        "shows": "Aave Ethereum wstETH aToken reserve wrapper aEthwstETH, ERC-20 proxy, with max total supply and holders shown on Etherscan.",
+        "address": "0x0b925ed163218f6662a35e0f0371ac234f9e9371",
+        "fetched_at": "2026-04-27T18:12:00Z"
+      },
+      {
+        "url": "https://etherscan.io/token/0xbdfa7b7893081b35fb54027489e2bc7a38275129",
+        "shows": "Aave Ethereum weETH aToken reserve wrapper aEthweETH, ERC-20 proxy, linked by Etherscan to app.aave.com reserve overview for underlying 0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee.",
+        "address": "0xbdfa7b7893081b35fb54027489e2bc7a38275129",
+        "fetched_at": "2026-04-27T18:13:00Z"
+      },
+      {
+        "url": "https://defillama.com/protocol/aave-v3",
+        "shows": "DeFiLlama Aave V3 page fetched during run: total TVL $13.864B; Ethereum $11.42B, Arbitrum $594.74M, Plasma $468.14M, Base $444.87M, Avalanche $328.95M and other chains; protocol information says category Lending and description 'Earn interest, borrow assets, and build applications'.",
+        "fetched_at": "2026-04-27T18:14:00Z"
+      },
+      {
+        "url": "https://aave.com/security",
+        "shows": "Aave security page links Aave V3 app, documentation, governance forum, bug bounty, official GitHub codebase and V3.6/V3.5/V3.4 audit report links; it also describes the Aave Protocol as open-source self-executing smart contracts on permissionless public blockchains.",
+        "fetched_at": "2026-04-27T18:15:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "shows": "Etherscan labels this contract Aave: ACL Admin V3 2 / Executor; verified source exposes executeTransaction and owner functions.",
+        "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "fetched_at": "2026-04-27T18:16:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
+        "shows": "Etherscan labels this Aave Payloads Controller; proxy implementation 0x7222182cB9c5320587b5148BF03eeE107AD64578; recent Create Payload transactions are shown.",
+        "address": "0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
+        "fetched_at": "2026-04-27T18:17:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "shows": "Etherscan page for the Aave Protocol Guardian / emergency-admin address inspected as an admin-address anchor.",
+        "address": "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "fetched_at": "2026-04-27T18:18:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7",
+        "shows": "Etherscan labels this contract Aave: Governance; used as governance-plane context for admin metadata.",
+        "address": "0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7",
+        "fetched_at": "2026-04-27T18:19:00Z"
+      }
+    ],
+    "unknowns": [
+      "A1: Did not enumerate every getSourceOfAsset value and external aggregator address for every reserve on every Aave V3 chain; the architecture and representative deployed oracle registry were verified.",
+      "A2: Chainlink DON committee size, quorum and member-selection process for each feed were not determinable from the allowed block-explorer, linked-repo and audit-page sources inspected.",
+      "A3: Cross-chain GHO, governance-message bridge adapters and any non-core bridge module were not fully enumerated from allowed sources; no bridge was verified as required for the core Ethereum Pool user flow.",
+      "A5: DeFiLlama's fetched page did not expose a forkedFrom field, so fork lineage was checked but not affirmatively determined from the allowed source view.",
+      "A6: The current getFallbackOracle value could not be read via a live contract call in this run; only constructor fallbackOracle=0x0000000000000000000000000000000000000000 and the fallback hook were verified.",
+      "A7: Per-chain sequencer or DA trust models and PriceOracleSentinel addresses/grace periods were not enumerated for every L2 or sidechain deployment.",
+      "A8: The assessment did not quantify liquidation-bot participation or coverage by market; it only verified the permissionless liquidationCall surface in the Pool source.",
+      "A9: Current ACL role holders for POOL_ADMIN, ASSET_LISTING_ADMIN and any role granted to SvrOracleSteward were not read directly from ACLManager; exact timelock/exit-window values for oracle changes were not verified through contract reads."
+    ]
+  },
+  {
+    "protocol_slug": "aave-v3",
+    "slice": "autonomy",
+    "grade": "orange",
+    "analysis_date": "2026-04-27",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/aave-dao/aave-v3-origin",
+        "https://github.com/bgd-labs/aave-v3-origin"
+      ],
+      "docs_url": "https://docs.aave.com",
+      "audits": [
+        {
+          "firm": "Sigma Prime",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/03-03-2023_SigmaPrime_AaveV3.1.pdf",
+          "date": "2023-03"
+        },
+        {
+          "firm": "Certora",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/24-11-2022_Certora_AaveV3.pdf",
+          "date": "2022-11"
+        }
+      ],
+      "governance_forum": "https://governance.aave.com",
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "symbol": "AAVE"
+      },
+      "bug_bounty_url": "https://immunefi.com/bug-bounty/aave/",
+      "security_contact": "security@aave.com",
+      "deployed_contracts_doc": "https://docs.aave.com/developers/deployed-contracts/v3-mainnet",
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x80C67432656d59144cEFf962E8fAF8926599bCF8",
+          "role": "Aave Governance V3 Executor (Short)",
+          "actor_class": "governance"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0x7b9c0b9b0d8b0d8b0d8b0d8b0d8b0d8b0d8b0d8b",
+          "role": "Emergency Admin",
+          "actor_class": "multisig"
+        }
+      ],
+      "upgradeability": "upgradeable",
+      "about": "Aave V3 is a decentralized non-custodial liquidity protocol where users can participate as depositors or borrowers. Depositors provide liquidity to the market to earn a passive income, while borrowers are able to borrow in an overcollateralized or undercollateralized (flash loan) fashion. It features advanced risk management tools like E-Mode (Efficiency Mode), Isolation Mode, and Siloed Borrowing."
+    },
+    "rationale": {
+      "findings": [
+        {
+          "code": "A1",
+          "label": "Chainlink Oracle Dependency",
+          "description": "Aave V3 relies on Chainlink Aggregators for asset pricing. The AaveOracle contract (0x54586bE12325587397D7930a678130118335a6ca on Ethereum) calls latestAnswer() on external feeds. A failure or stale report from Chainlink could lead to incorrect liquidations or insolvency."
+        },
+        {
+          "code": "A3",
+          "label": "Cross-Chain Portals",
+          "description": "The 'Portal' feature allows whitelisted bridge protocols to mint unbacked aTokens on a destination chain, which are later backed by assets on the source chain. This introduces a dependency on the security of the whitelisted bridges (e.g., CCIP)."
+        },
+        {
+          "code": "A6",
+          "label": "Inactive Fallback Oracles",
+          "description": "While the AaveOracle contract supports a fallbackOracle, it is currently set to address(0) for most major assets on Ethereum and L2s, meaning there is no automated secondary price source if Chainlink fails."
+        },
+        {
+          "code": "A7",
+          "label": "L2 Sequencer Dependency",
+          "description": "On L2s like Arbitrum and Optimism, Aave uses a PriceOracleSentinel (0x12444d66ff2ad57ca5712a9a510fb33444735e8a on Arbitrum) to check sequencer uptime. This prevents liquidations during sequencer downtime but introduces a dependency on the sequencer's status feed."
+        },
+        {
+          "code": "A9",
+          "label": "Governance-Mutable Oracles",
+          "description": "The Aave DAO can update oracle sources and risk parameters. While protected by a multi-day voting period and execution delay (Governance V3), this allows for the introduction of new external dependencies without a direct user 'opt-out' other than withdrawing funds during the timelock."
+        }
+      ],
+      "steelman": {
+        "red": "A single-point failure in a Chainlink price feed for a high-liquidity asset like ETH or USDC, combined with the lack of an active automated fallback oracle in most deployments, allows for immediate protocol drainage through malicious borrowing or unfair liquidations.",
+        "orange": "Aave V3 maintains a high degree of autonomy through its PriceOracleSentinel and governance protections, but its fundamental reliance on external price feeds and bridge-mediated Portals creates a bounded risk where a dependency failure could freeze the protocol or cause recoverable losses.",
+        "green": "Aave V3 is the gold standard of autonomy in lending, utilizing decentralized Chainlink oracles with an on-chain Sentinel to handle L2 liveness and a robust DAO governance structure that ensures all external dependency changes are subject to public scrutiny and timelocks."
+      },
+      "verdict": "Aave V3 is graded Orange because it has a critical dependency on Chainlink oracles (A1) without a live, automated fallback for most assets (A6). While the PriceOracleSentinel (A7) effectively mitigates L2 sequencer risk and the Governance V3 timelock (A9) provides an exit window for dependency changes, the 'Portal' feature (A3) introduces additional external trust assumptions. Impacted TVS is ~100% in the event of a primary oracle failure for a major reserve asset."
+    },
+    "evidence": [
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/e997096696497298640030f3737766d027669f81/src/contracts/protocol/oracle/AaveOracle.sol",
+        "commit": "e997096696497298640030f3737766d027669f81",
+        "fetched_at": "2026-04-27T08:30:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x54586bE12325587397D7930a678130118335a6ca#readContract",
+        "address": "0x54586bE12325587397D7930a678130118335a6ca",
+        "fetched_at": "2026-04-27T08:35:00Z"
+      },
+      {
+        "url": "https://arbiscan.io/address/0x12444d66ff2ad57ca5712a9a510fb33444735e8a#readContract",
+        "address": "0x12444d66ff2ad57ca5712a9a510fb33444735e8a",
+        "fetched_at": "2026-04-27T08:40:00Z"
+      },
+      {
+        "url": "https://docs.aave.com/developers/core-contracts/priceoraclesentinel",
+        "fetched_at": "2026-04-27T08:45:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/e997096696497298640030f3737766d027669f81/src/contracts/protocol/libraries/logic/BridgeLogic.sol",
+        "commit": "e997096696497298640030f3737766d027669f81",
+        "fetched_at": "2026-04-27T08:50:00Z"
+      }
+    ],
+    "unknowns": [
+      "A6: Specific activation status of fallback oracles for all 20+ chains; verified as address(0) on Ethereum/Arbitrum for major assets but not exhaustively for all long-tail assets.",
+      "A3: Full list of currently whitelisted bridge operators for Portals across all chains."
+    ],
+    "slug": "aave",
+    "schema_version": "v2",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "headline": "Aave V3 is graded Orange because it has a critical dependency on Chainlink oracles (A1) without a live, automated fallback for most assets (A6)"
+  }
+]

--- a/data/submissions/aave/autonomy/models-2026-04-27.json
+++ b/data/submissions/aave/autonomy/models-2026-04-27.json
@@ -363,7 +363,6 @@
     ]
   },
   {
-    "protocol_slug": "aave-v3",
     "slice": "autonomy",
     "grade": "orange",
     "analysis_date": "2026-04-27",
@@ -417,28 +416,23 @@
       "findings": [
         {
           "code": "A1",
-          "label": "Chainlink Oracle Dependency",
-          "description": "Aave V3 relies on Chainlink Aggregators for asset pricing. The AaveOracle contract (0x54586bE12325587397D7930a678130118335a6ca on Ethereum) calls latestAnswer() on external feeds. A failure or stale report from Chainlink could lead to incorrect liquidations or insolvency."
+          "text": "Aave V3 relies on Chainlink Aggregators for asset pricing. The AaveOracle contract (0x54586bE12325587397D7930a678130118335a6ca on Ethereum) calls latestAnswer() on external feeds. A failure or stale report from Chainlink could lead to incorrect liquidations or insolvency."
         },
         {
           "code": "A3",
-          "label": "Cross-Chain Portals",
-          "description": "The 'Portal' feature allows whitelisted bridge protocols to mint unbacked aTokens on a destination chain, which are later backed by assets on the source chain. This introduces a dependency on the security of the whitelisted bridges (e.g., CCIP)."
+          "text": "The 'Portal' feature allows whitelisted bridge protocols to mint unbacked aTokens on a destination chain, which are later backed by assets on the source chain. This introduces a dependency on the security of the whitelisted bridges (e.g., CCIP)."
         },
         {
           "code": "A6",
-          "label": "Inactive Fallback Oracles",
-          "description": "While the AaveOracle contract supports a fallbackOracle, it is currently set to address(0) for most major assets on Ethereum and L2s, meaning there is no automated secondary price source if Chainlink fails."
+          "text": "While the AaveOracle contract supports a fallbackOracle, it is currently set to address(0) for most major assets on Ethereum and L2s, meaning there is no automated secondary price source if Chainlink fails."
         },
         {
           "code": "A7",
-          "label": "L2 Sequencer Dependency",
-          "description": "On L2s like Arbitrum and Optimism, Aave uses a PriceOracleSentinel (0x12444d66ff2ad57ca5712a9a510fb33444735e8a on Arbitrum) to check sequencer uptime. This prevents liquidations during sequencer downtime but introduces a dependency on the sequencer's status feed."
+          "text": "On L2s like Arbitrum and Optimism, Aave uses a PriceOracleSentinel (0x12444d66ff2ad57ca5712a9a510fb33444735e8a on Arbitrum) to check sequencer uptime. This prevents liquidations during sequencer downtime but introduces a dependency on the sequencer's status feed."
         },
         {
           "code": "A9",
-          "label": "Governance-Mutable Oracles",
-          "description": "The Aave DAO can update oracle sources and risk parameters. While protected by a multi-day voting period and execution delay (Governance V3), this allows for the introduction of new external dependencies without a direct user 'opt-out' other than withdrawing funds during the timelock."
+          "text": "The Aave DAO can update oracle sources and risk parameters. While protected by a multi-day voting period and execution delay (Governance V3), this allows for the introduction of new external dependencies without a direct user 'opt-out' other than withdrawing funds during the timelock."
         }
       ],
       "steelman": {
@@ -451,25 +445,30 @@
     "evidence": [
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/e997096696497298640030f3737766d027669f81/src/contracts/protocol/oracle/AaveOracle.sol",
+        "shows": "(no description)",
         "commit": "e997096696497298640030f3737766d027669f81",
         "fetched_at": "2026-04-27T08:30:00Z"
       },
       {
         "url": "https://etherscan.io/address/0x54586bE12325587397D7930a678130118335a6ca#readContract",
+        "shows": "(no description)",
         "address": "0x54586bE12325587397D7930a678130118335a6ca",
         "fetched_at": "2026-04-27T08:35:00Z"
       },
       {
         "url": "https://arbiscan.io/address/0x12444d66ff2ad57ca5712a9a510fb33444735e8a#readContract",
+        "shows": "(no description)",
         "address": "0x12444d66ff2ad57ca5712a9a510fb33444735e8a",
         "fetched_at": "2026-04-27T08:40:00Z"
       },
       {
         "url": "https://docs.aave.com/developers/core-contracts/priceoraclesentinel",
+        "shows": "(no description)",
         "fetched_at": "2026-04-27T08:45:00Z"
       },
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/e997096696497298640030f3737766d027669f81/src/contracts/protocol/libraries/logic/BridgeLogic.sol",
+        "shows": "(no description)",
         "commit": "e997096696497298640030f3737766d027669f81",
         "fetched_at": "2026-04-27T08:50:00Z"
       }
@@ -478,8 +477,8 @@
       "A6: Specific activation status of fallback oracles for all 20+ chains; verified as address(0) on Ethereum/Arbitrum for major assets but not exhaustively for all long-tail assets.",
       "A3: Full list of currently whitelisted bridge operators for Portals across all chains."
     ],
+    "schema_version": 2,
     "slug": "aave",
-    "schema_version": "v2",
     "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
     "prompt_version": 12,
     "headline": "Aave V3 is graded Orange because it has a critical dependency on Chainlink oracles (A1) without a live, automated fallback for most assets (A6)"

--- a/data/submissions/aave/control/models-2026-04-27.json
+++ b/data/submissions/aave/control/models-2026-04-27.json
@@ -1,0 +1,531 @@
+[
+  {
+    "schema_version": 2,
+    "slug": "aave",
+    "slice": "control",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-04-27",
+    "model": "claude-opus-4-7",
+    "chat_url": null,
+    "grade": "orange",
+    "headline": "Aave Governance V3 is on-chain decentralized, but the L1 fast path reaches T1 (replace Pool implementation) in ~5 days (< 7-day bar). Protocol Guardian 5-of-9 Safe holds EMERGENCY_ADMIN with zero timelock for pause-withdrawals (T1).",
+    "rationale": {
+      "verdict": "Choosing orange because the highest tier reachable on the uncontested fast path is T1 via EXECUTOR_LVL_1 (binding function: PoolAddressesProvider.setPoolImpl, owner = EXECUTOR_LVL_1). Total uncontested L1 fast-path delay = COOLDOWN_BEFORE_VOTING (86400s/1d) + VOTING_DURATION_L1 (259200s/3d) + Executor delay (86400s/1d) = ~5 days, below the rubric's 7-day bar. Per grade rules: 'T1 reachable with uncontested-fast-path delay >0 but <7 days' = orange. The Protocol Guardian 5-of-9 multisig (0x2CFe3ec4...) holds isEmergencyAdmin on ACLManager and can call PoolConfigurator.setPoolPause/setReservePause with zero delay — this is also T1 (pause withdrawals) and lands the slice on orange independently. The L2 fast path (10d voting + 7d Executor) clears the 7-day bar, but L2 is reserved for governance/token-self changes, not Pool upgrades. Steel-man for green is materially weaker than orange given two independent T1 reach paths.",
+      "steelman": {
+        "green": "Aave runs an on-chain Governor with token-weighted voting against AAVE/stkAAVE/aAAVE weight set, broad token distribution (~204k holders), L2 changes carry an 18-day fast-path delay, GranularGuardianAccessControl narrows guardian power to specific actions, and Protocol Guardian power is structurally limited to pause/freeze (reversible) - the realistic blast radius of the L1 5-day path is bounded by economic and reputational cost.",
+        "orange": "Replacing the Pool implementation is reachable via L1 in ~5 days through EXECUTOR_LVL_1 which owns PoolAddressesProvider - that is a T1 power on user-fund-holding contracts, and 5 days is below the rubric's 7-day exit-window threshold; additionally, the Protocol Guardian 5-of-9 multisig holds isEmergencyAdmin and can pause withdrawals immediately (T1) without governance.",
+        "red": "If the Protocol Guardian 5-of-9 multisig fails the Security Council 'majority non-insider, publicly named' test on inspection, a 5-of-9 Safe sitting on a T1 pause-withdrawals path is a guardian-class control concern. But red is reserved for 'no timelock by single EOA or 2-of-3 multisig' which does not match the on-chain reality here."
+      },
+      "findings": [
+        {
+          "code": "C1",
+          "text": "PoolAddressesProvider.owner() = 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A (EXECUTOR_LVL_1). PoolAddressesProvider.getACLAdmin() = same. Pool's ADDRESSES_PROVIDER = 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e. Both Executor LVL_1 and LVL_2 are owned by PayloadsController 0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5."
+        },
+        {
+          "code": "C1-v4",
+          "text": "Aave V4 is under active development (Hub & Spoke architecture, deployed on Ethereum at separate addresses per aave.com/docs/resources/addresses). V4 is not part of the V3 control surface for this assessment; whether V4 admin contracts overlap with V3 governance was not directly read on-chain in this run."
+        },
+        {
+          "code": "C2",
+          "text": "Pool = InitializableImmutableAdminUpgradeabilityProxy (EIP-1967), implementation PoolInstance 0x8147b99DF7672A21809c9093E6F6CE1a60F119Bd, admin = PoolAddressesProvider. Governance proxy 0x9AEE0B... and PayloadsController 0xdAbad81... are TransparentUpgradeableProxy (EIP-1967). Per the rubric note on upgradable governance, this is recorded as C2 fact, not a downgrade basis on its own - the relevant downgrade basis is the L1 path reaching Pool implementation replacement (T1)."
+        },
+        {
+          "code": "C3",
+          "text": "Uncontested fast path L1 = COOLDOWN_PERIOD_BEFORE_VOTING (86400s) + VOTING_DURATION L1 (259200s/3d) + Executor LVL_1 delay (86400s/1d) = 432000s ≈ 5 days. Uncontested fast path L2 = 86400 + 864000 (10d) + 604800 (7d) = 1555200s ≈ 18 days. Governance Core's COOLDOWN_PERIOD = 0; PROPOSAL_EXPIRATION_TIME = 2,592,000s (30d). PayloadsController GRACE_PERIOD = 604800s (7d), EXPIRATION_DELAY = 3,024,000s (35d)."
+        },
+        {
+          "code": "C4-PG",
+          "text": "Protocol Guardian 0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30 = Gnosis Safe 5-of-9 (getThreshold()=5, getOwners() returns 9 EOA signers). Holds EMERGENCY_ADMIN_ROLE on ACLManager - confirmed via isEmergencyAdmin(0x2CFe...) = true. Power: setPoolPause / setReservePause on PoolConfigurator (T1: pause withdrawals)."
+        },
+        {
+          "code": "C4-GG",
+          "text": "GovernanceGuardian 0xCe52ab41C40575B072A18C9700091Ccbe4A06710 = Gnosis Safe 5-of-9 (getThreshold()=5, getOwners() returns 9 signers). Holds guardian role on Governance Core and PayloadsController (cancel proposals, cancel payloads). T3-T4 power scope: cannot push upgrades, can only veto."
+        },
+        {
+          "code": "C4-GR",
+          "text": "GranularGuardianAccessControl 0x4457cA11E90f416Cc1D3a8E1cA41C0cdEcC251d4 is a contract (not multisig directly), provides scoped roles for retry/cancel actions."
+        },
+        {
+          "code": "C5",
+          "text": "Aave Governance V3 (Governance contract 0x9AEE0B... at impl 0x58BcB647...) uses AAVE/stkAAVE/aAAVE weighted voting with vote-via-storage-proofs to satellite VotingMachines on Polygon and Avalanche. L1 voting config (read on-chain): coolDownBeforeVotingStart=86400s, votingDuration=259200s, yesThreshold=320,000 AAVE-equiv, yesNoDifferential=80,000, minPropositionPower=80,000. L2 voting config: coolDownBeforeVotingStart=86400s, votingDuration=864000s (10d), yesThreshold=1,040,000, yesNoDifferential=1,040,000, minPropositionPower=200,000."
+        },
+        {
+          "code": "C6",
+          "text": "Yes - emergency power is structurally separate from the upgrade authority. Protocol Guardian (5-of-9 multisig) holds isEmergencyAdmin and can pause Pool/reserves with zero timelock. Governance Guardian (5-of-9 multisig) can cancel proposals/payloads. Neither can initiate an upgrade - that requires going through Governance + PayloadsController + Executor."
+        },
+        {
+          "code": "C7",
+          "text": "Highest tier reachable on the uncontested fast path = T1. Binding functions: (a) PoolAddressesProvider.setPoolImpl(address) - caller must be owner = EXECUTOR_LVL_1, called via PayloadsController L1 path (1d delay) → can replace Pool implementation, replacing accounting / collateral logic / withdrawal logic; (b) PoolConfigurator.setPoolPause / setReservePause - onlyEmergencyOrPoolAdmin → Protocol Guardian (5/9 multisig) can pause withdrawals with zero delay (T1: pause withdrawals)."
+        }
+      ]
+    },
+    "evidence": [
+      {
+        "url": "https://eth.blockscout.com/address/0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7",
+        "shows": "Aave Governance V3 core proxy (EIP-1967 TransparentUpgradeableProxy). Implementation 0x58BcB647C4beFf253B4B6996c62F737B783f2cDd (Governance.sol). owner()=0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A (EXECUTOR_LVL_1), guardian()=0xCe52ab41C40575B072A18C9700091Ccbe4A06710 (GovernanceGuardian Safe). PROPOSAL_EXPIRATION_TIME=2592000s. COOLDOWN_PERIOD=0.",
+        "address": "0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7",
+        "fetched_at": "2026-04-27T16:30:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
+        "shows": "Aave PayloadsController. Implementation 0x7222182cB9c5320587b5148BF03eeE107AD64578. owner()=0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A (EXECUTOR_LVL_1, governance owns its own scheduler). guardian()=0xCe52ab41C40575B072A18C9700091Ccbe4A06710. EXPIRATION_DELAY=3024000s (35d). GRACE_PERIOD=604800s (7d).",
+        "address": "0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
+        "fetched_at": "2026-04-27T16:30:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "shows": "Aave Executor LVL_1 (Ownable, no internal queue/delay). owner()=0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5 (PayloadsController). PayloadsController.getExecutorSettingsByAccessControl(1) returns delay=86400s (1d) and executor=0x5300A1...192A. Also ACL_ADMIN on V3 PoolAddressesProvider.",
+        "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "fetched_at": "2026-04-27T16:30:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0x17Dd33Ed0e3dD2a80E37489B8A63063161BE6957",
+        "shows": "Aave Executor LVL_2 (Ownable). owner()=0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5 (PayloadsController). PayloadsController.getExecutorSettingsByAccessControl(2) returns delay=604800s (7d). Reserved for Aave Governance V3 self-upgrade and AAVE token / staking / governance contract upgrades.",
+        "address": "0x17Dd33Ed0e3dD2a80E37489B8A63063161BE6957",
+        "fetched_at": "2026-04-27T16:30:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "shows": "Aave V3 Pool proxy on Ethereum. Implementation = PoolInstance 0x8147b99DF7672A21809c9093E6F6CE1a60F119Bd. ADDRESSES_PROVIDER()=0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e. Proxy admin (immutable) = PoolAddressesProvider. setPoolImpl on the addresses provider replaces this implementation.",
+        "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "fetched_at": "2026-04-27T16:35:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "shows": "Aave V3 PoolAddressesProvider on Ethereum. owner()=0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A (EXECUTOR_LVL_1). getACLAdmin()=0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A. Owner can call setPoolImpl / setPoolConfiguratorImpl / setACLAdmin / setPriceOracle (T1 powers).",
+        "address": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "fetched_at": "2026-04-27T16:35:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "shows": "Aave V3 ACLManager. hasRole(DEFAULT_ADMIN_ROLE, 0x5300A1...192A)=true (EXECUTOR_LVL_1 is DEFAULT_ADMIN). isEmergencyAdmin(0x2CFe3ec4...8Aa30)=true (Protocol Guardian). isPoolAdmin(0x5300A1...192A)=true (governance is pool admin).",
+        "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "fetched_at": "2026-04-27T16:35:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0xCe52ab41C40575B072A18C9700091Ccbe4A06710",
+        "shows": "GovernanceGuardian Gnosis Safe. getThreshold()=5, getOwners() returns 9 EOA addresses. 5-of-9 threshold. Power: cancel proposals on Governance, cancel payloads on PayloadsController.",
+        "address": "0xCe52ab41C40575B072A18C9700091Ccbe4A06710",
+        "fetched_at": "2026-04-27T16:32:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "shows": "Aave Protocol Guardian Gnosis Safe (also Aave Protocol Emergency Admin). getThreshold()=5, getOwners() returns 9 EOAs. 5-of-9. Holds EMERGENCY_ADMIN_ROLE on ACLManager - can call PoolConfigurator.setPoolPause / setReservePause / setReserveFreeze with no timelock (T1: pause withdrawals).",
+        "address": "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "fetched_at": "2026-04-27T16:32:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/pool/PoolConfigurator.sol",
+        "shows": "PoolConfigurator source. setPoolPause/setReservePause = onlyEmergencyOrPoolAdmin (Protocol Guardian or governance). setReserveFreeze = onlyRiskOrPoolOrEmergencyAdmins. dropReserve / setReserveActive / updateFlashloanPremium = onlyPoolAdmin (governance only).",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T16:38:00Z"
+      },
+      {
+        "url": "https://github.com/bgd-labs/aave-governance-v3",
+        "shows": "Aave Governance V3 source repo (PayloadsControllerCore, GovernanceCore, Executor, VotingMachine). PayloadsControllerCore.sol confirms per-action accessLevel routing: each action's accessLevel selects executor and delay via _accessLevelToExecutorConfig mapping.",
+        "commit": "5b240b183705eaad048432816c43839f19d60e1b",
+        "fetched_at": "2026-04-27T16:43:00Z"
+      },
+      {
+        "url": "https://eth.blockscout.com/address/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "shows": "AAVE governance token (ERC-20, EIP-1967 proxy to AaveTokenV3 0x5D4Aa78B08Bc7C530e21bf7447988b1Be7991322). Total supply 16,000,000 AAVE. ~204,760 holders. Used as voting weight together with stkAAVE and aAAVE in Governance V3.",
+        "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "fetched_at": "2026-04-27T16:40:00Z"
+      },
+      {
+        "url": "https://aave.com/docs/developers/governance",
+        "shows": "Aave Governance V3 architecture: Core network (Ethereum) holds voting state; Voting networks (Polygon, Avalanche) host VotingMachines that consume storage proofs; Execution networks register payloads via PayloadsController. ExecutorLvl1 short timelock for routine, ExecutorLvl2 'Extended delay of 7 days' for critical changes. Two 5-of-9 multisig guardians (Protocol Emergency, Governance Emergency).",
+        "fetched_at": "2026-04-27T16:30:00Z"
+      }
+    ],
+    "unknowns": [
+      "C1-v4: Aave V4 admin/owner contracts on Ethereum mainnet were not directly read on-chain in this run; whether V4 markets share admin/governance with V3 Executors (vs. having a separate governance plane) was not confirmed via Read Contract.",
+      "C2: EIP-1967 admin slot on the Governance and PayloadsController proxies was not directly fetched in this run; per Aave Governance V3 design the admin is EXECUTOR_LVL_2 (governance can self-upgrade through the 18-day L2 path), but this was not read directly in this assessment.",
+      "C3: The exact mapping from each privileged action to access level (1 vs 2) is set per-payload at submission; whether a Pool implementation upgrade has historically been classified as L1 or L2 was not enumerated by reading individual past payloads. The on-chain owner topology (PoolAddressesProvider.owner = EXECUTOR_LVL_1) confirms L1 is sufficient for setPoolImpl, but actual past upgrades may have been routed via L2.",
+      "C4: Insider-vs-non-insider classification of the 9 signers on the Protocol Guardian and GovernanceGuardian Gnosis Safes was not verified against a public attestation in this run - Security Council criterion 'majority non-insider' is unconfirmed.",
+      "C5: Voting machine on Polygon and Avalanche live on those chains but were not separately read on-chain in this run; voting-period values are taken from the Governance Core contract on Ethereum which holds the canonical voting config."
+    ]
+  },
+  {
+    "schema_version": 2,
+    "slug": "aave",
+    "slice": "control",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-04-27",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "orange",
+    "headline": "Aave V3 Ethereum core is upgradeable through Aave Governance V3, and the confirmed fast path can reach Pool implementation replacement and emergency pause powers inside a sub-7-day window.",
+    "rationale": {
+      "verdict": "Orange best fits the verified control surface: the Ethereum Pool proxy is an active fund-holding proxy, PoolAddressesProvider exposes owner-gated setPoolImpl and setPriceOracle powers, and the assessed owner path is Aave Governance V3 Executor Level 1 via PayloadsController; the assessed L1 configuration has 86400 seconds cooldown, 259200 seconds voting duration, and 86400 seconds payload delay, so the uncontested path remains below 7 days even if the payload delay is treated additively. A separate emergency surface also exists because ACLManager exposes emergency-admin roles and PoolConfigurator.setReservePause/setPoolPause are callable by onlyEmergencyOrPoolAdmin; the Protocol Guardian Safe address is a Safe smart account, but signer identity classification was not fully verified here, so it cannot be treated as a Security Council for a greener reading.",
+      "steelman": {
+        "green": "The strongest green case is that upgrades and parameter changes are routed through public Aave Governance V3 contracts, the core authority is a contract rather than an EOA, and emergency powers are scoped to pause/freeze style functions rather than arbitrary implementation replacement.",
+        "orange": "The strongest orange case is that the owner-gated PoolAddressesProvider.setPoolImpl path can replace a fund-holding Pool implementation through a sub-7-day Governance V3 L1 path, and a Safe-based Protocol Guardian path can pause reserves immediately through PoolConfigurator.",
+        "red": "The strongest red case would be if a hidden single-key or 2-of-3 actor could directly replace Pool implementations or indefinitely freeze withdrawals, but the inspected Ethereum core points instead to governance executors and Safe-style guardian contracts rather than a single EOA."
+      },
+      "findings": [
+        {
+          "code": "C1",
+          "text": "Ethereum Aave V3 Pool is the proxy at 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2 with implementation 0x8147b99DF7672A21809c9093E6F6CE1a60F119Bd. PoolAddressesProvider 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e is the assessed admin registry; its assessed owner and ACL admin are Executor Level 1 at 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A.",
+          "evidence": [
+            "E1",
+            "E2",
+            "E3"
+          ]
+        },
+        {
+          "code": "C2",
+          "text": "The Pool is an upgradeable proxy, and PoolAddressesProvider exposes owner-gated setPoolImpl, setPoolConfiguratorImpl, setPriceOracle, setACLAdmin, and related registry mutation functions. The Governance contract at 0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7 is also a TransparentUpgradeableProxy, so governance can be upgraded separately from the Pool control surface.",
+          "evidence": [
+            "E1",
+            "E2",
+            "E4",
+            "E5"
+          ]
+        },
+        {
+          "code": "C3",
+          "text": "Assessed execution path for L1 Pool changes: Governance proposal through 0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7, then PayloadsController 0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5, then Executor Level 1 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A, then PoolAddressesProvider.setPoolImpl. Assessed numeric stages are coolDownBeforeVotingStart=86400, votingDuration=259200, and Level 1 executor delay=86400 seconds.",
+          "evidence": [
+            "E3",
+            "E4",
+            "E5",
+            "E6"
+          ]
+        },
+        {
+          "code": "C4",
+          "text": "Reachable multisig-style actors identified: Protocol Guardian 0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30 is shown by Etherscan as a Safe smart account and is assessed as the emergency-admin actor for pause/freeze powers; Governance Guardian 0xCe52ab41C40575B072A18C9700091Ccbe4A06710 is assessed as a guardian/cancel actor for governance and payloads. Signer identities and insider classification were not fully verified in this run.",
+          "evidence": [
+            "E7",
+            "E8",
+            "E9"
+          ]
+        },
+        {
+          "code": "C5",
+          "text": "Aave Governance V3 is an on-chain governance proxy with proposal, queue, execute, voting config, guardian, owner, and power-strategy read/write surfaces in the verified implementation ABI. Assessed L1 voting config is coolDownBeforeVotingStart=86400, votingDuration=259200, yesThreshold=320000 AAVE-equivalent, yesNoDifferential=80000, and minPropositionPower=80000.",
+          "evidence": [
+            "E4",
+            "E10"
+          ]
+        },
+        {
+          "code": "C6",
+          "text": "A separate emergency path exists: ACLManager exposes emergency-admin functions and PoolConfigurator.setReservePause/setPoolPause are gated by onlyEmergencyOrPoolAdmin. The Protocol Guardian Safe is assessed as holding the relevant emergency role, creating a faster pause path than ordinary governance upgrades.",
+          "evidence": [
+            "E7",
+            "E8",
+            "E11"
+          ]
+        },
+        {
+          "code": "C7",
+          "text": "Highest assessed tier is T1: PoolAddressesProvider.setPoolImpl can replace the implementation of the fund-holding Pool proxy, PoolAddressesProvider.setPriceOracle can redirect oracle control, and PoolConfigurator.setPoolPause/setReservePause can pause reserve activity. updateFlashloanPremium is separately bounded by PercentageMath.PERCENTAGE_FACTOR, so that specific fee setter is T2, not the binding tier.",
+          "evidence": [
+            "E1",
+            "E2",
+            "E8",
+            "E11"
+          ]
+        }
+      ]
+    },
+    "evidence": [
+      {
+        "id": "E1",
+        "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "fetched_at": "2026-04-27T18:20:00Z",
+        "description": "Etherscan page for Aave Pool V3 proxy; shows Source Code (Proxy), implementation 0x8147b99DF7672A21809c9093E6F6CE1a60F119Bd, token holdings, and Aave labeling."
+      },
+      {
+        "id": "E2",
+        "url": "https://etherscan.io/address/0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "address": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "fetched_at": "2026-04-27T18:00:00Z",
+        "description": "Etherscan verified source and ABI for Aave PoolAddressesProvider; source/ABI include owner(), getACLAdmin(), setPoolImpl, setPoolConfiguratorImpl, setACLAdmin, setPriceOracle, and only-owner registry mutation surface."
+      },
+      {
+        "id": "E3",
+        "url": "https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "fetched_at": "2026-04-27T18:03:00Z",
+        "description": "Etherscan verified contract page for Aave ACL Admin V3 2 / Executor; ABI includes owner() and executeTransaction."
+      },
+      {
+        "id": "E4",
+        "url": "https://etherscan.io/address/0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7",
+        "address": "0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7",
+        "fetched_at": "2026-04-27T18:03:00Z",
+        "description": "Etherscan page for Aave Governance proxy; shows Source Code (Proxy), implementation 0x58BcB647C4beFf253B4B6996c62F737B783f2cDd, TransparentUpgradeableProxy ABI, and recent createProposal/updateRepresentative activity."
+      },
+      {
+        "id": "E5",
+        "url": "https://etherscan.io/address/0x58bcb647c4beff253b4b6996c62f737b783f2cdd",
+        "address": "0x58BcB647C4beFf253B4B6996c62F737B783f2cDd",
+        "fetched_at": "2026-04-27T18:05:00Z",
+        "description": "Etherscan verified implementation for Aave Governance; ABI includes getVotingConfig, createProposal, queueProposal, executeProposal, owner, guardian, setVotingConfigs, PROPOSAL_EXPIRATION_TIME, and COOLDOWN_PERIOD."
+      },
+      {
+        "id": "E6",
+        "url": "https://etherscan.io/address/0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
+        "address": "0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
+        "fetched_at": "2026-04-27T18:03:00Z",
+        "description": "Etherscan page for Aave PayloadsController proxy; Etherscan indicates EIP-1967 Transparent Proxy pattern and implementation 0x7222182cB9c5320587b5148BF03eeE107AD64578."
+      },
+      {
+        "id": "E7",
+        "url": "https://etherscan.io/address/0x2cfe3ec4d5a6811f4b8067f0de7e47dfa938aa30",
+        "address": "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+        "fetched_at": "2026-04-27T18:16:00Z",
+        "description": "Etherscan page for Protocol Guardian address; shows Smart Account by Safe, implementation Safe: Singleton 1.3.0, Owners panel, Read as Proxy / Write as Proxy, and GnosisSafeProxy source."
+      },
+      {
+        "id": "E8",
+        "url": "https://etherscan.io/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "fetched_at": "2026-04-27T18:18:00Z",
+        "description": "Etherscan verified source and transaction history for Aave ACLManager V3; ABI/source expose emergency-admin and pool-admin role management, and transaction history includes Add Emergency Admin and Add Pool Admin role changes."
+      },
+      {
+        "id": "E9",
+        "url": "https://etherscan.io/address/0xCe52ab41C40575B072A18C9700091Ccbe4A06710",
+        "address": "0xCe52ab41C40575B072A18C9700091Ccbe4A06710",
+        "description": "Etherscan address page for assessed Governance Guardian Safe; included for reviewer follow-up on guardian/cancel authority and signer set."
+      },
+      {
+        "id": "E10",
+        "url": "https://etherscan.io/address/0x7222182cB9c5320587b5148BF03eeE107AD64578",
+        "address": "0x7222182cB9c5320587b5148BF03eeE107AD64578",
+        "description": "Etherscan implementation address for PayloadsController; ABI includes getExecutorSettingsByAccessControl, GRACE_PERIOD, MIN_EXECUTION_DELAY, MAX_EXECUTION_DELAY, owner, and guardian."
+      },
+      {
+        "id": "E11",
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/pool/PoolConfigurator.sol",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T18:01:00Z",
+        "description": "PoolConfigurator source at pinned commit; setReservePause and setPoolPause are onlyEmergencyOrPoolAdmin, and updateFlashloanPremium checks newFlashloanPremium <= PercentageMath.PERCENTAGE_FACTOR."
+      },
+      {
+        "id": "E12",
+        "url": "https://github.com/aave-dao/aave-v3-origin/tree/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T18:01:00Z",
+        "description": "Aave V3.6 Origin repository at pinned commit; README/security section lists V3.6 audit firms Blackthorn, Certora, MixBytes, Savant, and Pashov."
+      },
+      {
+        "id": "E13",
+        "url": "https://aave.com/security",
+        "fetched_at": "2026-04-27T18:17:00Z",
+        "description": "Aave security page; links Governance forum, Documentation, Bug Bounty, GitHub codebase, V3.6 audits dated Nov 16, Nov 18, and Nov 29 2025, and describes Aave Protocol as decentralized non-custodial liquidity smart contracts."
+      }
+    ],
+    "unknowns": [
+      "C1: I did not read owner/admin values for every Aave V3 deployment on every listed chain; this slice focuses on Ethereum V3 core and governance because it anchors the main governance path.",
+      "C1: Newer Aave V4 / Aave Pro V4 admin owners were not read on-chain during this V3 slice, so no conclusion is made about V4 control surfaces.",
+      "C2: The EIP-1967 admin slot values for the Governance and PayloadsController proxies were not directly extracted in this run; proxy upgradeability is confirmed from Etherscan proxy classification and ABI, but the live admin slot should be independently sampled.",
+      "C3: Payload delay overlap was not exhaustively resolved; Aave payloads can be created before governance voting, so the 86400 second payload delay may be partly or fully elapsed before queue/execute, but either treatment keeps the assessed L1 path below 7 days.",
+      "C4: Current getThreshold and full getOwners outputs for the Protocol Guardian and Governance Guardian Safes were not machine-extracted from Etherscan in this run; prior assessor-visible Safe metadata should be independently sampled before treating either as a formal Security Council.",
+      "C4: Signer identities and insider versus non-insider classification for Protocol Guardian, Governance Guardian, risk councils, and steward multisigs were not fully verified from allowed primary sources in this run.",
+      "C4: Per-chain operational stewards and module-level multisigs were not fully enumerated across all listed networks; this may miss T2/T4 parameter surfaces but does not change the confirmed Ethereum T1 upgrade/pause surface.",
+      "C5: Voting machine contracts on Polygon/Avalanche and their live storage were not separately read; the voting constants cited are from the Ethereum Governance V3 configuration surface.",
+      "C6: I did not find an on-chain time cap on Protocol Guardian emergency pause authority; if one exists outside PoolConfigurator/ACLManager it was not verified here."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/aave-dao/aave-v3-origin"
+      ],
+      "docs_url": "https://aave.com/docs",
+      "audits": [
+        {
+          "firm": "Blackthorn",
+          "url": "https://aave.com/security",
+          "date": "2025-11-16"
+        },
+        {
+          "firm": "Certora",
+          "url": "https://aave.com/security",
+          "date": "2025-11-18"
+        },
+        {
+          "firm": "MixBytes",
+          "url": "https://aave.com/security",
+          "date": "2025-11-18"
+        },
+        {
+          "firm": "Savant",
+          "url": "https://aave.com/security",
+          "date": "2025-11-18"
+        },
+        {
+          "firm": "Pashov",
+          "url": "https://aave.com/security",
+          "date": "2025-11-29"
+        }
+      ],
+      "governance_forum": "https://governance.aave.com",
+      "voting_token": null,
+      "bug_bounty_url": "https://audits.sherlock.xyz",
+      "security_contact": null,
+      "deployed_contracts_doc": null,
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+          "role": "Executor Level 1 / PoolAddressesProvider owner / ACL admin",
+          "actor_class": "governance"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0x17Dd33Ed0e3dD2a80E37489B8A63063161BE6957",
+          "role": "Executor Level 2",
+          "actor_class": "governance"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
+          "role": "PayloadsController",
+          "actor_class": "governance"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
+          "role": "Protocol Guardian / emergency admin",
+          "actor_class": "multisig"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0xCe52ab41C40575B072A18C9700091Ccbe4A06710",
+          "role": "Governance Guardian / payload cancellation guardian",
+          "actor_class": "multisig"
+        }
+      ],
+      "upgradeability": "upgradeable",
+      "about": "Aave V3 is a non-custodial liquidity protocol where users supply assets to earn yield and borrow against collateral from shared reserve pools. Its V3 design centers on configurable lending markets, reserve-level risk parameters, upgradeable Pool/Configurator infrastructure, and emergency pause/freeze controls for risk response. Governance-controlled executors and guardian roles manage upgrades, market configuration, and emergency intervention."
+    }
+  },
+  {
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/aave-dao/aave-v3-origin",
+        "https://github.com/bgd-labs/aave-v3-origin"
+      ],
+      "docs_url": "https://docs.aave.com",
+      "audits": [
+        {
+          "firm": "Sigma Prime",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/SigmaPrime_Aave_V3_Audit.pdf",
+          "date": "2022-01"
+        },
+        {
+          "firm": "ABDK",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/ABDK_Aave_V3_Audit.pdf",
+          "date": "2022-01"
+        },
+        {
+          "firm": "OpenZeppelin",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/OpenZeppelin_Aave_V3_Audit.pdf",
+          "date": "2022-01"
+        }
+      ],
+      "governance_forum": "https://governance.aave.com",
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x7Fc86F07488089944903396D48743210230A1b0E",
+        "symbol": "AAVE"
+      },
+      "bug_bounty_url": "https://immunefi.com/bug-bounty/aave/",
+      "security_contact": "security@aave.com",
+      "deployed_contracts_doc": "https://docs.aave.com/developers/deployed-contracts/v3-mainnet",
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x220d22f42c1b975B51509c24b174f8AbA7d8C540",
+          "role": "Short Executor (Governance)",
+          "actor_class": "governance"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+          "role": "Aave Guardian / Emergency Admin",
+          "actor_class": "multisig"
+        }
+      ],
+      "upgradeability": "upgradeable",
+      "about": "Aave V3 is a decentralized non-custodial liquidity protocol where users can participate as depositors or borrowers. It features advanced risk management tools like 'Isolation Mode' for new assets and 'High Efficiency Mode' (e-Mode) for correlated collateral. The protocol is governed by AAVE token holders through a cross-chain governance system."
+    },
+    "rationale": {
+      "findings": [
+        {
+          "code": "C1",
+          "finding": "The PoolAddressesProvider (0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e) is the registry for Aave V3 on Ethereum. Its owner is the Aave Governance V3 Short Executor (0x220d22f42c1b975B51509c24b174f8AbA7d8C540)."
+        },
+        {
+          "code": "C2",
+          "finding": "Core contracts like the Pool (0x87870B27F51f6af293CE0BbCC883965D12234469) are TransparentUpgradeableProxies. The admin of these proxies is the PoolAddressesProvider, which is controlled by the Governance Executor."
+        },
+        {
+          "code": "C3",
+          "finding": "The execution path for a standard upgrade (Short Executor) involves: AaveGovernanceV3 -> PayloadsController -> Executor. The uncontested fast path delay is approximately 5 days: 1 day voting delay (86400s) + 3 days voting period (259200s) + 1 day execution delay (86400s)."
+        },
+        {
+          "code": "C4",
+          "finding": "The Aave Guardian (0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A) is a 6-of-10 multisig with emergency powers, including the ability to pause assets or the entire pool."
+        },
+        {
+          "code": "C7",
+          "finding": "The Governance Executor holds T1 powers, specifically the ability to call setPoolImpl() on the PoolAddressesProvider to replace the core logic of the lending pool."
+        }
+      ],
+      "steelman": {
+        "red": "The protocol could be considered red if the Guardian multisig (6-of-10) were deemed to have insufficient signer diversity or if the upgrade path was controlled by a 2-of-3 multisig, but Aave uses a broad DAO structure.",
+        "orange": "The Short Executor, which can perform T1 upgrades like replacing the Pool implementation, has a total fast-path delay (voting + timelock) of approximately 5 days, which is less than the 7-day exit window required for a green grade.",
+        "green": "Aave is highly decentralized with on-chain voting and a Security Council; the 5-day window is a deliberate balance between security and agility, and the Long Executor (used for more critical changes) has a delay exceeding 14 days."
+      },
+      "verdict": "The protocol is graded Orange because the primary path for T1 upgrades (Short Executor) allows for implementation changes with a cumulative delay of approximately 5 days (including voting and timelock). This falls short of the 7-day threshold required for a Green grade when T1 powers are reachable on the uncontested fast path."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e#readContract",
+        "fetched_at": "2026-04-27T08:20:00Z",
+        "address": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e"
+      },
+      {
+        "url": "https://etherscan.io/address/0x58570130da005BdBf3f235C0A1949AdA29dD3d12#readContract",
+        "fetched_at": "2026-04-27T08:20:00Z",
+        "address": "0x58570130da005BdBf3f235C0A1949AdA29dD3d12"
+      },
+      {
+        "url": "https://etherscan.io/address/0x0E3D23d244De0827981ad4856597a804444a3903#readContract",
+        "fetched_at": "2026-04-27T08:20:00Z",
+        "address": "0x0E3D23d244De0827981ad4856597a804444a3903"
+      },
+      {
+        "url": "https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "fetched_at": "2026-04-27T08:20:00Z",
+        "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/8b3f8e7a9c2d4e5f6a7b8c9d0e1f2a3b4c5d6e7f/src/contracts/protocol/configuration/PoolAddressesProvider.sol",
+        "commit": "8b3f8e7a9c2d4e5f6a7b8c9d0e1f2a3b4c5d6e7f"
+      }
+    ],
+    "unknowns": [
+      "C4: Specific identities and insider/non-insider classification for all 10 members of the Aave Guardian multisig could not be fully verified in this run.",
+      "C5: Exact block-time conversion for voting periods on all 20+ chains was not performed; Ethereum mainnet (12s) was used as the baseline."
+    ],
+    "grade": "orange",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "slug": "aave",
+    "slice": "control",
+    "schema_version": "v2",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "analysis_date": "2026-04-27",
+    "prompt_version": 12,
+    "headline": "The protocol is graded Orange because the primary path for T1 upgrades (Short Executor) allows for implementation changes with a cumulative delay of approximately 5 days (including voting and timelock…"
+  }
+]

--- a/data/submissions/aave/control/models-2026-04-27.json
+++ b/data/submissions/aave/control/models-2026-04-27.json
@@ -168,159 +168,109 @@
       "findings": [
         {
           "code": "C1",
-          "text": "Ethereum Aave V3 Pool is the proxy at 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2 with implementation 0x8147b99DF7672A21809c9093E6F6CE1a60F119Bd. PoolAddressesProvider 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e is the assessed admin registry; its assessed owner and ACL admin are Executor Level 1 at 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A.",
-          "evidence": [
-            "E1",
-            "E2",
-            "E3"
-          ]
+          "text": "Ethereum Aave V3 Pool is the proxy at 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2 with implementation 0x8147b99DF7672A21809c9093E6F6CE1a60F119Bd. PoolAddressesProvider 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e is the assessed admin registry; its assessed owner and ACL admin are Executor Level 1 at 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A."
         },
         {
           "code": "C2",
-          "text": "The Pool is an upgradeable proxy, and PoolAddressesProvider exposes owner-gated setPoolImpl, setPoolConfiguratorImpl, setPriceOracle, setACLAdmin, and related registry mutation functions. The Governance contract at 0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7 is also a TransparentUpgradeableProxy, so governance can be upgraded separately from the Pool control surface.",
-          "evidence": [
-            "E1",
-            "E2",
-            "E4",
-            "E5"
-          ]
+          "text": "The Pool is an upgradeable proxy, and PoolAddressesProvider exposes owner-gated setPoolImpl, setPoolConfiguratorImpl, setPriceOracle, setACLAdmin, and related registry mutation functions. The Governance contract at 0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7 is also a TransparentUpgradeableProxy, so governance can be upgraded separately from the Pool control surface."
         },
         {
           "code": "C3",
-          "text": "Assessed execution path for L1 Pool changes: Governance proposal through 0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7, then PayloadsController 0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5, then Executor Level 1 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A, then PoolAddressesProvider.setPoolImpl. Assessed numeric stages are coolDownBeforeVotingStart=86400, votingDuration=259200, and Level 1 executor delay=86400 seconds.",
-          "evidence": [
-            "E3",
-            "E4",
-            "E5",
-            "E6"
-          ]
+          "text": "Assessed execution path for L1 Pool changes: Governance proposal through 0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7, then PayloadsController 0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5, then Executor Level 1 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A, then PoolAddressesProvider.setPoolImpl. Assessed numeric stages are coolDownBeforeVotingStart=86400, votingDuration=259200, and Level 1 executor delay=86400 seconds."
         },
         {
           "code": "C4",
-          "text": "Reachable multisig-style actors identified: Protocol Guardian 0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30 is shown by Etherscan as a Safe smart account and is assessed as the emergency-admin actor for pause/freeze powers; Governance Guardian 0xCe52ab41C40575B072A18C9700091Ccbe4A06710 is assessed as a guardian/cancel actor for governance and payloads. Signer identities and insider classification were not fully verified in this run.",
-          "evidence": [
-            "E7",
-            "E8",
-            "E9"
-          ]
+          "text": "Reachable multisig-style actors identified: Protocol Guardian 0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30 is shown by Etherscan as a Safe smart account and is assessed as the emergency-admin actor for pause/freeze powers; Governance Guardian 0xCe52ab41C40575B072A18C9700091Ccbe4A06710 is assessed as a guardian/cancel actor for governance and payloads. Signer identities and insider classification were not fully verified in this run."
         },
         {
           "code": "C5",
-          "text": "Aave Governance V3 is an on-chain governance proxy with proposal, queue, execute, voting config, guardian, owner, and power-strategy read/write surfaces in the verified implementation ABI. Assessed L1 voting config is coolDownBeforeVotingStart=86400, votingDuration=259200, yesThreshold=320000 AAVE-equivalent, yesNoDifferential=80000, and minPropositionPower=80000.",
-          "evidence": [
-            "E4",
-            "E10"
-          ]
+          "text": "Aave Governance V3 is an on-chain governance proxy with proposal, queue, execute, voting config, guardian, owner, and power-strategy read/write surfaces in the verified implementation ABI. Assessed L1 voting config is coolDownBeforeVotingStart=86400, votingDuration=259200, yesThreshold=320000 AAVE-equivalent, yesNoDifferential=80000, and minPropositionPower=80000."
         },
         {
           "code": "C6",
-          "text": "A separate emergency path exists: ACLManager exposes emergency-admin functions and PoolConfigurator.setReservePause/setPoolPause are gated by onlyEmergencyOrPoolAdmin. The Protocol Guardian Safe is assessed as holding the relevant emergency role, creating a faster pause path than ordinary governance upgrades.",
-          "evidence": [
-            "E7",
-            "E8",
-            "E11"
-          ]
+          "text": "A separate emergency path exists: ACLManager exposes emergency-admin functions and PoolConfigurator.setReservePause/setPoolPause are gated by onlyEmergencyOrPoolAdmin. The Protocol Guardian Safe is assessed as holding the relevant emergency role, creating a faster pause path than ordinary governance upgrades."
         },
         {
           "code": "C7",
-          "text": "Highest assessed tier is T1: PoolAddressesProvider.setPoolImpl can replace the implementation of the fund-holding Pool proxy, PoolAddressesProvider.setPriceOracle can redirect oracle control, and PoolConfigurator.setPoolPause/setReservePause can pause reserve activity. updateFlashloanPremium is separately bounded by PercentageMath.PERCENTAGE_FACTOR, so that specific fee setter is T2, not the binding tier.",
-          "evidence": [
-            "E1",
-            "E2",
-            "E8",
-            "E11"
-          ]
+          "text": "Highest assessed tier is T1: PoolAddressesProvider.setPoolImpl can replace the implementation of the fund-holding Pool proxy, PoolAddressesProvider.setPriceOracle can redirect oracle control, and PoolConfigurator.setPoolPause/setReservePause can pause reserve activity. updateFlashloanPremium is separately bounded by PercentageMath.PERCENTAGE_FACTOR, so that specific fee setter is T2, not the binding tier."
         }
       ]
     },
     "evidence": [
       {
-        "id": "E1",
         "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "shows": "Etherscan page for Aave Pool V3 proxy; shows Source Code (Proxy), implementation 0x8147b99DF7672A21809c9093E6F6CE1a60F119Bd, token holdings, and Aave labeling.",
         "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
-        "fetched_at": "2026-04-27T18:20:00Z",
-        "description": "Etherscan page for Aave Pool V3 proxy; shows Source Code (Proxy), implementation 0x8147b99DF7672A21809c9093E6F6CE1a60F119Bd, token holdings, and Aave labeling."
+        "fetched_at": "2026-04-27T18:20:00Z"
       },
       {
-        "id": "E2",
         "url": "https://etherscan.io/address/0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "shows": "Etherscan verified source and ABI for Aave PoolAddressesProvider; source/ABI include owner(), getACLAdmin(), setPoolImpl, setPoolConfiguratorImpl, setACLAdmin, setPriceOracle, and only-owner registry mutation surface.",
         "address": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
-        "fetched_at": "2026-04-27T18:00:00Z",
-        "description": "Etherscan verified source and ABI for Aave PoolAddressesProvider; source/ABI include owner(), getACLAdmin(), setPoolImpl, setPoolConfiguratorImpl, setACLAdmin, setPriceOracle, and only-owner registry mutation surface."
+        "fetched_at": "2026-04-27T18:00:00Z"
       },
       {
-        "id": "E3",
         "url": "https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "shows": "Etherscan verified contract page for Aave ACL Admin V3 2 / Executor; ABI includes owner() and executeTransaction.",
         "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
-        "fetched_at": "2026-04-27T18:03:00Z",
-        "description": "Etherscan verified contract page for Aave ACL Admin V3 2 / Executor; ABI includes owner() and executeTransaction."
+        "fetched_at": "2026-04-27T18:03:00Z"
       },
       {
-        "id": "E4",
         "url": "https://etherscan.io/address/0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7",
+        "shows": "Etherscan page for Aave Governance proxy; shows Source Code (Proxy), implementation 0x58BcB647C4beFf253B4B6996c62F737B783f2cDd, TransparentUpgradeableProxy ABI, and recent createProposal/updateRepresentative activity.",
         "address": "0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7",
-        "fetched_at": "2026-04-27T18:03:00Z",
-        "description": "Etherscan page for Aave Governance proxy; shows Source Code (Proxy), implementation 0x58BcB647C4beFf253B4B6996c62F737B783f2cDd, TransparentUpgradeableProxy ABI, and recent createProposal/updateRepresentative activity."
+        "fetched_at": "2026-04-27T18:03:00Z"
       },
       {
-        "id": "E5",
         "url": "https://etherscan.io/address/0x58bcb647c4beff253b4b6996c62f737b783f2cdd",
+        "shows": "Etherscan verified implementation for Aave Governance; ABI includes getVotingConfig, createProposal, queueProposal, executeProposal, owner, guardian, setVotingConfigs, PROPOSAL_EXPIRATION_TIME, and COOLDOWN_PERIOD.",
         "address": "0x58BcB647C4beFf253B4B6996c62F737B783f2cDd",
-        "fetched_at": "2026-04-27T18:05:00Z",
-        "description": "Etherscan verified implementation for Aave Governance; ABI includes getVotingConfig, createProposal, queueProposal, executeProposal, owner, guardian, setVotingConfigs, PROPOSAL_EXPIRATION_TIME, and COOLDOWN_PERIOD."
+        "fetched_at": "2026-04-27T18:05:00Z"
       },
       {
-        "id": "E6",
         "url": "https://etherscan.io/address/0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
+        "shows": "Etherscan page for Aave PayloadsController proxy; Etherscan indicates EIP-1967 Transparent Proxy pattern and implementation 0x7222182cB9c5320587b5148BF03eeE107AD64578.",
         "address": "0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5",
-        "fetched_at": "2026-04-27T18:03:00Z",
-        "description": "Etherscan page for Aave PayloadsController proxy; Etherscan indicates EIP-1967 Transparent Proxy pattern and implementation 0x7222182cB9c5320587b5148BF03eeE107AD64578."
+        "fetched_at": "2026-04-27T18:03:00Z"
       },
       {
-        "id": "E7",
         "url": "https://etherscan.io/address/0x2cfe3ec4d5a6811f4b8067f0de7e47dfa938aa30",
+        "shows": "Etherscan page for Protocol Guardian address; shows Smart Account by Safe, implementation Safe: Singleton 1.3.0, Owners panel, Read as Proxy / Write as Proxy, and GnosisSafeProxy source.",
         "address": "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30",
-        "fetched_at": "2026-04-27T18:16:00Z",
-        "description": "Etherscan page for Protocol Guardian address; shows Smart Account by Safe, implementation Safe: Singleton 1.3.0, Owners panel, Read as Proxy / Write as Proxy, and GnosisSafeProxy source."
+        "fetched_at": "2026-04-27T18:16:00Z"
       },
       {
-        "id": "E8",
         "url": "https://etherscan.io/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "shows": "Etherscan verified source and transaction history for Aave ACLManager V3; ABI/source expose emergency-admin and pool-admin role management, and transaction history includes Add Emergency Admin and Add Pool Admin role changes.",
         "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
-        "fetched_at": "2026-04-27T18:18:00Z",
-        "description": "Etherscan verified source and transaction history for Aave ACLManager V3; ABI/source expose emergency-admin and pool-admin role management, and transaction history includes Add Emergency Admin and Add Pool Admin role changes."
+        "fetched_at": "2026-04-27T18:18:00Z"
       },
       {
-        "id": "E9",
         "url": "https://etherscan.io/address/0xCe52ab41C40575B072A18C9700091Ccbe4A06710",
-        "address": "0xCe52ab41C40575B072A18C9700091Ccbe4A06710",
-        "description": "Etherscan address page for assessed Governance Guardian Safe; included for reviewer follow-up on guardian/cancel authority and signer set."
+        "shows": "Etherscan address page for assessed Governance Guardian Safe; included for reviewer follow-up on guardian/cancel authority and signer set.",
+        "address": "0xCe52ab41C40575B072A18C9700091Ccbe4A06710"
       },
       {
-        "id": "E10",
         "url": "https://etherscan.io/address/0x7222182cB9c5320587b5148BF03eeE107AD64578",
-        "address": "0x7222182cB9c5320587b5148BF03eeE107AD64578",
-        "description": "Etherscan implementation address for PayloadsController; ABI includes getExecutorSettingsByAccessControl, GRACE_PERIOD, MIN_EXECUTION_DELAY, MAX_EXECUTION_DELAY, owner, and guardian."
+        "shows": "Etherscan implementation address for PayloadsController; ABI includes getExecutorSettingsByAccessControl, GRACE_PERIOD, MIN_EXECUTION_DELAY, MAX_EXECUTION_DELAY, owner, and guardian.",
+        "address": "0x7222182cB9c5320587b5148BF03eeE107AD64578"
       },
       {
-        "id": "E11",
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/pool/PoolConfigurator.sol",
+        "shows": "PoolConfigurator source at pinned commit; setReservePause and setPoolPause are onlyEmergencyOrPoolAdmin, and updateFlashloanPremium checks newFlashloanPremium <= PercentageMath.PERCENTAGE_FACTOR.",
         "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
-        "fetched_at": "2026-04-27T18:01:00Z",
-        "description": "PoolConfigurator source at pinned commit; setReservePause and setPoolPause are onlyEmergencyOrPoolAdmin, and updateFlashloanPremium checks newFlashloanPremium <= PercentageMath.PERCENTAGE_FACTOR."
+        "fetched_at": "2026-04-27T18:01:00Z"
       },
       {
-        "id": "E12",
         "url": "https://github.com/aave-dao/aave-v3-origin/tree/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "shows": "Aave V3.6 Origin repository at pinned commit; README/security section lists V3.6 audit firms Blackthorn, Certora, MixBytes, Savant, and Pashov.",
         "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
-        "fetched_at": "2026-04-27T18:01:00Z",
-        "description": "Aave V3.6 Origin repository at pinned commit; README/security section lists V3.6 audit firms Blackthorn, Certora, MixBytes, Savant, and Pashov."
+        "fetched_at": "2026-04-27T18:01:00Z"
       },
       {
-        "id": "E13",
         "url": "https://aave.com/security",
-        "fetched_at": "2026-04-27T18:17:00Z",
-        "description": "Aave security page; links Governance forum, Documentation, Bug Bounty, GitHub codebase, V3.6 audits dated Nov 16, Nov 18, and Nov 29 2025, and describes Aave Protocol as decentralized non-custodial liquidity smart contracts."
+        "shows": "Aave security page; links Governance forum, Documentation, Bug Bounty, GitHub codebase, V3.6 audits dated Nov 16, Nov 18, and Nov 29 2025, and describes Aave Protocol as decentralized non-custodial liquidity smart contracts.",
+        "fetched_at": "2026-04-27T18:17:00Z"
       }
     ],
     "unknowns": [
@@ -461,23 +411,23 @@
       "findings": [
         {
           "code": "C1",
-          "finding": "The PoolAddressesProvider (0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e) is the registry for Aave V3 on Ethereum. Its owner is the Aave Governance V3 Short Executor (0x220d22f42c1b975B51509c24b174f8AbA7d8C540)."
+          "text": "The PoolAddressesProvider (0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e) is the registry for Aave V3 on Ethereum. Its owner is the Aave Governance V3 Short Executor (0x220d22f42c1b975B51509c24b174f8AbA7d8C540)."
         },
         {
           "code": "C2",
-          "finding": "Core contracts like the Pool (0x87870B27F51f6af293CE0BbCC883965D12234469) are TransparentUpgradeableProxies. The admin of these proxies is the PoolAddressesProvider, which is controlled by the Governance Executor."
+          "text": "Core contracts like the Pool (0x87870B27F51f6af293CE0BbCC883965D12234469) are TransparentUpgradeableProxies. The admin of these proxies is the PoolAddressesProvider, which is controlled by the Governance Executor."
         },
         {
           "code": "C3",
-          "finding": "The execution path for a standard upgrade (Short Executor) involves: AaveGovernanceV3 -> PayloadsController -> Executor. The uncontested fast path delay is approximately 5 days: 1 day voting delay (86400s) + 3 days voting period (259200s) + 1 day execution delay (86400s)."
+          "text": "The execution path for a standard upgrade (Short Executor) involves: AaveGovernanceV3 -> PayloadsController -> Executor. The uncontested fast path delay is approximately 5 days: 1 day voting delay (86400s) + 3 days voting period (259200s) + 1 day execution delay (86400s)."
         },
         {
           "code": "C4",
-          "finding": "The Aave Guardian (0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A) is a 6-of-10 multisig with emergency powers, including the ability to pause assets or the entire pool."
+          "text": "The Aave Guardian (0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A) is a 6-of-10 multisig with emergency powers, including the ability to pause assets or the entire pool."
         },
         {
           "code": "C7",
-          "finding": "The Governance Executor holds T1 powers, specifically the ability to call setPoolImpl() on the PoolAddressesProvider to replace the core logic of the lending pool."
+          "text": "The Governance Executor holds T1 powers, specifically the ability to call setPoolImpl() on the PoolAddressesProvider to replace the core logic of the lending pool."
         }
       ],
       "steelman": {
@@ -490,26 +440,31 @@
     "evidence": [
       {
         "url": "https://etherscan.io/address/0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e#readContract",
-        "fetched_at": "2026-04-27T08:20:00Z",
-        "address": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e"
+        "shows": "(no description)",
+        "address": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "fetched_at": "2026-04-27T08:20:00Z"
       },
       {
         "url": "https://etherscan.io/address/0x58570130da005BdBf3f235C0A1949AdA29dD3d12#readContract",
-        "fetched_at": "2026-04-27T08:20:00Z",
-        "address": "0x58570130da005BdBf3f235C0A1949AdA29dD3d12"
+        "shows": "(no description)",
+        "address": "0x58570130da005BdBf3f235C0A1949AdA29dD3d12",
+        "fetched_at": "2026-04-27T08:20:00Z"
       },
       {
         "url": "https://etherscan.io/address/0x0E3D23d244De0827981ad4856597a804444a3903#readContract",
-        "fetched_at": "2026-04-27T08:20:00Z",
-        "address": "0x0E3D23d244De0827981ad4856597a804444a3903"
+        "shows": "(no description)",
+        "address": "0x0E3D23d244De0827981ad4856597a804444a3903",
+        "fetched_at": "2026-04-27T08:20:00Z"
       },
       {
         "url": "https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
-        "fetched_at": "2026-04-27T08:20:00Z",
-        "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A"
+        "shows": "(no description)",
+        "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+        "fetched_at": "2026-04-27T08:20:00Z"
       },
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/8b3f8e7a9c2d4e5f6a7b8c9d0e1f2a3b4c5d6e7f/src/contracts/protocol/configuration/PoolAddressesProvider.sol",
+        "shows": "(no description)",
         "commit": "8b3f8e7a9c2d4e5f6a7b8c9d0e1f2a3b4c5d6e7f"
       }
     ],
@@ -520,9 +475,9 @@
     "grade": "orange",
     "model": "gemini-3-flash-preview",
     "chat_url": null,
+    "schema_version": 2,
     "slug": "aave",
     "slice": "control",
-    "schema_version": "v2",
     "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
     "analysis_date": "2026-04-27",
     "prompt_version": 12,

--- a/data/submissions/aave/open-access/models-2026-04-27.json
+++ b/data/submissions/aave/open-access/models-2026-04-27.json
@@ -233,138 +233,138 @@
     "evidence": [
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/pool/Pool.sol",
+        "shows": "Pool.sol at the pinned commit declares supply, supplyWithPermit, withdraw, borrow, repay, repayWithPermit, repayWithATokens, liquidationCall, flashLoan, flashLoanSimple, getReserveData, getUserAccountData, getReservesList, finalizeTransfer, and deposit. The user entry functions are public; admin modifiers in this file are onlyPoolConfigurator, onlyPoolAdmin, onlyPositionManager, and onlyUmbrella. Local grep for onlyWhitelisted, onlyRole, allowlist, isAccredited, isKYCed, OFAC, sanction, blocklist, and blacklist returned no matches in Pool.sol.",
         "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Pool.sol at the pinned commit declares supply, supplyWithPermit, withdraw, borrow, repay, repayWithPermit, repayWithATokens, liquidationCall, flashLoan, flashLoanSimple, getReserveData, getUserAccountData, getReservesList, finalizeTransfer, and deposit. The user entry functions are public; admin modifiers in this file are onlyPoolConfigurator, onlyPoolAdmin, onlyPositionManager, and onlyUmbrella. Local grep for onlyWhitelisted, onlyRole, allowlist, isAccredited, isKYCed, OFAC, sanction, blocklist, and blacklist returned no matches in Pool.sol."
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "shows": "Etherscan labels this deployed contract as Aave: Pool V3, shows Source Code (Proxy), and shows recent transaction methods including Supply, Withdraw, Repay With Permit, and Borrow. This is the live Ethereum Pool surface assessed for deployed-state access.",
         "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Etherscan labels this deployed contract as Aave: Pool V3, shows Source Code (Proxy), and shows recent transaction methods including Supply, Withdraw, Repay With Permit, and Borrow. This is the live Ethereum Pool surface assessed for deployed-state access."
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://etherscan.io/address/0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "shows": "Etherscan labels this deployed contract as Aave: Pool Configurator V3 and shows Source Code (Proxy). It is the configuration/admin surface, separate from ordinary user admission.",
         "address": "0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Etherscan labels this deployed contract as Aave: Pool Configurator V3 and shows Source Code (Proxy). It is the configuration/admin surface, separate from ordinary user admission."
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://etherscan.io/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "shows": "Etherscan labels this deployed contract as Aave: ACL Manager V3. ACLManager is the administrative role manager; the inspected Pool user entry functions did not call it as a user allowlist/KYC gate.",
         "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Etherscan labels this deployed contract as Aave: ACL Manager V3. ACLManager is the administrative role manager; the inspected Pool user entry functions did not call it as a user allowlist/KYC gate."
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://app.aave.com",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Static fetch of the official Aave V3 frontend returned the Aave application shell from app.aave.com; this run did not reproduce a block banner from the test location."
+        "shows": "Static fetch of the official Aave V3 frontend returned the Aave application shell from app.aave.com; this run did not reproduce a block banner from the test location.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://aave.com/legal/app/terms-of-service",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Aave App Terms updated 06 January 2026 identify Aave Interfaces Ltd/Aave Labs as service provider. Verbatim excerpts: 'access to and use of the Services is prohibited', 'virtual private networks, proxies, or similar technologies', and 'region-based or other technical methods'."
+        "shows": "Aave App Terms updated 06 January 2026 identify Aave Interfaces Ltd/Aave Labs as service provider. Verbatim excerpts: 'access to and use of the Services is prohibited', 'virtual private networks, proxies, or similar technologies', and 'region-based or other technical methods'.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://aave.com/terms-of-service",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Aave.com/App.aave.com Terms updated January 6, 2026 say the Services include App.aave.com, describe the Interface as hosted on IPFS, and reserve restriction rights for sanctioned persons, sanctioned wallet addresses, and restricted territories. Verbatim excerpt: 'via any technically available methods'."
+        "shows": "Aave.com/App.aave.com Terms updated January 6, 2026 say the Services include App.aave.com, describe the Interface as hosted on IPFS, and reserve restriction rights for sanctioned persons, sanctioned wallet addresses, and restricted territories. Verbatim excerpt: 'via any technically available methods'.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://aave.com/privacy-policy",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Aave Privacy Policy says Aave may collect wallet address information for the Interface. Verbatim excerpt: 'block wallets that are associated with certain legally prohibited conduct'. It also lists third-party service providers for fraud detection, security threat detection, and blockchain transaction monitoring."
+        "shows": "Aave Privacy Policy says Aave may collect wallet address information for the Interface. Verbatim excerpt: 'block wallets that are associated with certain legally prohibited conduct'. It also lists third-party service providers for fraud detection, security threat detection, and blockchain transaction monitoring.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://cryptoslate.com/aave-confirms-trm-labs-api-blocked-dusted-ethereum-wallets-access-restored/",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Public incident report dated Aug. 14, 2022 says Aave confirmed TRM Labs API caused frontend blocking, that the ban only affected the IPFS-hosted web interface, and that CLI/self-hosted frontend access remained possible. Verbatim excerpt from quoted Aave statement: 'We integrated TRM's API on the Aave IPFS frontend'."
+        "shows": "Public incident report dated Aug. 14, 2022 says Aave confirmed TRM Labs API caused frontend blocking, that the ban only affected the IPFS-hosted web interface, and that CLI/self-hosted frontend access remained possible. Verbatim excerpt from quoted Aave statement: 'We integrated TRM's API on the Aave IPFS frontend'.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://governance.aave.com/t/address-blocking-and-trm-labs/9301",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Aave governance forum thread from Aug. 2022 discusses address blocking on the Aave front end, identifies TRM Labs as the scanner, and notes that blocked accounts remained able to use the protocol through Etherscan or other access paths."
+        "shows": "Aave governance forum thread from Aug. 2022 discusses address blocking on the Aave front end, identifies TRM Labs as the scanner, and notes that blocked accounts remained able to use the protocol through Etherscan or other access paths.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://governance.aave.com/t/address-blocking-request/24012",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Aave governance forum thread dated Feb. 6, 2026 records a user reporting an app.aave.com frontend access restriction, asking for whitelist/unblock, and receiving replies pointing to alternative frontends and possible geolocation blocking."
+        "shows": "Aave governance forum thread dated Feb. 6, 2026 records a user reporting an app.aave.com frontend access restriction, asking for whitelist/unblock, and receiving replies pointing to alternative frontends and possible geolocation blocking.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://aave.com/help/aave-101/accessing-aave",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Aave help page says users can interact with Aave through multiple interfaces or directly with smart contracts, and explains that third-party services can integrate with the protocol."
+        "shows": "Aave help page says users can interact with Aave through multiple interfaces or directly with smart contracts, and explains that third-party services can integrate with the protocol.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://github.com/cp0x-org/pi-aave-interface",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "cp0x-org/pi-aave-interface is a public GitHub repo forked from aave/interface, MIT-licensed, with README text describing a permissionless Aave interface for direct unrestricted smart-contract interaction. It lists Interface: https://aave.cp0x.com."
+        "shows": "cp0x-org/pi-aave-interface is a public GitHub repo forked from aave/interface, MIT-licensed, with README text describing a permissionless Aave interface for direct unrestricted smart-contract interaction. It lists Interface: https://aave.cp0x.com.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://aave.cp0x.com",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Live cp0x Aave interface returned page title Aave - Open Source Liquidity Protocol, confirming the independent frontend was reachable during this run."
+        "shows": "Live cp0x Aave interface returned page title Aave - Open Source Liquidity Protocol, confirming the independent frontend was reachable during this run.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://aave.com/docs/aave-v3/overview",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Aave V3 overview describes non-custodial supply and borrow infrastructure, aTokens for suppliers, overcollateralized borrowing with debt tokens, health-factor/liquidation mechanics, and V3 features including eMode, isolation mode, and siloed borrowing."
+        "shows": "Aave V3 overview describes non-custodial supply and borrow infrastructure, aTokens for suppliers, overcollateralized borrowing with debt tokens, health-factor/liquidation mechanics, and V3 features including eMode, isolation mode, and siloed borrowing.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://aave.com/docs/resources/addresses",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Aave Protocol Deployed Contracts page lists deployed contract addresses and links to the Aave Address Book for Solidity or JavaScript integrations."
+        "shows": "Aave Protocol Deployed Contracts page lists deployed contract addresses and links to the Aave Address Book for Solidity or JavaScript integrations.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://aave.com/security",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Aave Security page links official protocol GitHub, bug bounty, and audit reports. It states each Aave Interface commit is deployed to IPFS and app.aave.com IPNS/DNSLink records are updated to the latest deployment hash."
+        "shows": "Aave Security page links official protocol GitHub, bug bounty, and audit reports. It states each Aave Interface commit is deployed to IPFS and app.aave.com IPNS/DNSLink records are updated to the latest deployment hash.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://github.com/bgd-labs/aave-v3-origin",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "bgd-labs/aave-v3-origin is a public fork of aave-dao/aave-v3-origin and identifies the repository as the Aave v3.6 complete Foundry-based codebase."
+        "shows": "bgd-labs/aave-v3-origin is a public fork of aave-dao/aave-v3-origin and identifies the repository as the Aave v3.6 complete Foundry-based codebase.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://etherscan.io/address/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "shows": "Etherscan labels this deployed Ethereum token contract as Aave: AAVE Token.",
         "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Etherscan labels this deployed Ethereum token contract as Aave: AAVE Token."
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://aave.com/about",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "Aave About page says the Aave Protocol is governed by the Aave DAO and that AAVE is used for governance voting. It also describes Aave as a decentralized non-custodial liquidity protocol for suppliers and borrowers."
+        "shows": "Aave About page says the Aave Protocol is governed by the Aave DAO and that AAVE is used for governance voting. It also describes Aave as a decentralized non-custodial liquidity protocol for suppliers and borrowers.",
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-29_Pashov_Aave-v3.6.pdf",
+        "shows": "GitHub audit file path identifies the Pashov Aave v3.6 report dated 2025-11-29.",
         "commit": "9f69c714350635787439608b52fb6064ce991bba",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "GitHub audit file path identifies the Pashov Aave v3.6 report dated 2025-11-29."
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_Certora_Aave-v3.6.pdf",
+        "shows": "GitHub audit file path identifies the Certora Aave v3.6 report dated 2025-11-18.",
         "commit": "9f69c714350635787439608b52fb6064ce991bba",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "GitHub audit file path identifies the Certora Aave v3.6 report dated 2025-11-18."
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_MixBytes_Aave-v3.6.pdf",
+        "shows": "GitHub audit file path identifies the MixBytes Aave v3.6 report dated 2025-11-18.",
         "commit": "9f69c714350635787439608b52fb6064ce991bba",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "GitHub audit file path identifies the MixBytes Aave v3.6 report dated 2025-11-18."
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_Savant_Aave-v3.6.pdf",
+        "shows": "GitHub audit file path identifies the Savant Aave v3.6 report dated 2025-11-18.",
         "commit": "9f69c714350635787439608b52fb6064ce991bba",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "GitHub audit file path identifies the Savant Aave v3.6 report dated 2025-11-18."
+        "fetched_at": "2026-04-27T18:30:00Z"
       },
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-16_Blackthorn_Aave-v3.6.pdf",
+        "shows": "GitHub audit file path identifies the Blackthorn Aave v3.6 report dated 2025-11-16.",
         "commit": "9f69c714350635787439608b52fb6064ce991bba",
-        "fetched_at": "2026-04-27T18:30:00Z",
-        "shows": "GitHub audit file path identifies the Blackthorn Aave v3.6 report dated 2025-11-16."
+        "fetched_at": "2026-04-27T18:30:00Z"
       }
     ],
     "unknowns": [
@@ -373,10 +373,6 @@
     ]
   },
   {
-    "protocol": {
-      "slug": "aave-v3",
-      "name": "Aave V3"
-    },
     "slice": "open-access",
     "grade": "orange",
     "analysis_date": "2026-04-27",
@@ -424,39 +420,27 @@
       "findings": [
         {
           "code": "A1",
-          "label": "Permissionless Smart Contracts",
-          "description": "Core user-facing functions (supply, withdraw, borrow, repay) in the Pool contract do not contain whitelist or allowlist modifiers for standard markets.",
-          "evidence_url": "https://github.com/aave-dao/aave-v3-origin/blob/e06990e6fc1730935363f5927397bb99db573762/src/contracts/protocol/pool/Pool.sol#L145"
+          "text": "Core user-facing functions (supply, withdraw, borrow, repay) in the Pool contract do not contain whitelist or allowlist modifiers for standard markets."
         },
         {
           "code": "A2",
-          "label": "Autonomous Admission",
-          "description": "No off-chain operator, sequencer, or relayer approval is required to admit user transactions to the Aave V3 pools; transactions are processed immediately on-chain.",
-          "evidence_url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2#code"
+          "text": "No off-chain operator, sequencer, or relayer approval is required to admit user transactions to the Aave V3 pools; transactions are processed immediately on-chain."
         },
         {
           "code": "A3-active",
-          "label": "Frontend Wallet Screening",
-          "description": "The official Aave interface (app.aave.com) actively screens wallet addresses using TRM Labs and blocks those associated with sanctioned or prohibited activities.",
-          "evidence_url": "https://aave.com/terms-of-service"
+          "text": "The official Aave interface (app.aave.com) actively screens wallet addresses using TRM Labs and blocks those associated with sanctioned or prohibited activities."
         },
         {
           "code": "A3b-ii",
-          "label": "Independent Access Paths",
-          "description": "Multiple independent, non-ToS-bound access paths exist, including the open-source cp0x interface and third-party aggregators like DeFi Saver.",
-          "evidence_url": "https://aave.cp0x.com"
+          "text": "Multiple independent, non-ToS-bound access paths exist, including the open-source cp0x interface and third-party aggregators like DeFi Saver."
         },
         {
           "code": "A4",
-          "label": "No On-chain Blocklist",
-          "description": "The Aave V3 smart contracts do not implement an on-chain user blocklist or sanctions check within the core liquidity pool logic.",
-          "evidence_url": "https://github.com/aave-dao/aave-v3-origin/blob/e06990e6fc1730935363f5927397bb99db573762/src/contracts/protocol/pool/Pool.sol"
+          "text": "The Aave V3 smart contracts do not implement an on-chain user blocklist or sanctions check within the core liquidity pool logic."
         },
         {
           "code": "A6",
-          "label": "Jurisdictional Restrictions",
-          "description": "The Terms of Service explicitly prohibit users from the United States and other sanctioned jurisdictions from using the Interface.",
-          "evidence_url": "https://aave.com/terms-of-service"
+          "text": "The Terms of Service explicitly prohibit users from the United States and other sanctioned jurisdictions from using the Interface."
         }
       ],
       "steelman": {
@@ -469,41 +453,41 @@
     "evidence": [
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/e06990e6fc1730935363f5927397bb99db573762/src/contracts/protocol/pool/Pool.sol",
+        "shows": "The Pool.sol contract contains supply(), borrow(), and withdraw() functions without user-level whitelist modifiers.",
         "commit": "e06990e6fc1730935363f5927397bb99db573762",
-        "fetched_at": "2026-04-27T08:20:00Z",
-        "shows": "The Pool.sol contract contains supply(), borrow(), and withdraw() functions without user-level whitelist modifiers."
+        "fetched_at": "2026-04-27T08:20:00Z"
       },
       {
         "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "shows": "Verified deployment of Aave V3 Pool on Ethereum Mainnet.",
         "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
-        "fetched_at": "2026-04-27T08:21:00Z",
-        "shows": "Verified deployment of Aave V3 Pool on Ethereum Mainnet."
+        "fetched_at": "2026-04-27T08:21:00Z"
       },
       {
         "url": "https://aave.com/terms-of-service",
-        "fetched_at": "2026-04-27T08:22:00Z",
-        "shows": "Verbatim: 'We use TRM Labs, Inc. (“TRM”) to provide us with data regarding digital asset wallet addresses... if TRM’s services indicate that a wallet address is associated with a Sanctioned Person or other prohibited activity, we may block such wallet address from accessing the Interface.' and 'You are not a citizen, resident, or located in... the United States of America.'"
+        "shows": "Verbatim: 'We use TRM Labs, Inc. (“TRM”) to provide us with data regarding digital asset wallet addresses... if TRM’s services indicate that a wallet address is associated with a Sanctioned Person or other prohibited activity, we may block such wallet address from accessing the Interface.' and 'You are not a citizen, resident, or located in... the United States of America.'",
+        "fetched_at": "2026-04-27T08:22:00Z"
       },
       {
         "url": "https://aave.cp0x.com",
-        "fetched_at": "2026-04-27T08:23:00Z",
-        "shows": "A live, independent frontend for Aave V3 operated by cp0x."
+        "shows": "A live, independent frontend for Aave V3 operated by cp0x.",
+        "fetched_at": "2026-04-27T08:23:00Z"
       },
       {
         "url": "https://github.com/cp0x-org/pi-aave-interface",
+        "shows": "Open-source repository for the cp0x Aave interface, allowing for self-hosting.",
         "commit": "4f8e9d2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e",
-        "fetched_at": "2026-04-27T08:24:00Z",
-        "shows": "Open-source repository for the cp0x Aave interface, allowing for self-hosting."
+        "fetched_at": "2026-04-27T08:24:00Z"
       },
       {
         "url": "https://app.defisaver.com",
-        "fetched_at": "2026-04-27T08:25:00Z",
-        "shows": "Third-party DeFi management interface with integrated Aave V3 support."
+        "shows": "Third-party DeFi management interface with integrated Aave V3 support.",
+        "fetched_at": "2026-04-27T08:25:00Z"
       }
     ],
     "unknowns": [],
     "slug": "aave",
-    "schema_version": "v2",
+    "schema_version": 2,
     "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
     "prompt_version": 12,
     "headline": "The protocol is graded orange"

--- a/data/submissions/aave/open-access/models-2026-04-27.json
+++ b/data/submissions/aave/open-access/models-2026-04-27.json
@@ -1,0 +1,511 @@
+[
+  {
+    "schema_version": 2,
+    "slug": "aave",
+    "slice": "open-access",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-04-27",
+    "model": "claude-opus-4-7",
+    "chat_url": null,
+    "grade": "orange",
+    "headline": "Smart contracts are admission-permissionless; official frontend app.aave.com applies TRM Labs wallet screening + ToS restricted-jurisdiction enforcement. Independent A3b-ii paths exist (cp0x pi-aave-interface, direct contract calls) but are third-party-operated.",
+    "rationale": {
+      "verdict": "Choosing orange because Aave V3 smart contracts are admission-permissionless (Pool.supply/withdraw/borrow/repay/liquidationCall/flashLoan are public virtual override with no whitelist/KYC modifier per Pool.sol @ commit 1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978), but the official frontend app.aave.com applies A3-active enforcement via TRM Labs API integration which screens connected wallets and rejects flagged ones (publicly confirmed by Aave Labs in the 2022 dusted-wallets incident: 'We integrated TRM's API on the Aave IPFS frontend'), and the ToS at aave.com/legal/app/terms-of-service explicitly reserves the right to restrict access on the basis of Restricted Jurisdictions (Belarus, Cuba, Iran, North Korea, Russia, Syria, Venezuela, etc.) and to act when users attempt circumvention through VPNs or proxies. Independent A3b-ii paths exist (cp0x pi-aave-interface live at aave.cp0x.com under MIT license, direct contract calls via Etherscan, CLI/SDK), but they are operated by third parties or require technical capability and are not officially documented by Aave on its public landing pages. Per the rubric, A3-active screening on the official frontend without clearly-documented non-technical alternatives places this slice at orange, not green. Red is not appropriate because there is no contract-level whitelist, no on-chain blocklist updated by a single party, and no operator approval gating admission.",
+      "steelman": {
+        "green": "All on-chain entry/exit functions are fully permissionless (no modifier on supply/withdraw/borrow/repay), the smart contracts admit any address unconditionally, and credible independent frontends (cp0x pi-aave-interface at aave.cp0x.com, MIT-licensed) plus direct-contract paths via Etherscan and SDKs mean any user excluded from app.aave.com retains effective access; the TRM screening is documented as front-end-only with documented workarounds.",
+        "orange": "The official protocol-branded frontend (app.aave.com, operated by Aave Interfaces Ltd / Aave Labs) actively screens wallet addresses against TRM Labs and explicitly enforces Restricted-Jurisdiction policy with anti-VPN-circumvention language, and while alternatives exist they are run by third parties (cp0x) or require CLI/Etherscan skills, so admission via the canonical interface is non-trivially gated for non-technical users.",
+        "red": "If the TRM-driven frontend block were treated as a single-party operator gating admission with no replacement procedure, and if the third-party cp0x interface were excluded as not protocol-controlled, the official admission path could be viewed as controlled by one operator. This is the weakest steelman because contracts have no whitelist, no on-chain blocklist, and the underlying chain access is not actually gatable by Aave Labs."
+      },
+      "findings": [
+        {
+          "code": "A1",
+          "text": "Pool.sol user-facing functions supply, supplyWithPermit, withdraw, borrow, repay, repayWithPermit, repayWithATokens, liquidationCall, flashLoan, flashLoanSimple are declared public virtual override with no onlyWhitelisted/onlyRole/isAccredited/isKYCed/allowlist modifier. Only modifiers in Pool.sol are onlyPoolConfigurator, onlyPoolAdmin, onlyPositionManager(address onBehalfOf), onlyUmbrella - all gating admin operations, not user entry. grep on Pool.sol returned no matches for whitelist|allowlist|isAccredited|isKYCed|sanction."
+        },
+        {
+          "code": "A2",
+          "text": "User-facing supply/withdraw/borrow/repay route to SupplyLogic.executeSupply / SupplyLogic.executeWithdraw / BorrowLogic.executeBorrow / BorrowLogic.executeRepay with user: _msgSender(); no off-chain keeper/sequencer/relayer approval is required to admit the action. Liquidations are open to any caller (liquidationCall is public). No operator committee gates admission."
+        },
+        {
+          "code": "A3-active",
+          "text": "Aave Labs publicly confirmed runtime wallet screening on the official frontend in the August-2022 dusted-wallets incident: 'We integrated TRM's API on the Aave IPFS frontend, which is why some users may be experiencing trouble accessing the Aave app.' The governance forum thread 'Address Blocking and TRM Labs' confirms that Aave 'use[s] TRM Labs to scan for supposed illegal or sanctioned activity' with blocked accounts 'only banned from using their front end- not from using the Aave protocol entirely.' Satisfies evidentiary floor (d) public incident report + (c) named third-party screening provider."
+        },
+        {
+          "code": "A3-passive",
+          "text": "ToS at aave.com/legal/app/terms-of-service Section 2.3: 'access to and use of the Services is prohibited for any person or entity that is located in, organized under the laws of, or ordinarily resident in any country or territory that is, or whose government is, the subject of comprehensive trade or economic sanctions ... including, without limitation, Belarus, Cote d'Ivoire, Crimea, Cuba, Donetsk PR, Iran, Iraq, Kherson, Liberia, Libya, Luhansk PR, Myanmar, North Korea, Russia, Sudan, Syria, Venezuela, Zaporizhzhia.' Anti-circumvention clause: 'The Company reserves the right ... if you attempt to circumvent such restrictions through virtual private networks, proxies, or similar technologies.' These are passive eligibility/attestation clauses; their grade-weight is ~0.25."
+        },
+        {
+          "code": "A3b-i",
+          "text": "Aave's official frontend is also pinned to IPFS (referenced by Aave Labs as the 'Aave IPFS frontend' in the TRM incident statement). The same ToS defines 'Interface' as 'an independent interface providing one of the available applications through which users, via their self-custodial wallets, interact with the Aave Protocol' and 'Services' as 'both the Aave.com website ... and App.aave.com interface'. IPFS-pinned redistributions of the official UI remain bound by the same ToS and so are not an independent A3b-ii path."
+        },
+        {
+          "code": "A3b-ii",
+          "text": "cp0x maintains pi-aave-interface, an independent permissionless frontend for Aave V3, deployed live at https://aave.cp0x.com (HTTP/1.1 200 from nginx, served from cp0x infrastructure, distinct legal entity from Aave Interfaces Ltd). Repo (github.com/cp0x-org/pi-aave-interface) is publicly accessible, MIT-licensed, README states 'An open-source, permissionless interface for the Aave protocol, designed to be fully permissionless and enable direct, unrestricted interaction with smart contracts.' Aave's TRM-labs-block incident report explicitly notes 'Users could still connect via CLI or forking the front-end to host in their environments.' These paths exist but are not officially advertised on aave.com landing pages and skew technical."
+        },
+        {
+          "code": "A4",
+          "text": "Off-chain compliance tooling: TRM Labs API integrated on the official IPFS-hosted frontend to screen wallet addresses against sanctions lists (confirmed by Aave Labs in the dusted-wallets incident and the governance forum thread 'Address Blocking and TRM Labs'). Privacy Policy at aave.com/privacy-policy: 'We may collect the wallet address you use to connect to the Interface to block wallets that are associated with certain legally prohibited conduct from Interface.' No on-chain OFAC oracle (Chainalysis Sanctions Oracle) is checked by Pool.sol; screening is exclusively at the application/frontend layer."
+        },
+        {
+          "code": "A5",
+          "text": "Read access: fully permissionless on-chain (any caller can call view functions getReserveData, getUserAccountData, getReservesList, etc. on the verified proxy 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2). Write access: permissionless at the contract layer (no modifier gates supply/withdraw/borrow/repay), but the official app.aave.com frontend gates write access by wallet via TRM screening + ToS jurisdictional self-attestation. The split between contract-level (open) and frontend-level (gated) is the central observation."
+        },
+        {
+          "code": "A6",
+          "text": "Two canonical ToS endpoints exist: aave.com/terms-of-service (older, naming OFAC/UN/EU/HM Treasury sanction lists) and aave.com/legal/app/terms-of-service (newer, with explicit VPN/proxy circumvention clause). Operator entity: 'Aave Interfaces Ltd ... Aave Labs, Company, we, us, or our.' Privacy Policy at aave.com/privacy-policy contains the wallet-blocking disclosure verbatim."
+        }
+      ]
+    },
+    "evidence": [
+      {
+        "url": "https://raw.githubusercontent.com/bgd-labs/aave-v3-origin/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/pool/Pool.sol",
+        "shows": "Pool.sol at HEAD of bgd-labs/aave-v3-origin main. Functions supply (line 118), supplyWithPermit (142), withdraw (181), borrow (205), repay (234), liquidationCall (351), flashLoan (379) all declared public virtual override with no whitelist/KYC/role modifier. grep -niE 'whitelist|allowlist|isAccredited|isKYCed|sanction' returned zero matches.",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T16:36:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "shows": "Verified Aave V3 Pool proxy on Ethereum mainnet. Etherscan tag: 'Aave: Pool V3'. Source code 'Exact Match'. Implementation: 0x8147b99D...a60F119Bd. Admin (proxy admin): 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e (Pool Addresses Provider V3). Read Contract pane open to any caller - confirms permissionless deployed-state.",
+        "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "fetched_at": "2026-04-27T16:33:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "shows": "Verified Aave V3 PoolConfigurator proxy on Ethereum. Etherscan tag: 'Aave: Pool Configurator V3'. Implementation 0x6fDdde45f777a4e461b0721a578b169b44579623. Configurator gates admin operations only - orthogonal to user admission.",
+        "address": "0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "fetched_at": "2026-04-27T16:48:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "shows": "Verified ACLManager on Ethereum. Etherscan tag: 'Aave: ACL Manager V3'. OpenZeppelin AccessControl pattern. ACL governs administrative roles, not user admission.",
+        "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "fetched_at": "2026-04-27T16:55:00Z"
+      },
+      {
+        "url": "https://aave.com/legal/app/terms-of-service",
+        "shows": "Section 2.3 (Restricted Jurisdictions) lists Belarus, Cote d'Ivoire, Crimea, Cuba, Donetsk PR, Iran, Iraq, Kherson, Liberia, Libya, Luhansk PR, Myanmar, North Korea, Russia, Sudan, Syria, Venezuela, Zaporizhzhia. Anti-circumvention clause: 'The Company reserves the right ... if you attempt to circumvent such restrictions through virtual private networks, proxies, or similar technologies.' Operator: 'Aave Interfaces Ltd ... Aave Labs, Company, we, us, or our.'",
+        "fetched_at": "2026-04-27T16:42:00Z"
+      },
+      {
+        "url": "https://aave.com/terms-of-service",
+        "shows": "Older ToS sanctions clause: 'you are the target of any sanctions administered or enforced by the U.S. Department of the Treasury's Office of Foreign Assets Control (OFAC), the United Nations Security Council, the European Union, Her Majesty's Treasury ... your wallet address is listed on the Specially Designated Nationals and Blocked Persons List (SDN List), Consolidated Sanctions List (Non-SDN Lists).' Definition: Interface = 'an independent interface providing one of the available applications.'",
+        "fetched_at": "2026-04-27T16:31:00Z"
+      },
+      {
+        "url": "https://aave.com/privacy-policy",
+        "shows": "Verbatim wallet-blocking disclosure: 'We may collect the wallet address you use to connect to the Interface to block wallets that are associated with certain legally prohibited conduct from Interface.' Service Providers clause: 'We share information with third-party service providers for business purposes, including fraud detection and prevention, security threat detection, data analytics ... and blockchain transaction monitoring.'",
+        "fetched_at": "2026-04-27T16:39:00Z"
+      },
+      {
+        "url": "https://cryptoslate.com/aave-confirms-trm-labs-api-blocked-dusted-ethereum-wallets-access-restored/",
+        "shows": "Public incident report. Aave Labs statement: 'We integrated TRM's API on the Aave IPFS frontend, which is why some users may be experiencing trouble accessing the Aave app.' Scope: the ban 'only stopped users from interacting with its IPFS-hosted web interface for the Aave protocol.' Workaround: 'Users could still connect via CLI or forking the front-end to host in their environments.' Satisfies A3-active evidentiary floor (d) and (c).",
+        "fetched_at": "2026-04-27T16:58:00Z"
+      },
+      {
+        "url": "https://governance.aave.com/t/address-blocking-and-trm-labs/9301",
+        "shows": "Aave governance forum thread 'Address Blocking and TRM Labs'. Confirms Aave 'use[s] TRM Labs to scan for supposed illegal or sanctioned activity'. User clarification: blocked accounts 'are only banned from using their front end - not from using the Aave protocol entirely (aka through etherscan or others).'",
+        "fetched_at": "2026-04-27T17:00:00Z"
+      },
+      {
+        "url": "https://github.com/cp0x-org/pi-aave-interface",
+        "shows": "Independent A3b-ii frontend. Repo cp0x-org/pi-aave-interface, public, MIT-licensed (license relicensed 2025-12-13 in commit e5caa67). README: 'An open-source, permissionless interface for the Aave protocol, designed to be fully permissionless and enable direct, unrestricted interaction with smart contracts.' Live deploys: https://aave.cp0x.com and https://pi.cp0x.com.",
+        "commit": "e5caa6792b3347af8f76cadddb6b2b5de0a643b3",
+        "fetched_at": "2026-04-27T16:56:00Z"
+      },
+      {
+        "url": "https://aave.cp0x.com",
+        "shows": "HTTP/1.1 200 OK from nginx/1.24.0 (Ubuntu), Next.js application, served independently from cp0x infrastructure (separate legal entity from Aave Interfaces Ltd). Page title: 'Aave - Open Source Liquidity Protocol'. No TRM/Chainalysis/sanction strings found in initial HTML payload. Confirms an operational independent A3b-ii path.",
+        "fetched_at": "2026-04-27T16:37:13Z"
+      },
+      {
+        "url": "https://app.aave.com",
+        "shows": "HTTP/2 200, served via Cloudflare + Vercel (server: cloudflare, x-vercel-cache: HIT). Static initial HTML payload does not embed Chainalysis/TRM script tags directly (screening is performed via runtime API call from client-side JS to a backend endpoint, per the public incident report). Production canonical Aave Labs frontend.",
+        "fetched_at": "2026-04-27T16:37:08Z"
+      }
+    ],
+    "unknowns": [
+      "A4: No public confirmation that an on-chain Chainalysis Sanctions Oracle is queried by Aave V3 contracts on any chain. Frontend uses TRM Labs API; the contract layer was not seen calling any sanctions oracle in Pool.sol at SHA 1e3d70c."
+    ]
+  },
+  {
+    "schema_version": 2,
+    "slug": "aave",
+    "slice": "open-access",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-04-27",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "orange",
+    "headline": "Aave V3 core contracts admit supply, withdraw, borrow, repay, liquidation, flash-loan, and direct read paths without KYC or allowlist gates, but Aave Labs' official interface has documented wallet and region screening; direct-contract and independent frontend alternatives exist.",
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/aave-dao/aave-v3-origin",
+        "https://github.com/bgd-labs/aave-v3-origin"
+      ],
+      "docs_url": "https://aave.com/docs",
+      "audits": [
+        {
+          "firm": "Pashov",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-29_Pashov_Aave-v3.6.pdf",
+          "date": "2025-11-29"
+        },
+        {
+          "firm": "Certora",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_Certora_Aave-v3.6.pdf",
+          "date": "2025-11-18"
+        },
+        {
+          "firm": "MixBytes",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_MixBytes_Aave-v3.6.pdf",
+          "date": "2025-11-18"
+        },
+        {
+          "firm": "Savant",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_Savant_Aave-v3.6.pdf",
+          "date": "2025-11-18"
+        },
+        {
+          "firm": "Blackthorn",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-16_Blackthorn_Aave-v3.6.pdf",
+          "date": "2025-11-16"
+        }
+      ],
+      "governance_forum": "https://governance.aave.com",
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "symbol": "AAVE"
+      },
+      "bug_bounty_url": "https://audits.sherlock.xyz",
+      "security_contact": null,
+      "deployed_contracts_doc": "https://aave.com/docs/resources/addresses",
+      "admin_addresses": [],
+      "upgradeability": "upgradeable",
+      "about": "Aave V3 is a non-custodial liquidity protocol where suppliers deposit assets into shared reserves, receive interest-bearing aTokens, and can use eligible collateral to borrow other assets. Borrowers take overcollateralized loans tracked by debt tokens, with health-factor risk checks and permissionless liquidations when collateral falls below required thresholds. V3 adds market controls such as eMode, isolation mode, siloed borrowing, and reserve caps."
+    },
+    "rationale": {
+      "verdict": "Orange best fits the evidence: the checked Aave V3 Pool source at commit 1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978 exposes supply, withdraw, borrow, repay, liquidation, flash-loan, and read functions as public caller-driven contract actions, and the live Ethereum Pool proxy is verified on Etherscan; however, Aave's official app/legal and privacy pages disclose wallet and region restrictions, and public incident/forum records show TRM-based frontend blocking. Red is not supported because I found no contract-level whitelist, KYC gate, or on-chain sanctions blocklist in the inspected core Pool paths, and Aave documents direct smart-contract access while cp0x operates an independent open-source Aave interface.",
+      "steelman": {
+        "green": "The strongest green case is that Aave V3's checked on-chain entry and exit functions are public, do not require KYC or allowlist admission, do not depend on an off-chain operator approval step, and remain reachable through direct smart-contract calls and independent frontends.",
+        "orange": "The strongest orange case is that Aave Labs' canonical interface applies active admission controls at the frontend layer through wallet and region screening, even though the underlying contracts remain open.",
+        "red": "The strongest red case would treat Aave Labs' screened official frontend as a single-operator gate for ordinary users, but that case is weaker because the Pool contracts and direct block-explorer or self-hosted access paths are not controlled by that frontend."
+      },
+      "findings": [
+        {
+          "code": "A1",
+          "text": "The inspected Pool user functions supply, supplyWithPermit, withdraw, borrow, repay, repayWithPermit, repayWithATokens, liquidationCall, flashLoan, flashLoanSimple, and deposit are public. Pool.sol contains admin modifiers onlyPoolConfigurator, onlyPoolAdmin, onlyPositionManager, and onlyUmbrella for non-entry administrative or delegated functions; no onlyWhitelisted, onlyRole, allowlist, isAccredited, or isKYCed gate was found on the checked core user actions, so there is no allowlist maintainer to identify for those paths."
+        },
+        {
+          "code": "A2",
+          "text": "Deposits, withdrawals, borrows, repayments, liquidations, flash loans, and public read calls are admitted directly by Pool contract calls using msg.sender, subject to protocol state such as liquidity, health factor, reserve configuration, and user-granted position-manager delegation. AToken transfers are finalized through Pool.finalizeTransfer for accounting and health checks; I found no keeper, sequencer, privileged relayer, oracle poster, single operator, or permissioned committee whose approval is required before these user actions are admitted."
+        },
+        {
+          "code": "A3-active",
+          "text": "The official interface has active access controls at the frontend layer: Aave privacy terms disclose wallet collection for blocking legally prohibited conduct, the terms reserve region-based technical restrictions, CryptoSlate recorded Aave's TRM API frontend integration during the dusted-wallet incident, and a 2026 Aave forum thread records a user reporting app.aave.com frontend access restriction and asking for address unblocking."
+        },
+        {
+          "code": "A3-passive",
+          "text": "Aave terms also include passive eligibility restrictions covering sanctions, restricted jurisdictions, age/legal capacity, and anti-circumvention language. These clauses apply to Aave Labs/Aave Interfaces services and are not present as contract-level checks in the inspected Pool source."
+        },
+        {
+          "code": "A3b-i",
+          "text": "Aave documents that the official Interface is hosted on IPFS and the security page says each Aave Interface commit is deployed to IPFS with app.aave.com DNSLink/IPNS updates. Because Aave's terms cover App.aave.com and the Interface, IPFS redistributions of the official interface are not treated here as independent access paths."
+        },
+        {
+          "code": "A3b-ii",
+          "text": "Independent access paths exist: Aave's help page says users can interact directly with smart contracts through block explorers or code, Etherscan exposes the live Ethereum Pool proxy, and cp0x operates a public MIT-licensed pi-aave-interface at aave.cp0x.com with a README describing direct unrestricted smart-contract interaction."
+        },
+        {
+          "code": "A4",
+          "text": "I found sanctions/compliance tooling at the official frontend layer, not the checked Pool contract layer. The privacy policy discloses wallet blocking and blockchain transaction monitoring providers, and the TRM incident records show frontend screening, while the inspected Pool source and live Pool proxy evidence did not show an on-chain OFAC or similar blocklist check on core user entry/exit functions."
+        },
+        {
+          "code": "A5",
+          "text": "Read access is permissionless through public view functions such as getReserveData, getUserAccountData, and getReservesList on the verified Pool proxy. Write access at the contract layer is permissionless for supply, withdraw, borrow, repay, liquidation, flash-loan, collateral-mode, and eMode actions, subject to protocol solvency, liquidity, reserve state, and user approvals; the official frontend can restrict access before a user reaches those contract calls."
+        },
+        {
+          "code": "A6",
+          "text": "Legal links located were https://aave.com/terms-of-service, https://aave.com/legal/app/terms-of-service, and https://aave.com/privacy-policy. The extracted clauses include restricted-jurisdiction, sanctions, anti-circumvention, and wallet-address blocking language."
+        }
+      ]
+    },
+    "evidence": [
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/pool/Pool.sol",
+        "commit": "1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Pool.sol at the pinned commit declares supply, supplyWithPermit, withdraw, borrow, repay, repayWithPermit, repayWithATokens, liquidationCall, flashLoan, flashLoanSimple, getReserveData, getUserAccountData, getReservesList, finalizeTransfer, and deposit. The user entry functions are public; admin modifiers in this file are onlyPoolConfigurator, onlyPoolAdmin, onlyPositionManager, and onlyUmbrella. Local grep for onlyWhitelisted, onlyRole, allowlist, isAccredited, isKYCed, OFAC, sanction, blocklist, and blacklist returned no matches in Pool.sol."
+      },
+      {
+        "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Etherscan labels this deployed contract as Aave: Pool V3, shows Source Code (Proxy), and shows recent transaction methods including Supply, Withdraw, Repay With Permit, and Borrow. This is the live Ethereum Pool surface assessed for deployed-state access."
+      },
+      {
+        "url": "https://etherscan.io/address/0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "address": "0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Etherscan labels this deployed contract as Aave: Pool Configurator V3 and shows Source Code (Proxy). It is the configuration/admin surface, separate from ordinary user admission."
+      },
+      {
+        "url": "https://etherscan.io/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Etherscan labels this deployed contract as Aave: ACL Manager V3. ACLManager is the administrative role manager; the inspected Pool user entry functions did not call it as a user allowlist/KYC gate."
+      },
+      {
+        "url": "https://app.aave.com",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Static fetch of the official Aave V3 frontend returned the Aave application shell from app.aave.com; this run did not reproduce a block banner from the test location."
+      },
+      {
+        "url": "https://aave.com/legal/app/terms-of-service",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Aave App Terms updated 06 January 2026 identify Aave Interfaces Ltd/Aave Labs as service provider. Verbatim excerpts: 'access to and use of the Services is prohibited', 'virtual private networks, proxies, or similar technologies', and 'region-based or other technical methods'."
+      },
+      {
+        "url": "https://aave.com/terms-of-service",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Aave.com/App.aave.com Terms updated January 6, 2026 say the Services include App.aave.com, describe the Interface as hosted on IPFS, and reserve restriction rights for sanctioned persons, sanctioned wallet addresses, and restricted territories. Verbatim excerpt: 'via any technically available methods'."
+      },
+      {
+        "url": "https://aave.com/privacy-policy",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Aave Privacy Policy says Aave may collect wallet address information for the Interface. Verbatim excerpt: 'block wallets that are associated with certain legally prohibited conduct'. It also lists third-party service providers for fraud detection, security threat detection, and blockchain transaction monitoring."
+      },
+      {
+        "url": "https://cryptoslate.com/aave-confirms-trm-labs-api-blocked-dusted-ethereum-wallets-access-restored/",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Public incident report dated Aug. 14, 2022 says Aave confirmed TRM Labs API caused frontend blocking, that the ban only affected the IPFS-hosted web interface, and that CLI/self-hosted frontend access remained possible. Verbatim excerpt from quoted Aave statement: 'We integrated TRM's API on the Aave IPFS frontend'."
+      },
+      {
+        "url": "https://governance.aave.com/t/address-blocking-and-trm-labs/9301",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Aave governance forum thread from Aug. 2022 discusses address blocking on the Aave front end, identifies TRM Labs as the scanner, and notes that blocked accounts remained able to use the protocol through Etherscan or other access paths."
+      },
+      {
+        "url": "https://governance.aave.com/t/address-blocking-request/24012",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Aave governance forum thread dated Feb. 6, 2026 records a user reporting an app.aave.com frontend access restriction, asking for whitelist/unblock, and receiving replies pointing to alternative frontends and possible geolocation blocking."
+      },
+      {
+        "url": "https://aave.com/help/aave-101/accessing-aave",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Aave help page says users can interact with Aave through multiple interfaces or directly with smart contracts, and explains that third-party services can integrate with the protocol."
+      },
+      {
+        "url": "https://github.com/cp0x-org/pi-aave-interface",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "cp0x-org/pi-aave-interface is a public GitHub repo forked from aave/interface, MIT-licensed, with README text describing a permissionless Aave interface for direct unrestricted smart-contract interaction. It lists Interface: https://aave.cp0x.com."
+      },
+      {
+        "url": "https://aave.cp0x.com",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Live cp0x Aave interface returned page title Aave - Open Source Liquidity Protocol, confirming the independent frontend was reachable during this run."
+      },
+      {
+        "url": "https://aave.com/docs/aave-v3/overview",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Aave V3 overview describes non-custodial supply and borrow infrastructure, aTokens for suppliers, overcollateralized borrowing with debt tokens, health-factor/liquidation mechanics, and V3 features including eMode, isolation mode, and siloed borrowing."
+      },
+      {
+        "url": "https://aave.com/docs/resources/addresses",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Aave Protocol Deployed Contracts page lists deployed contract addresses and links to the Aave Address Book for Solidity or JavaScript integrations."
+      },
+      {
+        "url": "https://aave.com/security",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Aave Security page links official protocol GitHub, bug bounty, and audit reports. It states each Aave Interface commit is deployed to IPFS and app.aave.com IPNS/DNSLink records are updated to the latest deployment hash."
+      },
+      {
+        "url": "https://github.com/bgd-labs/aave-v3-origin",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "bgd-labs/aave-v3-origin is a public fork of aave-dao/aave-v3-origin and identifies the repository as the Aave v3.6 complete Foundry-based codebase."
+      },
+      {
+        "url": "https://etherscan.io/address/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Etherscan labels this deployed Ethereum token contract as Aave: AAVE Token."
+      },
+      {
+        "url": "https://aave.com/about",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "Aave About page says the Aave Protocol is governed by the Aave DAO and that AAVE is used for governance voting. It also describes Aave as a decentralized non-custodial liquidity protocol for suppliers and borrowers."
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-29_Pashov_Aave-v3.6.pdf",
+        "commit": "9f69c714350635787439608b52fb6064ce991bba",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "GitHub audit file path identifies the Pashov Aave v3.6 report dated 2025-11-29."
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_Certora_Aave-v3.6.pdf",
+        "commit": "9f69c714350635787439608b52fb6064ce991bba",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "GitHub audit file path identifies the Certora Aave v3.6 report dated 2025-11-18."
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_MixBytes_Aave-v3.6.pdf",
+        "commit": "9f69c714350635787439608b52fb6064ce991bba",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "GitHub audit file path identifies the MixBytes Aave v3.6 report dated 2025-11-18."
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_Savant_Aave-v3.6.pdf",
+        "commit": "9f69c714350635787439608b52fb6064ce991bba",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "GitHub audit file path identifies the Savant Aave v3.6 report dated 2025-11-18."
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-16_Blackthorn_Aave-v3.6.pdf",
+        "commit": "9f69c714350635787439608b52fb6064ce991bba",
+        "fetched_at": "2026-04-27T18:30:00Z",
+        "shows": "GitHub audit file path identifies the Blackthorn Aave v3.6 report dated 2025-11-16."
+      }
+    ],
+    "unknowns": [
+      "A3-active: I did not reproduce a live block banner with a sanctioned wallet or restricted-country IP during this run; the active-frontend finding is based on Aave policy pages plus public incident and forum evidence, not my own blocked-session observation.",
+      "A4: I checked Pool.sol and the Ethereum Pool proxy, but did not exhaustively inspect every deployed chain implementation for local deviations; no on-chain sanctions or OFAC blocklist check was found in the inspected core paths."
+    ]
+  },
+  {
+    "protocol": {
+      "slug": "aave-v3",
+      "name": "Aave V3"
+    },
+    "slice": "open-access",
+    "grade": "orange",
+    "analysis_date": "2026-04-27",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/aave-dao/aave-v3-origin",
+        "https://github.com/bgd-labs/aave-v3-origin"
+      ],
+      "docs_url": "https://docs.aave.com",
+      "audits": [
+        {
+          "firm": "Sigma Prime",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/2022-01-27_SigmaPrime_AaveV3.pdf",
+          "date": "2022-01-27"
+        },
+        {
+          "firm": "Trail of Bits",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/2022-03-14_TrailOfBits_AaveV3.pdf",
+          "date": "2022-03-14"
+        }
+      ],
+      "governance_forum": "https://governance.aave.com",
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x7Fc66500c84A76Ad7e9c93437bfc5Ac33E2DDaE9",
+        "symbol": "AAVE"
+      },
+      "bug_bounty_url": "https://immunefi.com/bounty/aave/",
+      "security_contact": "https://github.com/aave-dao/aave-v3-origin/blob/main/SECURITY.md",
+      "deployed_contracts_doc": "https://docs.aave.com/developers/deployed-contracts/v3-mainnet",
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0xEE56e2B3D49159022b71869955dbF07245799b17",
+          "role": "Governance Executor (Short)",
+          "actor_class": "governance"
+        }
+      ],
+      "upgradeability": "upgradeable",
+      "about": "Aave V3 is a decentralized non-custodial liquidity protocol where users can participate as depositors or borrowers. Depositors provide liquidity to the market to earn a passive income, while borrowers are able to borrow in an overcollateralized (perpetually) or undercollateralized (one-block liquidity) fashion. It features advanced risk management tools like Isolation Mode, E-Mode, and Siloed Borrowing."
+    },
+    "rationale": {
+      "findings": [
+        {
+          "code": "A1",
+          "label": "Permissionless Smart Contracts",
+          "description": "Core user-facing functions (supply, withdraw, borrow, repay) in the Pool contract do not contain whitelist or allowlist modifiers for standard markets.",
+          "evidence_url": "https://github.com/aave-dao/aave-v3-origin/blob/e06990e6fc1730935363f5927397bb99db573762/src/contracts/protocol/pool/Pool.sol#L145"
+        },
+        {
+          "code": "A2",
+          "label": "Autonomous Admission",
+          "description": "No off-chain operator, sequencer, or relayer approval is required to admit user transactions to the Aave V3 pools; transactions are processed immediately on-chain.",
+          "evidence_url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2#code"
+        },
+        {
+          "code": "A3-active",
+          "label": "Frontend Wallet Screening",
+          "description": "The official Aave interface (app.aave.com) actively screens wallet addresses using TRM Labs and blocks those associated with sanctioned or prohibited activities.",
+          "evidence_url": "https://aave.com/terms-of-service"
+        },
+        {
+          "code": "A3b-ii",
+          "label": "Independent Access Paths",
+          "description": "Multiple independent, non-ToS-bound access paths exist, including the open-source cp0x interface and third-party aggregators like DeFi Saver.",
+          "evidence_url": "https://aave.cp0x.com"
+        },
+        {
+          "code": "A4",
+          "label": "No On-chain Blocklist",
+          "description": "The Aave V3 smart contracts do not implement an on-chain user blocklist or sanctions check within the core liquidity pool logic.",
+          "evidence_url": "https://github.com/aave-dao/aave-v3-origin/blob/e06990e6fc1730935363f5927397bb99db573762/src/contracts/protocol/pool/Pool.sol"
+        },
+        {
+          "code": "A6",
+          "label": "Jurisdictional Restrictions",
+          "description": "The Terms of Service explicitly prohibit users from the United States and other sanctioned jurisdictions from using the Interface.",
+          "evidence_url": "https://aave.com/terms-of-service"
+        }
+      ],
+      "steelman": {
+        "red": "Aave V3 could be considered red because the Aave DAO maintains the power to appoint Pool Admins who can freeze markets or change risk parameters, and the primary frontend is heavily gated by both geo-blocking and active TRM wallet screening.",
+        "orange": "Aave V3 is orange because while the underlying smart contracts are permissionless and have no on-chain blocklists, the official frontend implements active A3-active enforcement (TRM screening and geo-blocking), necessitating the use of third-party interfaces for restricted users.",
+        "green": "Aave V3 is green because the protocol is architecturally permissionless at the contract level, and the existence of robust, independent, and open-source alternative frontends like cp0x ensures that no single entity can prevent a user from accessing the protocol."
+      },
+      "verdict": "The protocol is graded orange. While the smart contracts (A1, A2, A4) are entirely permissionless and do not require operator approval for admission, the official frontend (app.aave.com) implements active enforcement (A3-active) via TRM Labs wallet screening and jurisdictional geo-blocking. The presence of credible A3b-ii alternatives like cp0x and DeFi Saver mitigates the risk of total exclusion but does not override the rubric's requirement for a green grade to have no A3-active restrictions on the official interface."
+    },
+    "evidence": [
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/e06990e6fc1730935363f5927397bb99db573762/src/contracts/protocol/pool/Pool.sol",
+        "commit": "e06990e6fc1730935363f5927397bb99db573762",
+        "fetched_at": "2026-04-27T08:20:00Z",
+        "shows": "The Pool.sol contract contains supply(), borrow(), and withdraw() functions without user-level whitelist modifiers."
+      },
+      {
+        "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "fetched_at": "2026-04-27T08:21:00Z",
+        "shows": "Verified deployment of Aave V3 Pool on Ethereum Mainnet."
+      },
+      {
+        "url": "https://aave.com/terms-of-service",
+        "fetched_at": "2026-04-27T08:22:00Z",
+        "shows": "Verbatim: 'We use TRM Labs, Inc. (“TRM”) to provide us with data regarding digital asset wallet addresses... if TRM’s services indicate that a wallet address is associated with a Sanctioned Person or other prohibited activity, we may block such wallet address from accessing the Interface.' and 'You are not a citizen, resident, or located in... the United States of America.'"
+      },
+      {
+        "url": "https://aave.cp0x.com",
+        "fetched_at": "2026-04-27T08:23:00Z",
+        "shows": "A live, independent frontend for Aave V3 operated by cp0x."
+      },
+      {
+        "url": "https://github.com/cp0x-org/pi-aave-interface",
+        "commit": "4f8e9d2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e",
+        "fetched_at": "2026-04-27T08:24:00Z",
+        "shows": "Open-source repository for the cp0x Aave interface, allowing for self-hosting."
+      },
+      {
+        "url": "https://app.defisaver.com",
+        "fetched_at": "2026-04-27T08:25:00Z",
+        "shows": "Third-party DeFi management interface with integrated Aave V3 support."
+      }
+    ],
+    "unknowns": [],
+    "slug": "aave",
+    "schema_version": "v2",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "headline": "The protocol is graded orange"
+  }
+]

--- a/data/submissions/aave/verifiability/models-2026-04-27.json
+++ b/data/submissions/aave/verifiability/models-2026-04-27.json
@@ -1,0 +1,416 @@
+[
+  {
+    "schema_version": 2,
+    "slug": "aave",
+    "slice": "verifiability",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-04-27",
+    "model": "claude-opus-4-7",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Pool/PoolConfigurator/PoolAddressesProvider all 'Source Code Verified - Exact Match' on Etherscan; deployed implementations correspond to aave-dao/aave-v3-origin@v3.6.0; v3.6 audited Nov 2025 by 5 recognized firms (Certora, MixBytes, Pashov, Blackthorn, Savant) ~2 months before on-chain upgrade Jan 2026.",
+    "rationale": {
+      "verdict": "All three core Aave V3 contracts on Ethereum mainnet (Pool proxy 0x87870Bca..., PoolConfigurator proxy 0x64b761D8..., PoolAddressesProvider 0x2f39d218...) show 'Source Code Verified - Exact Match' on Etherscan. Both proxy AND current implementation contracts are independently verified: Pool implementation 0x8147b99d... ('PoolInstance', Solidity 0.8.27) and PoolConfigurator implementation 0x6fDdde45... ('PoolConfiguratorInstance', Solidity 0.8.27). The deployed implementations correspond to the public aave-dao/aave-v3-origin repo at tag v3.6.0 (commit 5a230ec82fcb10afc7fe7cffa8978752fb17aa2b): contract names match exactly, the v3.6.0 PoolInstance.sol declares POOL_REVISION=10 and PoolConfiguratorInstance.sol declares CONFIGURATOR_REVISION=7. The current v3.6 release was audited by five recognized firms (Certora, MixBytes, Pashov, Blackthorn, Savant) in Nov 2025, ~2 months before the on-chain upgrade (Jan 16, 2026), well within the 6-month freshness window. Earlier versions (V3 genesis, V3.0.1, V3.0.2, V3.1, V3.2, V3.3, V3.4, V3.5) were each independently re-audited by recognized firms (OpenZeppelin, Trail of Bits, ABDK, Sigma Prime, Peckshield, Certora, MixBytes, ChainSecurity, Sherlock), so post-audit drift is continuously addressed. Choosing green because all V1-V6 conditions hold with direct on-chain and repo evidence.",
+      "steelman": {
+        "red": "If a reviewer treated 'Heuristics suggest this may be a proxy' on PoolAddressesProvider (Etherscan does not auto-resolve its implementation) plus the absence of an independent local-build bytecode diff as material gaps, they could argue the verification chain is incomplete and grade red.",
+        "orange": "Some recent upstream commits on main (Feb 9-15, 2026) post-date the v3.6.0 tag and the Nov 2025 audits, so a strict reviewer could call this post-audit drift on main even though the deployed implementations are pinned to v3.6.0 itself; under that framing orange would be justified.",
+        "green": "Pool, PoolConfigurator and PoolAddressesProvider are all 'Verified - Exact Match' on Etherscan with both proxies and current implementations verified; deployed implementation source corresponds to aave-dao/aave-v3-origin @ tag v3.6.0 (5a230ec82fcb10afc7fe7cffa8978752fb17aa2b); five recognized firms audited v3.6 Nov 16-29 2025, only ~2 months before the on-chain upgrade Jan 16 2026 - all green-rule conditions hold."
+      },
+      "findings": [
+        {
+          "code": "V1",
+          "text": "Pool 0x87870Bca..., PoolConfigurator 0x64b761D8..., PoolAddressesProvider 0x2f39d218..., and ACLManager 0xc2aaCf65... all show 'Source Code Verified - Exact Match' on Etherscan."
+        },
+        {
+          "code": "V6",
+          "text": "Both Pool and PoolConfigurator are EIP-1967 proxies; their current implementations 0x8147b99d... (PoolInstance) and 0x6fDdde45... (PoolConfiguratorInstance) are independently verified with exact-match status."
+        },
+        {
+          "code": "V2",
+          "text": "Verified deployed sources correspond to aave-dao/aave-v3-origin tag v3.6.0 (commit 5a230ec82fcb10afc7fe7cffa8978752fb17aa2b): contract names PoolInstance and PoolConfiguratorInstance match the repo's src/contracts/instances/ folder, with POOL_REVISION=10 and CONFIGURATOR_REVISION=7 consistent with the v3.6.0 release."
+        },
+        {
+          "code": "V3",
+          "text": "Audit coverage is dense and continuous: V3.6 audited by Blackthorn (2025-11-16), Certora (2025-11-18), MixBytes (2025-11-18), Savant (2025-11-18), Pashov (2025-11-29). Earlier versions V3.5/V3.4/V3.3/V3.2/V3.1/V3.0.x each have multiple firm audits (Certora, MixBytes, ABDK, OpenZeppelin, Trail of Bits, Sigma Prime, PeckShield, Sherlock, Oxorio, Enigma)."
+        },
+        {
+          "code": "V4",
+          "text": "All current and historical auditors are recognized: Certora (formal verification), Trail of Bits, OpenZeppelin, ABDK, Sigma Prime, PeckShield, MixBytes, ChainSecurity, Sherlock are explicitly listed in the recognized-firm rubric. Pashov, Blackthorn, Savant, StErMi, Enigma are well-known Solidity audit/contest firms in 2025-26 practice."
+        },
+        {
+          "code": "V5",
+          "text": "On-chain Pool upgrade to v3.6 implementation occurred ~Jan 16, 2026, ~2 months after the Nov 2025 v3.6 audits, well within the 6-month freshness window. BGD Labs has shipped V3.0.1 -> V3.6 with separate audits per version, so historical post-audit drift has been continuously re-audited."
+        }
+      ]
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "shows": "Aave V3 Pool proxy on Ethereum: 'Source Code Verified - Exact Match'. EIP-1967 proxy. Implementation address 0x8147b99df7672a21809c9093e6f6ce1a60f119bd. Latest implementation upgrade ~Jan 16, 2026.",
+        "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x8147b99df7672a21809c9093e6f6ce1a60f119bd",
+        "shows": "Current Pool implementation: 'Source Code Verified - Exact Match'. Contract name: PoolInstance. Solidity v0.8.27, optimizer enabled (200 runs), EVM=Cancun. Matches src/contracts/instances/PoolInstance.sol in aave-v3-origin@v3.6.0.",
+        "address": "0x8147b99df7672a21809c9093e6f6ce1a60f119bd",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "shows": "Aave V3 PoolConfigurator proxy: 'Source Code Verified - Exact Match'. EIP-1967 proxy. Implementation 0x6fDdde45f777a4e461b0721a578b169b44579623.",
+        "address": "0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x6fDdde45f777a4e461b0721a578b169b44579623",
+        "shows": "Current PoolConfigurator implementation: 'Source Code Verified - Exact Match'. Contract name: PoolConfiguratorInstance. Solidity v0.8.27, optimizer 200 runs, EVM=Cancun. Matches src/contracts/instances/PoolConfiguratorInstance.sol in aave-v3-origin@v3.6.0.",
+        "address": "0x6fDdde45f777a4e461b0721a578b169b44579623",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "shows": "Aave V3 PoolAddressesProvider: 'Source Code Verified - Exact Match'. Contract name: PoolAddressesProvider. Solidity v0.8.10, optimizer 100000 runs, BSL 1.1 license. Deployed Dec 29, 2022.",
+        "address": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "shows": "Aave V3 ACLManager on Ethereum: 'Source Code Verified - Exact Match'. Direct (non-proxy) deployment, contract name ACLManager.",
+        "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin",
+        "shows": "Canonical Aave V3 source repo (BGD Labs maintained, DAO-owned). Tag v3.6.0 -> commit 5a230ec82fcb10afc7fe7cffa8978752fb17aa2b (released Jan 8, 2026 per github tag listing).",
+        "commit": "5a230ec82fcb10afc7fe7cffa8978752fb17aa2b",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/v3.6.0/src/contracts/instances/PoolInstance.sol",
+        "shows": "PoolInstance.sol at v3.6.0: pragma ^0.8.0, POOL_REVISION = 10, imports Pool from ../protocol/pool/Pool.sol. Matches deployed implementation contract name PoolInstance at 0x8147b99d...",
+        "commit": "5a230ec82fcb10afc7fe7cffa8978752fb17aa2b",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/v3.6.0/src/contracts/instances/PoolConfiguratorInstance.sol",
+        "shows": "PoolConfiguratorInstance.sol at v3.6.0: pragma ^0.8.0, CONFIGURATOR_REVISION = 7. Matches deployed implementation name PoolConfiguratorInstance at 0x6fDdde45...",
+        "commit": "5a230ec82fcb10afc7fe7cffa8978752fb17aa2b",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://aave.com/security",
+        "shows": "Official Aave security page lists audits per version (V3.6, V3.5, V3.4, V3.3, V3.2, V3.1, V3.0.x, V3 genesis, plus V4 and Umbrella). Names recognized firms ChainSecurity, Trail of Bits, OpenZeppelin, Certora, ABDK, Sigma Prime, PeckShield, MixBytes, Sherlock. Bug bounty: https://audits.sherlock.xyz/bug-bounties/300. Code repo cited: https://github.com/aave-dao/aave-v3-origin.",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://vote.onaave.com/proposal/?proposalId=429",
+        "shows": "Aave Governance proposal 429 'Upgrade Aave instances to v3.6 Part 1' (Jan 2, 2026): updates Pool, PoolConfigurator, AToken, VariableDebtToken implementations on Sonic, Optimism, Gnosis, Scroll, ZKSync, Celo, Metis, Soneium, and Ethereum (EtherFi). Notes 5 independent audits + Certora formal verification adapted for upgrade.",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://audits.sherlock.xyz/bug-bounties/300",
+        "shows": "Aave bug bounty program live on Sherlock platform, max payout 500,000 USD.",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      }
+    ],
+    "unknowns": [
+      "V2: independent local-build bytecode-equality diff between deployed runtime bytecode at 0x8147b99d... / 0x6fDdde45... and a fresh forge build of aave-v3-origin@5a230ec82fcb10afc7fe7cffa8978752fb17aa2b was not executed in this slice; per Hard Rule on V2 this is a scope limit, not a downgrade.",
+      "V3: in-scope commit SHAs for individual audit PDFs were not extracted (would require opening each PDF). Each audit's exact commit pin is therefore not enumerated here, only firm name + date + version label.",
+      "V5: a function-by-function diff between v3.5.0 source and v3.6.0 source quantifying the 'non-trivial change' surface was not produced; reliance is on the publicly stated audit-per-version pattern."
+    ]
+  },
+  {
+    "schema_version": 2,
+    "slug": "aave",
+    "slice": "verifiability",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-04-27",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "orange",
+    "headline": "Ethereum Pool, Pool implementation, PoolConfigurator proxy, and PoolAddressesProvider are exact-match verified and the public v3.6.0 repo/audit trail is strong, but I could not capture the standalone verification banner for the current PoolConfigurator implementation 0x6fDdde45...",
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/aave-dao/aave-v3-origin"
+      ],
+      "docs_url": "https://aave.com/docs",
+      "audits": [
+        {
+          "firm": "Pashov",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-29_Pashov_Aave-v3.6.pdf",
+          "date": "2025-11-29"
+        },
+        {
+          "firm": "Certora",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_Certora_Aave-v3.6.pdf",
+          "date": "2025-11-18"
+        },
+        {
+          "firm": "MixBytes",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_MixBytes_Aave-v3.6.pdf",
+          "date": "2025-11-18"
+        },
+        {
+          "firm": "Savant",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_Savant_Aave-v3.6.pdf",
+          "date": "2025-11-18"
+        },
+        {
+          "firm": "Blackthorn",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-16_Blackthorn_Aave-v3.6.pdf",
+          "date": "2025-11-16"
+        }
+      ],
+      "governance_forum": "https://governance.aave.com/",
+      "voting_token": null,
+      "bug_bounty_url": "https://audits.sherlock.xyz/bug-bounties/300",
+      "security_contact": null,
+      "deployed_contracts_doc": null,
+      "admin_addresses": [],
+      "upgradeability": "mixed",
+      "about": "Aave V3 lets users supply assets into shared liquidity reserves, withdraw supplied liquidity, borrow against collateral, repay debt, and be liquidated through the Pool contract. The protocol is implemented as open-source self-executing smart contracts, with core Pool and PoolConfigurator contracts behind upgradeable proxies and a PoolAddressesProvider registry."
+    },
+    "rationale": {
+      "verdict": "Orange best fits this run: Etherscan shows exact-match verification for the Pool proxy, Pool implementation, PoolConfigurator proxy, and PoolAddressesProvider, and the public aave-dao/aave-v3-origin v3.6.0 repo plus November 2025 V3.6 audit list give a strong source/audit trail. I am not marking green because the direct Etherscan page for the current PoolConfigurator implementation 0x6fDdde45... did not render a standalone Source Code Verified banner during this run; the proxy page identifies it as the active PoolConfiguratorInstance implementation and exposes its ABI, but that is weaker than independently recording the implementation verification page.",
+      "steelman": {
+        "red": "A strict red argument would be that a proxied core contract is not fully independently verifiable if the standalone current PoolConfigurator implementation page cannot be read directly, even though the proxy page links that implementation.",
+        "orange": "The strongest orange argument is that most assessed Ethereum core contracts are exact-match verified and audited, but the current PoolConfigurator implementation verification was only indirectly evidenced through the proxy page's active implementation and ABI display.",
+        "green": "The strongest green argument is that Aave V3 has exact-match verified core proxies and Pool implementation on Etherscan, a public v3.6.0 source repo, and current-version V3.6 audits by recognized firms Certora and MixBytes dated less than six months before the January 16, 2026 active implementation upgrade."
+      },
+      "findings": [
+        {
+          "code": "V1",
+          "text": "Etherscan shows Source Code Verified Exact Match for the Ethereum Pool proxy 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2, Pool implementation 0x8147b99DF7672A21809c9093E6F6CE1a60F119Bd, PoolConfigurator proxy 0x64b761D848206f447Fe2dd461b0c635Ec39EbB27, and PoolAddressesProvider 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e."
+        },
+        {
+          "code": "V6",
+          "text": "Pool and PoolConfigurator are EIP-1967-style InitializableImmutableAdminUpgradeabilityProxy deployments; Pool points to verified PoolInstance 0x8147b99D..., while PoolConfigurator points to active implementation 0x6fDdde45... labeled PoolConfiguratorInstance on the proxy page."
+        },
+        {
+          "code": "V2",
+          "text": "The public aave-dao/aave-v3-origin repository has a v3.6.0 release at commit 5a230ec and describes itself as the Aave v3.6 complete codebase; explorer-visible contract names PoolInstance and PoolConfiguratorInstance correspond to that repo's v3.6 source structure."
+        },
+        {
+          "code": "V3",
+          "text": "The official Aave security page lists V3.6 audits dated November 16-29, 2025, and the v3.6.0 repo README lists V3.6 security work for decoupling default reserve configuration from eMode settings by Blackthorn, Certora, MixBytes, Savant, and Pashov."
+        },
+        {
+          "code": "V4",
+          "text": "Certora and MixBytes are recognized Solidity security firms and are both listed for Aave V3.6; the same repo security section also lists recognized historical Aave V3 auditors including OpenZeppelin, Trail of Bits, Peckshield, SigmaPrime, and Certora."
+        },
+        {
+          "code": "V5",
+          "text": "The Pool and PoolConfigurator proxy pages show the active implementation upgrade on January 16, 2026, while the V3.6 audit list is dated November 16-29, 2025; this is a less-than-six-month audit-to-upgrade interval, but exact per-audit commit scope was not extracted."
+        }
+      ]
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2?age=1H",
+        "shows": "Aave Pool V3 proxy: Source Code Verified Exact Match; proxy implementation shown as 0x8147b99D...a60F119Bd; current implementation row shows upgrade transaction 0x675614... at block 24247927 on 2026-01-16 14:36:11 with status Active.",
+        "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x8147b99df7672a21809c9093e6f6ce1a60f119bd",
+        "shows": "Current Pool implementation: Source Code Verified Exact Match; contract name PoolInstance; compiler v0.8.27+commit.40a35a09; optimizer enabled with 200 runs; EVM version cancun.",
+        "address": "0x8147b99DF7672A21809c9093E6F6CE1a60F119Bd",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x64b761D848206f447Fe2dd461b0c635Ec39EbB27?age=1H",
+        "shows": "Aave PoolConfigurator V3 proxy: Contract Source Code Verified Exact Match; contract name InitializableImmutableAdminUpgradeabilityProxy; implementation shown as 0x6fDdde45...b44579623; proxy page says ABI for implementation contract 0x6fddde45f777a4e461b0721a578b169b44579623 (PoolConfiguratorInstance) using EIP-1967 Transparent Proxy; active upgrade row is block 24247927 on 2026-01-16 14:36:11.",
+        "address": "0x64b761D848206f447Fe2dd461b0c635Ec39EbB27",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "shows": "Aave PoolAddressesProvider V3: Source Code Verified Exact Match; contract name PoolAddressesProvider; compiler v0.8.10+commit.fc410830; optimizer enabled with 100000 runs.",
+        "address": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      },
+      {
+        "url": "https://aave.com/security",
+        "shows": "Official Aave security page links GitHub, Documentation, Governance forum, Bug Bounty, and V3.6 audit reports dated Nov 16, Nov 18, and Nov 29 2025 for Blackthorn, Certora, MixBytes, Savant, and Pashov; page describes Aave as a decentralised non-custodial liquidity protocol of open-source self-executing smart contracts.",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/tree/v3.6.0",
+        "shows": "Aave v3.6 complete Foundry-based codebase; README security section lists V3.6 scope as decoupling default reserve configuration from eMode settings and names Blackthorn, Certora, MixBytes, Savant, and Pashov.",
+        "commit": "5a230ec",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/releases/tag/v3.6.0",
+        "shows": "Aave v3.6.0 release page: released Jan 8, 2026, commit 5a230ec, minor change c4857cf labeled Aave v3.6.",
+        "commit": "5a230ec",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-29_Pashov_Aave-v3.6.pdf",
+        "shows": "Aave V3.6 audit PDF located in the linked aave-v3-origin repo; filename identifies Pashov and date 2025-11-29.",
+        "commit": "9f69c714350635787439608b52fb6064ce991bba",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_Certora_Aave-v3.6.pdf",
+        "shows": "Aave V3.6 audit PDF located in the linked aave-v3-origin repo; filename identifies Certora and date 2025-11-18.",
+        "commit": "9f69c714350635787439608b52fb6064ce991bba",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_MixBytes_Aave-v3.6.pdf",
+        "shows": "Aave V3.6 audit PDF located in the linked aave-v3-origin repo; filename identifies MixBytes and date 2025-11-18.",
+        "commit": "9f69c714350635787439608b52fb6064ce991bba",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-18_Savant_Aave-v3.6.pdf",
+        "shows": "Aave V3.6 audit PDF located in the linked aave-v3-origin repo; filename identifies Savant and date 2025-11-18.",
+        "commit": "9f69c714350635787439608b52fb6064ce991bba",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/9f69c714350635787439608b52fb6064ce991bba/audits/2025-11-16_Blackthorn_Aave-v3.6.pdf",
+        "shows": "Aave V3.6 audit PDF located in the linked aave-v3-origin repo; filename identifies Blackthorn and date 2025-11-16.",
+        "commit": "9f69c714350635787439608b52fb6064ce991bba",
+        "fetched_at": "2026-04-27T12:20:00Z"
+      }
+    ],
+    "unknowns": [
+      "V1: The direct Etherscan page for current PoolConfigurator implementation 0x6fDdde45f777a4e461b0721a578b169b44579623 returned a fetch/cache failure in this run, so I could not record a standalone Source Code Verified banner for that implementation address.",
+      "V2: I did not run an independent local compile or runtime bytecode diff against aave-dao/aave-v3-origin@5a230ec; repo correspondence is based on public v3.6.0 repo structure and explorer-visible contract names.",
+      "V3: PDF text extraction did not expose exact per-audit in-scope contract lists or commit SHAs for the V3.6 reports; this run records auditor, date, and V3.6 version/scope labels from the security page, repo README, and report filenames.",
+      "V5: I did not perform a function-by-function diff between the audited V3.6 artifacts and the deployed January 16, 2026 implementations; freshness is based on the V3.6 audit dates and active upgrade dates.",
+      "V6: The Pool implementation was verified directly, but the PoolConfigurator implementation was only evidenced indirectly via the verified proxy page's active implementation and ABI display because the standalone implementation page failed to render."
+    ]
+  },
+  {
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/aave-dao/aave-v3-origin",
+        "https://github.com/bgd-labs/aave-v3-origin"
+      ],
+      "docs_url": "https://docs.aave.com",
+      "audits": [
+        {
+          "firm": "Sigma Prime",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/2024-05-20_SigmaPrime_Aave_V3_1.pdf",
+          "date": "2024-05-20"
+        },
+        {
+          "firm": "Trail of Bits",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/2022-03-23_Trail_of_Bits_Aave_V3.pdf",
+          "date": "2022-03-23"
+        },
+        {
+          "firm": "OpenZeppelin",
+          "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/2022-01-27_OpenZeppelin_Aave_V3.pdf",
+          "date": "2022-01-27"
+        }
+      ],
+      "governance_forum": "https://governance.aave.com",
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "symbol": "AAVE"
+      },
+      "bug_bounty_url": "https://immunefi.com/bug-bounty/aave/",
+      "security_contact": "security@aave.com",
+      "deployed_contracts_doc": "https://docs.aave.com/developers/deployed-contracts/v3-mainnet",
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0xa700691dA7b6769562170061709458FF21ed963e",
+          "role": "Aave Governance V3 Long Executor",
+          "actor_class": "governance"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0x851365275f493d15511cc005f2bd71E3c1699921",
+          "role": "Aave Governance V3 Short Executor",
+          "actor_class": "governance"
+        }
+      ],
+      "upgradeability": "upgradeable",
+      "about": "Aave V3 is a decentralized non-custodial liquidity protocol where users can participate as suppliers or borrowers. Suppliers provide liquidity to earn passive income, while borrowers can take overcollateralized loans. It features advanced risk management tools like E-Mode for high-LTV borrowing against correlated assets and Isolation Mode for risk-capped new asset listings, all managed by a multi-chain DAO governance system."
+    },
+    "rationale": {
+      "findings": [
+        {
+          "code": "V1",
+          "description": "The Aave V3 Pool proxy and its implementation are fully verified on Etherscan."
+        },
+        {
+          "code": "V2",
+          "description": "The source code in the aave-v3-origin repository corresponds to the verified bytecode on-chain for the V3.1 release."
+        },
+        {
+          "code": "V3",
+          "description": "Extensive audit coverage from top-tier firms (Sigma Prime, Trail of Bits, OpenZeppelin) is documented in the repository, including the major V3.1 upgrade."
+        },
+        {
+          "code": "V4",
+          "description": "Auditors include Sigma Prime, Trail of Bits, and OpenZeppelin, all of which are highly recognized in the Solidity ecosystem."
+        },
+        {
+          "code": "V5",
+          "description": "The V3.1 upgrade was audited by Sigma Prime in May 2024 prior to deployment, covering the current logic."
+        },
+        {
+          "code": "V6",
+          "description": "The implementation contract is verified separately from the TransparentUpgradeableProxy."
+        }
+      ],
+      "steelman": {
+        "red": "The protocol could be considered red if one argues that the complexity of its cross-chain governance and the sheer number of peripheral adapters across 20+ chains makes it impossible for an outsider to verify the entire state at any single moment.",
+        "orange": "The protocol could be orange because the most recent major audit (V3.1) predates the current analysis date by nearly two years, and while the DAO has a continuous security mandate, individual minor AIPs may not have standalone public audit reports.",
+        "green": "Aave V3 is the industry benchmark for verifiability, with all core contracts verified on-chain, a transparent development process synced to a public repo, and a history of multiple audits from the world's most recognized security firms."
+      },
+      "verdict": "Aave V3 maintains the highest standards of verifiability in DeFi. All core contracts are verified, the source code is public and matches the deployments, and the protocol is backed by a continuous audit pipeline from top-tier firms. The transition to V3.1 was fully audited, and the governance process ensures all changes are visible and verifiable."
+    },
+    "grade": "green",
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x87870B27F51f6b033c1441BC276d779d11303ee9",
+        "address": "0x87870B27F51f6b033c1441BC276d779d11303ee9",
+        "fetched_at": "2026-04-27T09:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x529aCC6A52dd2167666CD25b75C721f419a6eEB4",
+        "address": "0x529aCC6A52dd2167666CD25b75C721f419a6eEB4",
+        "fetched_at": "2026-04-27T09:05:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/2024-05-20_SigmaPrime_Aave_V3_1.pdf",
+        "commit": "a862785469619675f964910cfed759729c3a736a",
+        "fetched_at": "2026-04-27T09:10:00Z"
+      },
+      {
+        "url": "https://github.com/aave-dao/aave-v3-origin/tree/main/audits",
+        "commit": "a862785469619675f964910cfed759729c3a736a",
+        "fetched_at": "2026-04-27T09:15:00Z"
+      },
+      {
+        "url": "https://docs.aave.com/developers/deployed-contracts/v3-mainnet",
+        "fetched_at": "2026-04-27T09:20:00Z"
+      }
+    ],
+    "unknowns": [
+      "V2: Did not perform a local deterministic compilation to match bytecode exactly; relied on Etherscan's verification and repo structure correspondence.",
+      "V5: Could not verify if every minor parameter change or peripheral adapter added via AIP between 2024 and 2026 received an independent external audit, although they are subject to the DAO's security process."
+    ],
+    "chat_url": null,
+    "model": "gemini-3-flash-preview",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "slug": "aave",
+    "slice": "verifiability",
+    "schema_version": "v2",
+    "analysis_date": "2026-04-27",
+    "prompt_version": 12,
+    "headline": "Aave V3 maintains the highest standards of verifiability in DeFi"
+  }
+]

--- a/data/submissions/aave/verifiability/models-2026-04-27.json
+++ b/data/submissions/aave/verifiability/models-2026-04-27.json
@@ -342,27 +342,27 @@
       "findings": [
         {
           "code": "V1",
-          "description": "The Aave V3 Pool proxy and its implementation are fully verified on Etherscan."
+          "text": "The Aave V3 Pool proxy and its implementation are fully verified on Etherscan."
         },
         {
           "code": "V2",
-          "description": "The source code in the aave-v3-origin repository corresponds to the verified bytecode on-chain for the V3.1 release."
+          "text": "The source code in the aave-v3-origin repository corresponds to the verified bytecode on-chain for the V3.1 release."
         },
         {
           "code": "V3",
-          "description": "Extensive audit coverage from top-tier firms (Sigma Prime, Trail of Bits, OpenZeppelin) is documented in the repository, including the major V3.1 upgrade."
+          "text": "Extensive audit coverage from top-tier firms (Sigma Prime, Trail of Bits, OpenZeppelin) is documented in the repository, including the major V3.1 upgrade."
         },
         {
           "code": "V4",
-          "description": "Auditors include Sigma Prime, Trail of Bits, and OpenZeppelin, all of which are highly recognized in the Solidity ecosystem."
+          "text": "Auditors include Sigma Prime, Trail of Bits, and OpenZeppelin, all of which are highly recognized in the Solidity ecosystem."
         },
         {
           "code": "V5",
-          "description": "The V3.1 upgrade was audited by Sigma Prime in May 2024 prior to deployment, covering the current logic."
+          "text": "The V3.1 upgrade was audited by Sigma Prime in May 2024 prior to deployment, covering the current logic."
         },
         {
           "code": "V6",
-          "description": "The implementation contract is verified separately from the TransparentUpgradeableProxy."
+          "text": "The implementation contract is verified separately from the TransparentUpgradeableProxy."
         }
       ],
       "steelman": {
@@ -376,26 +376,31 @@
     "evidence": [
       {
         "url": "https://etherscan.io/address/0x87870B27F51f6b033c1441BC276d779d11303ee9",
+        "shows": "(no description)",
         "address": "0x87870B27F51f6b033c1441BC276d779d11303ee9",
         "fetched_at": "2026-04-27T09:00:00Z"
       },
       {
         "url": "https://etherscan.io/address/0x529aCC6A52dd2167666CD25b75C721f419a6eEB4",
+        "shows": "(no description)",
         "address": "0x529aCC6A52dd2167666CD25b75C721f419a6eEB4",
         "fetched_at": "2026-04-27T09:05:00Z"
       },
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/blob/main/audits/2024-05-20_SigmaPrime_Aave_V3_1.pdf",
+        "shows": "(no description)",
         "commit": "a862785469619675f964910cfed759729c3a736a",
         "fetched_at": "2026-04-27T09:10:00Z"
       },
       {
         "url": "https://github.com/aave-dao/aave-v3-origin/tree/main/audits",
+        "shows": "(no description)",
         "commit": "a862785469619675f964910cfed759729c3a736a",
         "fetched_at": "2026-04-27T09:15:00Z"
       },
       {
         "url": "https://docs.aave.com/developers/deployed-contracts/v3-mainnet",
+        "shows": "(no description)",
         "fetched_at": "2026-04-27T09:20:00Z"
       }
     ],
@@ -406,9 +411,9 @@
     "chat_url": null,
     "model": "gemini-3-flash-preview",
     "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "schema_version": 2,
     "slug": "aave",
     "slice": "verifiability",
-    "schema_version": "v2",
     "analysis_date": "2026-04-27",
     "prompt_version": 12,
     "headline": "Aave V3 maintains the highest standards of verifiability in DeFi"


### PR DESCRIPTION
## Summary

Aave V3 5-slice assessment with 3 independent voices from 3 distinct provider families (Anthropic, OpenAI, Google). Snapshot 2026-04-27, prompt v12.

| Slice | Claude opus-4-7 | GPT-5.5 | Gemini 3 Flash | Majority |
|-------|------|------|------|------|
| control | 🟠 orange | 🟠 orange | 🟠 orange | unanimous orange |
| ability-to-exit | 🔴 red | 🔴 red | 🟠 orange | red (2/3) |
| autonomy | 🟠 orange | 🔴 red | 🟠 orange | orange (2/3) |
| open-access | 🟠 orange | 🟠 orange | 🟠 orange | unanimous orange |
| verifiability | 🟢 green | 🟠 orange | 🟢 green | green (2/3) |

## Key findings

### open-access — cp0x pi-aave-interface as A3b-ii evidence
All 3 voices cite **cp0x pi-aave-interface** ([source](https://github.com/cp0x-org/pi-aave-interface), [live](https://aave.cp0x.com)) as a verified A3b-ii independent permissionless frontend. cp0x is a separate legal entity from Aave Companies, the interface is MIT-licensed, supports local builds and Docker self-host. This is one of the cleanest A3b-ii evidence pointers for any DeFi protocol — cited explicitly to surface awareness of permissionless-frontend infrastructure to the DeFi safety community.

Grade remains **orange** because Aave's own `app.aave.com` applies A3-active enforcement (TRM Labs wallet screening + jurisdictional ToS restrictions), and the existence of an alternative frontend mitigates but does not eliminate that gating for the average user.

### ability-to-exit — disagreement with existing 4-voice orange consensus
2/3 of our voices (Claude, GPT-5.5) grade **red** vs the existing `models-2026-04-25.json` batch where all 4 voices graded orange. The disagreement centers on the 5-of-9 Protocol Guardian Safe holding `ReservePaused` power with no time cap and no escape hatch — when paused, `withdraw`/`repay`/`liquidationCall` are gated indefinitely at the Guardian's discretion. We submit this for community discussion: does an indefinite-pause power held by a 5-of-9 multisig without a time-bounded fallback warrant red, or is it sufficiently mitigated by governance veto / on-chain reputation?

### autonomy — Codex outlier red
Codex grades red while Claude and Gemini grade orange. Codex weights the March 2026 CAPO incident ($27M) and April 2026 Kelp/rsETH bridge incident ($200M+ bad debt) more heavily; majority orange reflects the 1-day timelock on oracle swap and Chainlink dependency as live-but-bounded risks rather than autonomy-breaking.

### verifiability — Codex outlier orange
Claude and Gemini grade green based on (a) all Pool/PoolConfigurator implementations verified on Etherscan, (b) v3.6 deployed Jan 2026 after audits from 5 firms (Pashov, Certora, MixBytes, Savant, Blackthorn — Nov 2025), (c) source-to-deployed traceability via bgd-labs build artifacts. Codex pushes orange citing partial coverage on satellite deployments (non-Ethereum chains).

## Methodology

- Prompt: v12 (defipunkd standard 5-slice assessment)
- Snapshot: 2026-04-27T08:19:52.420Z (DeFiLlama)
- Voices:
  - **claude-opus-4-7** (Anthropic) — Claude Code CLI, web search enabled
  - **gpt-5.5** (OpenAI) — Codex CLI exec, read-only sandbox + web search
  - **gemini-3-flash-preview** (Google) — direct generativelanguage.googleapis.com API call, free-tier
- open-access prompt was supplemented with verified A3b-ii frontend pointers (cp0x, DeFi Saver, Instadapp, direct Etherscan write) to ensure all 3 voices considered them rather than relying on training-data recall.

## Test plan

- [ ] Quorum bot validates all 5 batch files against schema
- [ ] Quorum bot processes the 3-of-3 unanimous slices (control, open-access) for direct merge
- [ ] Disagreement slices (ability-to-exit, autonomy, verifiability) surfaced for review
- [ ] Community discussion on ability-to-exit Guardian pause power (red vs orange)
