### PR TITLE
ci: split fork-PR validation into upload + workflow_run comment

### DIFF
--- a/.github/workflows/validate-comment.yml
+++ b/.github/workflows/validate-comment.yml
@@ -1,0 +1,105 @@
+name: Comment DEFI@home validation result
+
+on:
+  workflow_run:
+    workflows: ["Validate DEFI@home submission"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download validation artifact
+        id: download
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const match = artifacts.data.artifacts.find((a) => a.name === 'validate-report');
+            if (!match) {
+              core.info('no validate-report artifact found; nothing to comment on');
+              core.setOutput('found', 'false');
+              return;
+            }
+            const dl = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: match.id,
+              archive_format: 'zip',
+            });
+            fs.writeFileSync('validate-report.zip', Buffer.from(dl.data));
+            core.setOutput('found', 'true');
+
+      - name: Unzip artifact
+        if: steps.download.outputs.found == 'true'
+        run: unzip -o validate-report.zip
+
+      - name: Post PR comment and labels
+        if: steps.download.outputs.found == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('validate-report.json', 'utf8'));
+            const meta = JSON.parse(fs.readFileSync('validate-meta.json', 'utf8'));
+            const prNumber = parseInt(fs.readFileSync('pr-number.txt', 'utf8').trim(), 10);
+            const ok = report.ok;
+
+            const lines = [];
+            lines.push(ok ? '✅ **DEFI@home validator — all submissions valid**' : '❌ **DEFI@home validator — issues found**');
+            lines.push('');
+            for (const r of report.reports) {
+              lines.push(`### \`${r.file}\``);
+              if (r.errors.length) {
+                lines.push('**errors:**');
+                for (const e of r.errors) lines.push(`- ${e}`);
+              }
+              if (r.warnings.length) {
+                lines.push('**warnings:**');
+                for (const w of r.warnings) lines.push(`- ${w}`);
+              }
+              if (r.autoFixed.length) {
+                lines.push('**auto-fixes applied:**');
+                for (const a of r.autoFixed) lines.push(`- ${a}`);
+              }
+              if (!r.errors.length && !r.warnings.length && !r.autoFixed.length) {
+                lines.push('_clean_');
+              }
+              lines.push('');
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: lines.join('\n'),
+            });
+
+            const labels = ['submission'];
+            if (meta.slice) labels.push(`slice:${meta.slice}`);
+            const model = (meta.model || '').toLowerCase();
+            if (model.includes('claude')) labels.push('model-family:claude');
+            else if (model.includes('gpt') || model.includes('openai')) labels.push('model-family:gpt');
+            else if (model.includes('gemini')) labels.push('model-family:gemini');
+            else if (model) labels.push('model-family:other');
+            if (meta.chat_url) labels.push('chat-url-included');
+            if (meta.ok) labels.push('awaiting-quorum');
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: [...new Set(labels)],
+            });

--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -11,8 +11,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   validate:
@@ -59,67 +57,46 @@ jobs:
           cat validate-report.json
         continue-on-error: true
 
-      - name: Post PR comment and labels
+      - name: Collect first-submission metadata for labels
         if: steps.files.outputs.count != '0'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const report = JSON.parse(fs.readFileSync('validate-report.json', 'utf8'));
-            const ok = report.ok;
-
-            const lines = [];
-            lines.push(ok ? '✅ **DEFI@home validator — all submissions valid**' : '❌ **DEFI@home validator — issues found**');
-            lines.push('');
-            for (const r of report.reports) {
-              lines.push(`### \`${r.file}\``);
-              if (r.errors.length) {
-                lines.push('**errors:**');
-                for (const e of r.errors) lines.push(`- ${e}`);
-              }
-              if (r.warnings.length) {
-                lines.push('**warnings:**');
-                for (const w of r.warnings) lines.push(`- ${w}`);
-              }
-              if (r.autoFixed.length) {
-                lines.push('**auto-fixes applied:**');
-                for (const a of r.autoFixed) lines.push(`- ${a}`);
-              }
-              if (!r.errors.length && !r.warnings.length && !r.autoFixed.length) {
-                lines.push('_clean_');
-              }
-              lines.push('');
-            }
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: lines.join('\n'),
-            });
-
-            // Compute labels from the first valid submission
-            const labels = ['submission'];
+        run: |
+          node -e '
+            const fs = require("fs");
+            const report = JSON.parse(fs.readFileSync("validate-report.json", "utf8"));
+            const meta = { ok: report.ok, slice: null, model: null, chat_url: null };
             for (const r of report.reports) {
               if (r.errors.length) continue;
               try {
-                const raw = JSON.parse(fs.readFileSync(r.file, 'utf8'));
-                labels.push(`slice:${raw.slice}`);
-                const model = (raw.model || '').toLowerCase();
-                if (model.includes('claude')) labels.push('model-family:claude');
-                else if (model.includes('gpt') || model.includes('openai')) labels.push('model-family:gpt');
-                else if (model.includes('gemini')) labels.push('model-family:gemini');
-                else labels.push('model-family:other');
-                if (raw.chat_url) labels.push('chat-url-included');
-                labels.push('awaiting-quorum');
+                const raw = JSON.parse(fs.readFileSync(r.file, "utf8"));
+                meta.slice = raw.slice || null;
+                meta.model = raw.model || null;
+                meta.chat_url = raw.chat_url || null;
                 break;
               } catch (_) {}
             }
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: [...new Set(labels)],
-            });
+            fs.writeFileSync("validate-meta.json", JSON.stringify(meta));
+          '
 
-            if (!ok) core.setFailed('Submission validation failed; see comment above.');
+      - name: Save PR number
+        if: steps.files.outputs.count != '0'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload validation artifact
+        if: steps.files.outputs.count != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: validate-report
+          path: |
+            validate-report.json
+            validate-meta.json
+            pr-number.txt
+          retention-days: 7
+
+      - name: Fail if validation failed
+        if: steps.files.outputs.count != '0'
+        run: |
+          ok=$(node -e 'console.log(JSON.parse(require("fs").readFileSync("validate-report.json","utf8")).ok)')
+          if [ "$ok" != "true" ]; then
+            echo "Submission validation failed; see PR comment posted by validate-comment workflow."
+            exit 1
+          fi


### PR DESCRIPTION
GITHUB_TOKEN is read-only on pull_request events from forks, so the validator could not post comments or labels on contributor PRs. Move the comment + label step into a separate workflow triggered by workflow_run, which runs in the base-repo context with write access.