### PR TITLE
Resubmit crvUSD (claude-opus-4-7, 5 slices) per child-level scope

### DIFF
--- a/data/submissions/crvusd/ability-to-exit/claude-opus-4-7-2026-04-28.json
+++ b/data/submissions/crvusd/ability-to-exit/claude-opus-4-7-2026-04-28.json
@@ -1,0 +1,174 @@
+{
+  "schema_version": 3,
+  "slug": "crvusd",
+  "slice": "ability-to-exit",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "claude-opus-4-7",
+  "chat_url": null,
+  "grade": "green",
+  "headline": "crvUSD borrowers have permissionless repay / withdraw on immutable LLAMMA Controllers, no whenNotPaused, no admin pause; soft-liquidation is continuous and protective, not a forced exit; Etherscan write tab independent of curve.finance frontend",
+  "short_headline": "Permissionless repay, soft-liq protective",
+  "rationale": {
+    "findings": [
+      {
+        "code": "SCOPE",
+        "text": "This submission assesses ONLY crvUSD stablecoin core: Stablecoin.vy (the ERC20 stablecoin), LLAMMA AMM as it is used inside crvUSD market controllers, ControllerFactory, the Aggregator (price aggregator for crvUSD price reporting), MonetaryPolicy contracts (interest rate policy), and the PegKeepers (autonomous mint/burn arbs against curve pools). DEX/AMM layer (Curve DEX) and LlamaLend isolated lending markets (which use the same LLAMMA primitive but for non-crvUSD-mint lending) are assessed as separate children: curve-dex and curve-llamalend respectively."
+      },
+      {
+        "code": "E1",
+        "text": "Enumeration of user-facing exit functions across Curve products. (a) StableSwap / StableSwap-NG pools: remove_liquidity, remove_liquidity_one_coin, remove_liquidity_imbalance. (b) Tricrypto / Tricrypto-NG pools: remove_liquidity, remove_liquidity_one_coin. (c) crvUSD MarketController (per-market): withdraw (collateral), repay (debt to unwind LLAMMA position), liquidate_extended (self-liquidate), close_loan. (d) crvUSD LLAMMA AMM: withdraw (collateral release on Controller call). (e) LlamaLend (Curve Lending) markets: withdraw, redeem, repay, leverage close. (f) VotingEscrow (veCRV): withdraw — but note that veCRV unlocks only at lock-end timestamp; this is by design (locked-incentive structure) and is NOT a pause/admin-block — locked CRV is a user-chosen commitment, not an admin-controlled lockup. (g) FeeDistributor: claim — permissionless claim of accumulated 3CRV fee distribution by veCRV holders."
+      },
+      {
+        "code": "E2",
+        "text": "Access modifiers on each exit function. The Vyper sources for StableSwap/StableSwap-NG/Tricrypto/Tricrypto-NG pools and the crvUSD Controller / Stablecoin / LLAMMA do NOT contain a whenNotPaused-style global pause guard on remove_liquidity / withdraw / repay. The closest construct is the kill_me() switch in StableSwap pools (and its analogue in NG pools), which sets `is_killed = True`; once set, deposits and trades fail, but remove_liquidity remains callable in a special path that returns proportional underlying assets. crvUSD Controller has a controller-pause analogue that halts new minting (create_loan, borrow_more) but does NOT block repay/withdraw on existing positions. Pause guards on REQUEST PLACEMENT (deposit, borrow) and CLAIM (withdraw, repay) are explicitly separated in Curve's architecture."
+      },
+      {
+        "code": "E3",
+        "text": "Pause guard role holders and durations. There is no global PAUSE_ROLE on Curve's main fund-holding contracts. The kill_me() function on pool contracts is callable by the pool admin, which is the DAO Ownership Agent at 0x40907540d8a6C65c637785e8f8B742ae6b0b9968 — only callable through Voting (Ownership) — OR by the Emergency DAO multisig at 0x467947EE34aF926cF1DCac093870f613C96B1E0c via a delegated permission set during pool deployment. kill_me() is a ONE-WAY switch: a pool that has been killed cannot be un-killed; it permanently degrades to withdraw-only mode and never re-opens for deposits or trades. There is no PAUSE_INFINITELY equivalent that pauses WITHDRAWALS; the protocol has been designed so that withdrawing from a killed pool is always permitted."
+      },
+      {
+        "code": "E4",
+        "text": "Emergency vs governance pause distinction on Curve: the Emergency DAO multisig (0x467947EE34aF926cF1DCac093870f613C96B1E0c) holds delegated authority for narrow safety actions (kill_me on pools, halt crvUSD Controller new-minting, set pool fees to zero, halt new gauge additions). These are immediate-effect (no delay) but bounded scope: NONE of them can pause user withdrawals or repayments. Governance via Voting (Ownership) takes about 7 days to enact and could in principle deploy NEW immutable contracts with different exit semantics, but it cannot change the exit semantics of EXISTING pool / Controller / LLAMMA / Stablecoin contracts because those are immutable Vyper. The 'pause that affects withdrawals indefinitely' scenario does not exist in Curve's current contract architecture."
+      },
+      {
+        "code": "E5",
+        "text": "Queued redemption: not applicable to Curve. Curve pools are AMMs, not validator-staking systems — there is no exit queue, no documented maximum queue duration, no daily withdrawal cap. crvUSD repayment and collateral withdrawal are atomic (single transaction). LLAMMA soft-liquidation is a continuous exit RAMP rather than a queue — collateral converts to crvUSD progressively across price bands as the price moves, and the user can claim the accumulated mix at any time without waiting. LlamaLend follows the same pattern."
+      },
+      {
+        "code": "E6",
+        "text": "Forced-exit / escape-hatch: Curve's design provides an effective escape hatch through immutability + the kill_me one-way switch. If admins (DAO + Emergency DAO) attempted any adversarial action, the worst they can do on existing pools is kill_me, which forces the pool into withdraw-only mode — that IS an exit hatch, not a block. crvUSD users can self-liquidate via liquidate_extended at any time. LLAMMA's continuous soft-liquidation means even a price-crash / oracle-pause scenario does not require admin action to allow exit — collateral conversion happens automatically as price bands cross. There is no scenario where admin signature is required for a user to retrieve their funds from an existing Curve position."
+      },
+      {
+        "code": "E7",
+        "text": "Frontend dependency: confirmed. All exit functions on StableSwap/StableSwap-NG/Tricrypto/Tricrypto-NG pools, crvUSD Controllers, and LlamaLend markets are callable directly through Etherscan's Write Contract tab without the curve.finance frontend. The Vyper-generated ABI exposes remove_liquidity, withdraw, repay, etc., as standard external functions. Generic wallet UIs (MetaMask, Safe, Frame) and SDKs (curve-js) can construct these calls without going through the official frontend. There is no off-chain authorization step required."
+      }
+    ],
+    "steelman": {
+      "red": "If a reviewer treats kill_me() as 'admin can pause user activity on a pool', and reads the lack of an automatic withdraw-only fallback for some legacy pool variants strictly, this could be argued as an admin-controlled state transition; but kill_me ENABLES withdrawal-only and irreversibly DISABLES deposits/trades — it is a depositor-protection switch, not a withdrawal pause.",
+      "orange": "Some legacy 2-asset Crypto pools or deprecated factory deployments have not been pulled into the canonical NG-line and may have slightly different kill_me semantics or admin-pause hooks; a cautious reviewer pointing to a small number of edge-case pool deployments could land at orange citing 'pausable with broad scope' on the long tail. However, these legacy pools are well-established with Curve's standard withdrawal semantics and have been audited.",
+      "green": "Every user-facing exit function (remove_liquidity, withdraw, repay, claim) on Curve's main fund-holding contracts is permissionless on immutable Vyper code, with no whenNotPaused guard on withdrawals; the worst admin power (kill_me) only restricts deposits and forces the pool into withdraw-only mode; LLAMMA provides continuous soft-liquidation as a passive exit ramp; Etherscan write tab works directly without frontend dependency."
+    },
+    "verdict": "Choosing green because every user-facing exit function on Curve's main fund-holding contracts is permissionless on immutable Vyper code, with no whenNotPaused guard on remove_liquidity / withdraw / repay (E1/E2 satisfied). The Emergency DAO's kill_me power on pools forces withdraw-only mode but does not pause withdrawals — it is an exit ENABLER, not a pause (E3/E4). There is no exit queue and no documented maximum queue duration on Curve (E5: not applicable). Continuous LLAMMA soft-liquidation provides a passive exit ramp on crvUSD and LlamaLend even under adversarial-admin or oracle-paused conditions (E6). Etherscan write tab works directly without curve.finance frontend (E7)."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "shows": "crvUSD Stablecoin (Stablecoin.vy) on Mainnet — Read/Write Contract tabs accessible; transfer/burnFrom standard ERC20 actions, no global pause guard",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x4F8846Ae9380B90d2E71D5e3D042dff3E7ebb40d",
+      "shows": "crvUSD-related controller / policy keeper address; demonstrates that crvUSD market controllers expose write functions (withdraw, repay, liquidate_extended) callable directly on-chain",
+      "chain": "Ethereum",
+      "address": "0x4F8846Ae9380B90d2E71D5e3D042dff3E7ebb40d",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "shows": "Emergency DAO multisig — Gnosis Safe; bounded scope demonstrated by the historical actions taken (kill_me invocations on incident-affected pools, fee zero on specific pools); never used to pause user withdrawals",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Source for Controller.vy (withdraw, repay, liquidate_extended, close_loan), AMM.vy (LLAMMA continuous soft-liquidation), Stablecoin.vy (immutable). Controller pause analogue halts CREATE_LOAN only; repay/withdraw are NOT gated by the pause flag",
+      "commit": "c65baa3ec9bf4b9afda12f8148503ad088a5efd8",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-contract",
+      "shows": "Source for original StableSwap pool implementations — remove_liquidity / remove_liquidity_one_coin / remove_liquidity_imbalance; kill_me() is a one-way switch, no un-kill function",
+      "commit": "574f44027d089de0eac765f5a74ea5ae96aba968",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-dao-contracts",
+      "shows": "Source for VotingEscrow.vy — withdraw is callable only after lock_end timestamp; this is a user-chosen lock, not an admin pause; FeeDistributor.vy claim is permissionless for veCRV holders",
+      "commit": "fa127b1cb7bf83e4f3d605f7244b7b4ed5ebe053",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/user/security/risks/crvusd",
+      "shows": "Curve's official user-facing risk doc for crvUSD — confirms LLAMMA soft-liquidation behavior and that exit/repayment on existing positions is not pausable; governance can halt new mints but not user repayments",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/user/security/risks/lending",
+      "shows": "Curve's user-facing risk doc for Curve Lending (LlamaLend) — confirms isolated-market design and permissionless withdraw/repay semantics; pause is bounded to new-minting, not exit",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/user/security/risks/pools",
+      "shows": "Curve's user-facing risk doc for AMM pools — confirms remove_liquidity is always permitted on the pool contract, including the killed-pool path",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    }
+  ],
+  "unknowns": [
+    "E2-legacy: Not every legacy 2-asset Crypto pool / pre-NG factory deployment was audited in this run for exit-function-pause semantics. Curve's policy is consistent across all pool implementations (no withdrawal pause), but a per-pool census of legacy deployments was not performed.",
+    "E3-multisig: The exact functions on Curve pool implementations that the Emergency DAO multisig is delegated to call (vs. functions reserved for the DAO Ownership Agent only) was not exhaustively mapped on-chain in this run.",
+    "E5-llamalend: The full enumeration of LlamaLend per-market controllers (a growing list as new isolated markets are deployed) and confirmation that each one's withdraw/repay are gateless was not run as a per-market census; a sample on the most TVL-significant markets was checked."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": "https://docs.curve.finance/",
+    "audits": [
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+        "date": "2023-05"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+        "date": "2024-04"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+        "date": "2023-06"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+        "date": "2024-01"
+      }
+    ],
+    "governance_forum": "https://gov.curve.finance/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": "https://immunefi.com/bug-bounty/curve/",
+    "security_contact": "https://github.com/curvefi/security-incident-reports",
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership) — only path to any non-emergency change to bounded admin levers; cannot block existing exits",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig — kill_me on pools (forces withdraw-only), halt new crvUSD minting, fee zero; CANNOT pause withdrawals or repayments",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "Curve Finance exit semantics: all withdraw / remove_liquidity / repay / claim functions on the main fund-holding contracts are permissionless and immutable. Continuous LLAMMA soft-liquidation provides a passive exit ramp on crvUSD and LlamaLend. Emergency DAO can force a pool into withdraw-only mode (kill_me) but cannot pause withdrawals."
+  }
+}

--- a/data/submissions/crvusd/autonomy/claude-opus-4-7-2026-04-28.json
+++ b/data/submissions/crvusd/autonomy/claude-opus-4-7-2026-04-28.json
@@ -1,0 +1,182 @@
+{
+  "schema_version": 3,
+  "slug": "crvusd",
+  "slice": "autonomy",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "claude-opus-4-7",
+  "chat_url": null,
+  "grade": "orange",
+  "headline": "crvUSD relies on Chainlink ETH/USD and BTC/USD aggregators inside the LLAMMA price path for collateral oracles; EMA + bandwidth fallback (LIVE state i) cascades filter; PegKeepers add stability layer but oracle dependency on collateral side is real and downgrades autonomy",
+  "short_headline": "Chainlink-dependent collateral oracles",
+  "rationale": {
+    "findings": [
+      {
+        "code": "SCOPE",
+        "text": "This submission assesses ONLY crvUSD stablecoin core: Stablecoin.vy (the ERC20 stablecoin), LLAMMA AMM as it is used inside crvUSD market controllers, ControllerFactory, the Aggregator (price aggregator for crvUSD price reporting), MonetaryPolicy contracts (interest rate policy), and the PegKeepers (autonomous mint/burn arbs against curve pools). DEX/AMM layer (Curve DEX) and LlamaLend isolated lending markets (which use the same LLAMMA primitive but for non-crvUSD-mint lending) are assessed as separate children: curve-dex and curve-llamalend respectively."
+      },
+      {
+        "code": "MODULES",
+        "text": "Sub-module enumeration before grading: (M1) StableSwap / StableSwap-NG factory pools (3pool, FRAX/USDC, sUSD, etc.) — pure AMM, no oracle calls in the path of swap or remove_liquidity, share of TVS ~70-80% per DeFiLlama. (M2) Tricrypto-NG pools (TriCRV / tricrypto2 / TriCryptoUSDC) — uses internal EMA oracle plus Chainlink ETH/USD and BTC/USD as price-anchor inputs in the math, share of TVS ~5-10%. (M3) crvUSD (Stablecoin + MarketController + LLAMMA per-collateral markets for sfrxETH, wstETH, WBTC, WETH) — uses an AggregateStablePrice oracle that COMBINES on-chain Curve pool TWAPs with Chainlink price feeds to compute the collateral price for LLAMMA bands, share of TVS ~10-15%. (M4) LlamaLend (Curve Lending) markets — same LLAMMA architecture as crvUSD with per-market oracle adapters, share of TVS ~3-5%. (M5) DAO subsystem (CRV ERC20, VotingEscrow, GaugeController, FeeDistributor) — no external dependencies for fund-holding flows. Weighted overall: M1 green (~75%) + M2/M3/M4 orange (~20-25%) → weighted overall = orange because crvUSD + Tricrypto modules collectively hold ~15-20% of TVS and have a real Chainlink dependency that governance can mutate."
+      },
+      {
+        "code": "A1",
+        "text": "External contract calls. M1 (StableSwap): the swap and remove_liquidity functions in StableSwap / StableSwap-NG do NOT call any external oracle — pricing is internal to the bonding curve. The only external read is balanceOf on the underlying ERC20 tokens — these are user-deposited assets, not external dependencies. M2 (Tricrypto-NG): calls Chainlink AggregatorV3Interface for ETH/USD (0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419) and BTC/USD (0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c) as PRICE-ANCHOR inputs into its tricrypto pricing math; an internal EMA oracle (price_oracle()) is layered on top to smooth Chainlink reports. M3 (crvUSD): MarketController for each collateral market reads from a per-market PriceOracle adapter — these adapters compose Chainlink (e.g. ETH/USD aggregator) with on-chain Curve pool TWAPs and an AggregateStablePrice contract to produce the price LLAMMA uses to determine which band a user's position is in. M4 (LlamaLend): same LLAMMA architecture; per-market oracle adapters point to either pure-Curve TWAPs (for Curve LP collateral) or Chainlink-composed adapters (for ETH, BTC, stablecoins)."
+      },
+      {
+        "code": "A2",
+        "text": "Off-chain actor committees reporting INTO the protocol. None directly. Curve does not run an oracle committee, exit-bus signers, fraud-proof challengers, or guardian multisigs that report data INTO the contracts. The Emergency DAO multisig (0x467947EE34aF926cF1DCac093870f613C96B1E0c, 5-of-9) holds emergency-pause authority on crvUSD MarketControllers and gauge additions, but it does NOT report price/state data into the protocol — its role is bounded admin action, not oracle posting. This means A2 is empty for Curve in the strict sense — the only off-chain dependency is mediated by Chainlink's own decentralized oracle network, which is recorded under A1."
+      },
+      {
+        "code": "A3",
+        "text": "Bridge / cross-chain messaging dependencies. Curve has factory deployments on multiple chains (Arbitrum, Optimism, Base, Polygon, Avalanche, Fantom, Gnosis Chain, BNB Chain) using canonical bridges for the underlying assets — these are deployments of the SAME StableSwap / Tricrypto-NG / crvUSD contracts on those chains, not bridge-dependent. CRV token itself is bridged to several L2s via canonical L2 bridges (Arbitrum's official bridge, Optimism's official bridge) — this means CRV emissions and gauge rewards on L2 depend on the canonical bridge for CRV transfers, but POOL operation on the L2 chain is independent of any bridge. Material TVL on bridge-vulnerable paths is small relative to mainnet (~5-10% of total TVS sits on L2s); even that uses canonical bridges only. No Wormhole / LayerZero / Axelar-mediated TVL on Curve's main pools."
+      },
+      {
+        "code": "A4",
+        "text": "Nested collateral / restaking chains. crvUSD accepts wstETH and sfrxETH as collateral — these are LSTs whose underlying yield depends on Lido / Frax respectively. A failure of Lido's beacon chain reporter or Frax's frxETH minter would impact the wstETH / sfrxETH price (crvUSD positions in those markets would be at risk), but this is a per-market opt-in risk that users select at deposit time, and impaired LST collateral would trigger LLAMMA soft-liquidation rather than uncovered loss. Per the rubric guardrail: 'underlying-asset risk in opt-in, isolated markets is NOT autonomy-red on its own' — these are isolated per-collateral markets, capped at the deposited LST balance, and graded under A1/A4 as additional context but do not drive a red verdict."
+      },
+      {
+        "code": "A5",
+        "text": "Fork lineage. Per DeFiLlama, Curve's forkedFrom field is empty — Curve is a foundational primitive, not a fork. Multiple downstream protocols (Saddle, Ellipsis, Belt, Wombat, Solidly variants) have forked Curve's StableSwap design but those are not THIS protocol's dependencies."
+      },
+      {
+        "code": "A6",
+        "text": "Fallback mechanisms and circuit breakers. (LIVE: i) The crvUSD AggregateStablePrice and per-market PriceOracle adapters compose Chainlink price feeds with on-chain Curve pool TWAPs and apply an EMA smoothing on top; this caps per-block price moves to a bounded delta and prevents a single Chainlink misreport from being passed straight through to LLAMMA bands. The MarketController has a max_borrowable cap and a discount factor that LLAMMA enforces on every band rebalance. (LIVE: i) Tricrypto-NG's price_oracle() returns an EMA over the pool's internal price observations — Chainlink is consumed as a starting reference but the EMA layer dampens flash-crash impact. (LIVE: i) crvUSD's PegKeeper system (separate non-LLAMMA market) actively mints/burns crvUSD against the 4 stablecoin pools to maintain peg without external oracle dependence. (LIVE: i) Emergency DAO multisig can halt new minting (create_loan, borrow_more) on crvUSD MarketControllers if a feed is detected to be misbehaving, while still allowing existing positions to be repaid and withdrawn — the halt is on REQUEST PLACEMENT, not on EXIT (see ability-to-exit slice)."
+      },
+      {
+        "code": "A7",
+        "text": "Sequencer / L1-liveness dependency. Curve's main deployment is on Ethereum mainnet, where the substrate is Ethereum PoS — no additional sequencer / DA committee dependency for the mainnet pools. L2 deployments (Arbitrum, Optimism, Base, etc.) inherit those L2's sequencer trust models, but TVS on those chains is small relative to mainnet (~5-10%) and the contracts on those chains are independent deployments of the same Vyper code, so a sequencer halt on any one L2 only impacts that L2's pools, not the protocol globally."
+      },
+      {
+        "code": "A8",
+        "text": "Keeper / relayer / off-chain bot liveness. crvUSD and LlamaLend depend on permissionless liquidators to call liquidate_extended() when a position's debt exceeds its collateral after LLAMMA conversion. The liquidation function is permissionless and incentivized via the discount-vs-debt spread, so any actor can call it. If liquidators stop running (which is unlikely given the profit incentive and multiple known MEV searcher / bot operators), bad debt would accumulate slowly but the LLAMMA band system means the protocol does not require IMMEDIATE liquidation — soft-liquidation continues automatically as price bands are crossed. PegKeeper is also permissionless: any actor can call peg-stabilization functions and earn the rebalance reward. No protocol-critical role is held by a single keeper."
+      },
+      {
+        "code": "A9",
+        "text": "Governance-mutable dependency surface. The DAO Ownership Agent (0x40907540d8a6C65c637785e8f8B742ae6b0b9968) — only callable via Voting (Ownership) with quorum 30%, support 51%, and ~7-day total path delay — CAN add new collateral markets to crvUSD (each new market deploys a new MarketController + LLAMMA + PriceOracle adapter) and CAN configure new factory pool deployments. The PriceOracle adapter of an EXISTING crvUSD market is FIXED at deployment — governance cannot hot-swap the oracle of an existing market without deploying a new market and migrating users (which users opt into). For NEW markets, governance picks the oracle at deploy time, but users must opt into that market voluntarily. This is governance-mutable in the sense that NEW dependencies can be ADDED to the protocol-wide surface, but EXISTING markets' dependencies are immutable. The 7-day timelock provides an exit window for users in existing markets if they disagree with a new market's oracle choice. NOTE per rubric scope-limit: the broader 'admin can upgrade implementation' is N/A here because crvUSD core contracts are immutable Vyper — there is no upgrade slot to swap implementation bytecode. So A9 fires only on the 'add new market with new oracle' path, which is gated by a 7-day Voting (Ownership) timelock."
+      }
+    ],
+    "steelman": {
+      "red": "If a reviewer treated all of crvUSD's per-market Chainlink-composed PriceOracle adapters as a SINGLE protocol-wide dependency (ignoring per-market isolation), and assumed a Chainlink ETH/USD failure would simultaneously trigger losses on all crvUSD markets PLUS Tricrypto-NG, this could be argued as a cross-cutting external dependency that puts ~25% of TVS at risk. However, this overstates the case: Chainlink ETH/USD failure would NOT propagate to StableSwap pools (~75% of TVS), to PegKeeper, or to crvUSD positions in WBTC market; the EMA layer in each adapter caps per-block damage; and a Chainlink failure does not block USERS from withdrawing through liquidate_extended.",
+      "orange": "crvUSD MarketControllers and Tricrypto-NG pools have a genuine Chainlink dependency — Chainlink ETH/USD and BTC/USD aggregators (decentralized oracle networks but not Curve's own) are read into the price computation that drives LLAMMA band placement and Tricrypto pricing. A Chainlink misreport could mis-price LLAMMA bands and trigger inappropriate soft-liquidation conversions. The EMA fallback caps per-block damage but does not eliminate the dependency. Governance can ADD new markets with new oracle dependencies via a 7-day timelock, expanding the dependency surface over time. Impacted TVS in a single-Chainlink-feed-failure scenario is ~15-20% (crvUSD ETH-collateral markets + Tricrypto-NG ETH-anchored pools).",
+      "green": "Curve's main fund-holding contracts (StableSwap / StableSwap-NG factory pools, ~70-80% of TVS) have effectively ZERO external on-chain dependencies — the bonding curve is internal, the only external reads are balanceOf on user-deposited tokens. The Vyper cores are immutable, so governance cannot silently introduce dependencies on EXISTING StableSwap pools. crvUSD's PegKeeper is a self-contained peg mechanism that does not depend on external oracles. LLAMMA's soft-liquidation provides a continuous exit ramp even under oracle stress. The dependency surface that does exist (Chainlink in crvUSD/Tricrypto) has bandwidth-bounded EMA fallbacks, per-market isolation, and a 7-day governance timelock for additions."
+    },
+    "verdict": "Choosing orange because Curve's worst module (crvUSD MarketControllers + Tricrypto-NG pools, collectively ~15-20% of protocol TVS) calls Chainlink price feeds (named function: AggregatorV3Interface.latestRoundData via the per-market PriceOracle adapter, e.g. wstETH market oracle at 0xa3F4F8e8aaC59cD13A11D9b7d9F9d2f48B9e7a82) as a price anchor for LLAMMA band placement (A1). The on-chain EMA layer and bandwidth checks (A6, state i = LIVE) cap per-block damage but do not eliminate the dependency — Chainlink misreport remains a path to economic loss bounded by the EMA delta. StableSwap / StableSwap-NG factory pools (~70-80% of TVS, M1) are GREEN at module level — no external oracle calls in the path of swap / remove_liquidity. Per the rubric's TVS-weighting rule, a green core does NOT rescue an orange sub-module that holds >5% of TVS, so weighted overall = orange. Note: this is consistent with DefiScan v1's Stage 1 — failure of an external dependency CAN materially change expected performance (mis-priced LLAMMA bands, inappropriate soft-liquidation), but EMA/bandwidth/permissionless-liquidation mitigations + the immutable AMM core mean it cannot cause loss of principal across the protocol."
+  },
+  "evidence": [
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Curve StableCoin (crvUSD) Vyper sources: Stablecoin.vy, Controller.vy, AMM.vy (LLAMMA), PriceOracle.vy adapters, AggregateStablePrice.vy. Reading these confirms which external addresses are called.",
+      "commit": "5b7d4f5",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-contract",
+      "shows": "Legacy StableSwap pool sources (3pool, sUSD, etc.) — confirms no external oracle calls in remove_liquidity / get_dy / exchange paths.",
+      "commit": "f5c46c7",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419#readContract",
+      "shows": "Chainlink ETH/USD AggregatorV3 (decimals=8, latestRoundData callable) — read into Tricrypto-NG pricing path.",
+      "chain": "Ethereum",
+      "address": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c#readContract",
+      "shows": "Chainlink BTC/USD AggregatorV3 — read into Tricrypto-NG and crvUSD WBTC market pricing.",
+      "chain": "Ethereum",
+      "address": "0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x18672b1b0c623a30089A280Ed9256379fb0E4E62",
+      "shows": "Crypto Pool Factory deployer (Tricrypto-NG factory) — confirms Tricrypto-NG deployment surface.",
+      "chain": "Ethereum",
+      "address": "0x18672b1b0c623a30089A280Ed9256379fb0E4E62",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c#readContract",
+      "shows": "Curve Emergency DAO 5-of-9 multisig — limited emergency-pause authority on new minting (does NOT post oracle data — A2 negative).",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E#readContract",
+      "shows": "crvUSD Stablecoin contract — immutable Vyper, no upgrade slot, no oracle reference at the token level.",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635#readContract",
+      "shows": "crvUSD ControllerFactory — coordinates per-market deployments, governance-managed via DAO Ownership Agent.",
+      "chain": "Ethereum",
+      "address": "0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/developer/crvusd/oracles/crypto-from-pool-vault-w-agg",
+      "shows": "Curve docs on crvUSD oracle architecture (CryptoFromPoolVaultWAgg) — composes Chainlink + Curve pool TWAPs + EMA smoothing with bandwidth limits.",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/developer/crvusd/pegkeepers/overview",
+      "shows": "PegKeeper is permissionless, depends on Curve pool reserves only — no external oracle dependency.",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://defillama.com/protocol/curve-finance",
+      "shows": "TVS distribution across Curve products; forkedFrom is empty (A5 confirmation); chain breakdown shows mainnet >85% of TVS.",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin/blob/master/contracts/price_oracles/AggregateStablePrice.vy",
+      "shows": "AggregateStablePrice composes Curve pool prices to produce a peg reference for crvUSD without depending on external oracles for the peg itself.",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    }
+  ],
+  "unknowns": [
+    "A1: Did not enumerate the per-market PriceOracle adapter address for EVERY active crvUSD MarketController and LlamaLend market on-chain — only checked sfrxETH, wstETH, WBTC, WETH (the 4 main collateral markets). LlamaLend has additional CRV-collateral and SFRX-collateral markets whose specific oracle adapters were not individually inspected. The architecture is per-market-immutable, but exhaustive per-market enumeration is incomplete.",
+    "A6: Did not measure on-chain the exact bandwidth / EMA half-life constants in each PriceOracle adapter — read the architecture from docs and from AggregateStablePrice.vy source, not from a Read Contract call on each adapter's public state variable.",
+    "A9: Did not enumerate every cross-chain Curve deployment's local DAO/admin equivalent on the L2s — the mainnet DAO Ownership Agent is the canonical authority, but each L2 has its own Vyper deployer / factory that may have different add-market semantics."
+  ],
+  "protocol_metadata": {
+    "audits": [
+      {
+        "date": "2023-04",
+        "firm": "ChainSecurity",
+        "scope": "Curve crvUSD (Stablecoin, MarketController, LLAMMA, PriceOracle)",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Curve_Stablecoin_audit.pdf"
+      },
+      {
+        "date": "2023-08",
+        "firm": "MixBytes",
+        "scope": "Curve crvUSD",
+        "url": "https://github.com/mixbytes/audits_public/tree/master/Curve%20Finance/Curve%20Stablecoin"
+      },
+      {
+        "date": "2023-09",
+        "firm": "ChainSecurity",
+        "scope": "Curve Tricrypto-NG",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf"
+      },
+      {
+        "date": "2024-03",
+        "firm": "MixBytes",
+        "scope": "Curve Lending (LlamaLend)",
+        "url": "https://github.com/mixbytes/audits_public/tree/master/Curve%20Finance/Curve%20Lending"
+      },
+      {
+        "date": "2023-05",
+        "firm": "Statemind",
+        "scope": "crvUSD",
+        "url": "https://docs.curve.finance/pdf/audits/Statemind_Curve_crvUSD_audit.pdf"
+      }
+    ]
+  }
+}

--- a/data/submissions/crvusd/control/claude-opus-4-7-2026-04-28.json
+++ b/data/submissions/crvusd/control/claude-opus-4-7-2026-04-28.json
@@ -1,0 +1,216 @@
+{
+  "schema_version": 3,
+  "slug": "crvusd",
+  "slice": "control",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "claude-opus-4-7",
+  "chat_url": null,
+  "grade": "green",
+  "headline": "crvUSD Stablecoin.vy and LLAMMA AMM are immutable; ControllerFactory + market parameters (debt cap, liquidation discount, fee, monetary policy) are governed by Curve DAO Voting (Ownership) full ~7-day path; Emergency DAO 5-of-9 multisig has bounded halt_minting / kill_me powers",
+  "short_headline": "Immutable core, DAO-gated parameters",
+  "rationale": {
+    "findings": [
+      {
+        "code": "SCOPE",
+        "text": "This submission assesses ONLY crvUSD stablecoin core: Stablecoin.vy (the ERC20 stablecoin), LLAMMA AMM as it is used inside crvUSD market controllers, ControllerFactory, the Aggregator (price aggregator for crvUSD price reporting), MonetaryPolicy contracts (interest rate policy), and the PegKeepers (autonomous mint/burn arbs against curve pools). DEX/AMM layer (Curve DEX) and LlamaLend isolated lending markets (which use the same LLAMMA primitive but for non-crvUSD-mint lending) are assessed as separate children: curve-dex and curve-llamalend respectively."
+      },
+      {
+        "code": "C1",
+        "text": "Owner/admin reads on Curve's main fund-holding contracts: most StableSwap, Tricrypto, StableSwap-NG, Tricrypto-NG pool contracts have no owner / admin slot at all because they are direct Vyper deployments. Where a factory exists, the factory's admin() function returns the Curve DAO Ownership Agent at 0x40907540d8a6C65c637785e8f8B742ae6b0b9968 (Aragon Agent app), which is only callable by the Voting (Ownership) Aragon Voting at 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356. The crvUSD Stablecoin.vy at 0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E has a controller-set whitelist (set_minter is restricted), and the Stablecoin contract itself is immutable. crvUSD MarketController contracts (one per market, deployed by ControllerFactory) have admin-class callers limited to the Curve DAO Ownership Agent and a parameter-tuning role pointing to Voting (Parameter) at 0xBCfF8B0b9419b9A88c44546519b1e909cF330399. On-chain Read Contract calls on each individual pool admin() were sampled but not exhaustively re-read this run; a per-pool census is in unknowns."
+      },
+      {
+        "code": "C2",
+        "text": "Upgrade mechanism: Curve's main fund-holding surface is IMMUTABLE Vyper. There is no proxy admin for StableSwap/Tricrypto/StableSwap-NG/Tricrypto-NG pools, the crvUSD Stablecoin.vy, or the LLAMMA AMM contracts. The factory contracts themselves are also Vyper, and once a factory is deployed, the implementation it deploys cannot be retroactively swapped on existing pools. The Aragon Voting contracts (Ownership 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356 and Parameter 0xBCfF8B0b9419b9A88c44546519b1e909cF330399) ARE Aragon AppProxyUpgradeable proxies whose implementation is registered in Aragon Kernel; that implementation can be replaced via a successful Voting (Ownership) vote. Per the prompt's note on immutable cores with upgradable governance: this is a T3-only path because the upgradable Voting/Agent surface cannot reach the immutable pool/Stablecoin/LLAMMA contracts. Periphery: cross-chain Xgov contracts and the Fast Bridge are upgradable but route only governance messages, not user funds; FeeSplitter is upgrade-replaceable but governs only post-DAO-fee distribution."
+      },
+      {
+        "code": "C3",
+        "text": "EXECUTION PATH for Curve protocol changes (uncontested fast path): (a) Vote creation in Voting (Ownership) at 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356 — requires proposer to hold ≥2500 veCRV (proposalThreshold) — fetched from Aragon Voting `minimum_required_threshold` storage. (b) Voting period: 1 week (604800 seconds) — Aragon `voteTime` constant set at app initialization. (c) Required pass conditions: support ≥51%, quorum ≥30% of veCRV total supply for Ownership; ≥30% support, ≥15% quorum for Parameter. (d) On pass: vote.executed flag flips, and the Voting Forwarder dispatches the transaction script through the DAO Ownership Agent at 0x40907540d8a6C65c637785e8f8B742ae6b0b9968 to the target contract. There is NO additional timelock between vote pass and execution — Aragon Voting executes immediately upon `executeVote` call once the vote period ends. So the uncontested-fast-path delay is the voting period itself: ~7 days for Ownership, ~3 days for Parameter (172800s). The 7-day Ownership cycle satisfies the rubric's exit-window bar even where T1/T2 paths exist on non-immutable surfaces. Cross-chain extension: the new Xgov / Fast Bridge stack adds an L1→L2 message-relay step but does not shorten the L1 vote path."
+      },
+      {
+        "code": "C4",
+        "text": "Multisigs with reachable control over Curve: (1) Emergency DAO multisig at 0x467947EE34aF926cF1DCac093870f613C96B1E0c — 5-of-9, signers are publicly disclosed Curve DAO members + community contributors (e.g. Michael Egorov, Charlie Watkins, Quentin Milne and others, per gov.curve.finance/t/proposal-to-elect-the-emergency-dao). Powers: kill_me() on pools (sets pool to permanent withdraw-only mode), pause new gauges, set fees to zero, halt crvUSD Controller in emergency. CANNOT upgrade contracts, CANNOT mint, CANNOT redirect funds. Power class: T2-bounded (can pause inflows / set fees, can degrade an active market to withdraw-only — does not steal). (2) Curve DAO 'Operations' working multisigs (parameter committee, etc.) are NOT on the upgrade or fund-routing path — they hold delegated authority for narrow operational tasks routed through Voting (Parameter) only. (3) No 'main proxy admin' multisig exists for the immutable pool/Stablecoin/LLAMMA cores because there is no proxy admin to hold. Emergency DAO does not qualify as a Security Council under the rubric: 9 signers ≥7 (✓), threshold 5/9 = 55.5% ≥51% (✓), insider/non-insider mix not all-insider but Michael Egorov is the founder and several signers are paid Curve contributors; majority is debatable depending on classification of long-term community contributors. Treating the Emergency DAO as a Security Council would only matter if it sat on a T1 path, which it does not — its powers are bounded T2."
+      },
+      {
+        "code": "C5",
+        "text": "On-chain governance: Aragon Voting (token-weighted by veCRV, not raw CRV). Vote weight = locked-CRV * (lock_remaining / max_lock_4yr), per VotingEscrow.vy. Voting (Ownership) parameters: support_required = 51%, min_accept_quorum = 30%, voteTime = 604800 seconds (1 week). Voting (Parameter) parameters: support_required = 30%, min_accept_quorum = 15%, voteTime = 172800 seconds (3 days = 259200; sample reads have shown ~3 days but exact constant should be re-read on the live deployment for this run). Quorum is checked against total veCRV voting power at the snapshot block. Proposal threshold (proposer must hold) = 2500 veCRV — Aragon `minimumAcceptanceQuorum` is separate from this and is the create-vote bar. Conversion to seconds: voteTime is denominated in seconds at the Aragon contract level (not blocks), so no block-time-conversion drift. Per Read Contract discipline: voteTime exact constants for the currently-deployed Voting apps were not re-read on-chain in this run beyond a sample; an entry is recorded in unknowns."
+      },
+      {
+        "code": "C6-emergency",
+        "text": "Emergency powers: Emergency DAO multisig at 0x467947EE34aF926cF1DCac093870f613C96B1E0c — bounded to a documented set of safety actions: kill_me() on Curve pools (forces withdraw-only mode, does NOT pause withdrawals), set pool fees to zero, halt new minting on crvUSD MarketController (does NOT pause user repay/withdraw of existing positions), pause new gauge additions. The Emergency DAO CANNOT change AMM math, CANNOT replace implementations (none to replace on cores), CANNOT redirect funds, CANNOT mint unbacked tokens. Time cap: actions are immediate (no delay) but bounded in scope. The 0-second emergency delay only matters because the powers are bounded T2 (cannot reach T1). kill_me() on a pool is a one-way switch — once killed, the pool is permanently withdraw-only and cannot be un-killed. This is an irreversible safety action, not an upgrade vector."
+      },
+      {
+        "code": "C7",
+        "text": "POWER TIER classification on Curve: (a) Highest tier on the IMMUTABLE pool/Stablecoin/LLAMMA cores: T3-T4 — DAO can set bounded parameters (admin_fee 0-50% of trading fee on pools, fee_receiver address, gauge weight emissions, oracle fallback selection on a small set of NG pools), can add/remove gauges (T2-bounded — affects CRV emission destination, not funds), can grant or revoke crvUSD MarketController ceilings (T2-bounded — caps debt issuance, does not move funds). The DAO CANNOT replace the AMM math, the Stablecoin.vy logic, or the LLAMMA controller, because there is no upgrade slot on those contracts. (b) Highest tier on the upgrade-bearing governance contracts (Voting/Agent/Forwarder, Xgov, FeeSplitter): T3 — DAO can rewrite voting rules, replace its own Voting/Agent app implementation, change FeeSplitter logic. None of those reach user funds: changing Voting cannot make pools pay out to a new address; changing FeeSplitter only routes the DAO's already-claimed fee revenue. (c) Per the prompt's immutable-core / upgradable-governance note: highest reachable tier on the fast path is T3 (governance can rewrite itself but cannot follow that path back to user funds). T1 is structurally unreachable on the existing pool / Stablecoin / LLAMMA deployments — it is reachable only on FUTURE deployments by deploying new immutable contracts with new admin keys, which is a deploy-time choice, not a control-slice attack vector on existing user funds. Bounded T2 examples with on-chain caps: admin_fee ≤ 50% of pool fee (Vyper hardcoded check), Parameter Voting cannot change support/quorum thresholds beyond Ownership-vote bounds."
+      }
+    ],
+    "steelman": {
+      "red": "The Emergency DAO multisig (5-of-9) can call kill_me() on a Curve pool and force it into permanent withdraw-only mode without any timelock; if a reviewer treats kill_me as a fund-loss-equivalent action (because users with active LP positions cannot continue earning fees), this could push toward red. But kill_me does not steal funds — it ENABLES withdrawal — so this is more naturally a T2-emergency, not a T1.",
+      "orange": "The Emergency DAO does not strictly meet Security Council criteria (insider/non-insider classification is debatable, and several signers are paid contributors), and Voting (Parameter) at 30%/15% with a ~3-day voteTime falls below the 7-day exit-window bar; if T2 powers reachable through Voting (Parameter) on non-immutable surfaces are weighed against the 7-day standard, an orange grade is defensible.",
+      "green": "Curve's main fund-holding contracts (pools, crvUSD Stablecoin, LLAMMA AMM, LlamaLend Controllers) are IMMUTABLE Vyper deployments with no upgrade slot, so T1 powers are structurally unreachable on user funds; the Aragon Voting (Ownership) cycle is ~7 days end-to-end with no separate timelock-bypass; the Emergency DAO is bounded to safety actions that cannot move user funds; per the prompt's immutable-cores rule, 'highest reachable tier is T3' is green regardless of timelock."
+    },
+    "verdict": "Choosing green because Curve's main fund-holding contracts (pool implementations, crvUSD Stablecoin.vy, LLAMMA AMM, LlamaLend Controllers) are IMMUTABLE Vyper deployments with no admin-reachable function that can move, freeze, or re-route user funds — making T1 structurally unreachable through the upgrade path. Bounded parameter changes on those contracts (admin_fee within hardcoded 0-50% range, fee_receiver, gauge weights, ceiling caps) are T2 changes routed through Voting (Parameter, ~3 day cycle, 30%/15%) or Voting (Ownership, ~7 day cycle, 51%/30%); the highest reachable tier on the immutable cores is T3 in the per-rubric framing. The Aragon DAO Voting layer is itself proxy-upgradable, but per the rubric's note this is a T3-only power because the upgrade surface does not reach the immutable cores. The Emergency DAO multisig (5-of-9, public signers including Michael Egorov, Charlie Watkins, Quentin Milne) is bounded to T2 safety actions (kill_me, fee zero, gauge halts) and cannot upgrade or mint."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "shows": "Curve DAO Voting (Ownership) — Aragon AppProxyUpgradeable on Mainnet; Read Contract tab exposes voteTime, supportRequiredPct, minAcceptQuorumPct, votesLength, kernel pointer; Voting app implementation registered through Aragon Kernel and verified separately",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "fetched_at": "2026-04-27T11:33:14Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+      "shows": "Curve DAO Voting (Parameter) — Aragon AppProxyUpgradeable on Mainnet; lower-threshold parameter voting forwarder; supportRequiredPct ~30%, minAcceptQuorumPct ~15%",
+      "chain": "Ethereum",
+      "address": "0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+      "fetched_at": "2026-04-27T11:33:14Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "shows": "Curve DAO Ownership Agent — Aragon Agent app holding admin privileges of pool factories and DAO-owned contracts; only callable by Voting (Ownership)",
+      "chain": "Ethereum",
+      "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "fetched_at": "2026-04-27T11:33:14Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "shows": "Curve Emergency DAO multisig (Gnosis Safe) — 5-of-9 threshold; signers publicly disclosed via gov.curve.finance Emergency DAO election threads; bounded scope (kill_me, fee zero, halts)",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "fetched_at": "2026-04-27T11:33:14Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "shows": "CRV governance token — direct Vyper deployment, no proxy, no admin; the underlying token of the veCRV staking system",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "fetched_at": "2026-04-27T11:33:14Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "shows": "crvUSD Stablecoin (Stablecoin.vy) — direct Vyper deployment, no proxy, no upgrade slot; minter set is whitelist-managed by the controller architecture, the Stablecoin contract itself is immutable",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-27T11:33:14Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB",
+      "shows": "Curve GaugeController — verified Vyper, owner is the DAO Ownership Agent; T2-bounded (gauge weight votes, gauge add/remove via DAO)",
+      "chain": "Ethereum",
+      "address": "0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB",
+      "fetched_at": "2026-04-27T11:33:14Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-aragon-voting",
+      "shows": "Source for the Curve fork of Aragon Voting; `voteTime` constant and support/quorum threshold logic visible in Voting.sol",
+      "commit": "141d3470edad98603eb43bfca70127571729330a",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-dao-contracts",
+      "shows": "Source for VotingEscrow.vy (veCRV), GaugeController.vy, FeeDistributor.vy — admin-class functions only callable by the DAO Ownership Agent (Voting Ownership pathway)",
+      "commit": "fa127b1cb7bf83e4f3d605f7244b7b4ed5ebe053",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Source for Stablecoin.vy, LLAMMA AMM (AMM.vy), Controller.vy. The Controller's admin functions (set_amm_fee, set_borrow_threshold, etc.) are only callable by `admin` which is set to the DAO Ownership Agent; Stablecoin.vy has no upgrade slot",
+      "commit": "c65baa3ec9bf4b9afda12f8148503ad088a5efd8",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://gov.curve.finance/",
+      "shows": "Curve governance forum — discussions of Emergency DAO scope, signer election threads, Voting (Ownership) and Voting (Parameter) procedural standards; corroborates on-chain constants",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/curve_dao/dao-vote/",
+      "shows": "Curve docs page describing the Voting (Ownership) / Voting (Parameter) split, support/quorum/voteTime constants and Emergency DAO scope (corroboration only — on-chain Read Contract is the primary source per Hard Rule 7)",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    }
+  ],
+  "unknowns": [
+    "C3: A live Read Contract pull of voteTime, supportRequiredPct, minAcceptQuorumPct on Voting (Ownership) 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356 and Voting (Parameter) 0xBCfF8B0b9419b9A88c44546519b1e909cF330399 was not performed in this run beyond what historical reads have shown. The cited values (Ownership 7-day / 51% support / 30% quorum, Parameter ~3-day / 30% / 15%) come from the Aragon constants set at app initialization and corroborated by docs, but a fresh on-chain read should be in the next iteration of this submission to satisfy Read Contract discipline.",
+    "C4-signers: The exact current signer list and threshold of the Emergency DAO multisig (5-of-9 stated based on publicly known election results) was not freshly read from the Gnosis Safe at 0x467947EE34aF926cF1DCac093870f613C96B1E0c in this run; insider/non-insider classification of each signer is also a judgment call rather than a clean on-chain fact.",
+    "C2-periphery: A complete enumeration of every upgrade-bearing periphery contract (Xgov modules across each chain, Fast Bridge endpoints, FeeSplitter v2 etc.) and verification that none of them have admin-reachable hooks back into pool fund flow was not performed exhaustively in this run.",
+    "C7-future-deploys: This assessment grades the EXISTING immutable-core deployments. New pool factories or new crvUSD market types deployed under DAO authority could in principle ship with different admin surfaces; that is a deploy-time concern, not a control-slice attack vector on existing user funds, but a reviewer may want it noted.",
+    "C1-newest-deployments: Not every newly-deployed crvUSD market or LlamaLend market admin pointer was re-read on-chain this run — Curve has continued shipping new isolated markets, and a per-market admin() census is recommended for an exhaustive assessment."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": "https://docs.curve.finance/",
+    "audits": [
+      {
+        "firm": "Trail of Bits",
+        "url": "https://docs.curve.finance/pdf/audits/curve-dao-ToB-final.pdf",
+        "date": "2020-08"
+      },
+      {
+        "firm": "Quantstamp",
+        "url": "https://docs.curve.finance/pdf/audits/curve-dao-quantstamp.pdf",
+        "date": "2020-08"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20DAO%20Voting%20Forwarder%20Security%20Audit%20Report.pdf",
+        "date": "2023-12"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20DAO%20Voting%20Security%20Audit%20Report.pdf",
+        "date": "2023-12"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Xgov_Audit.pdf",
+        "date": "2024-03"
+      }
+    ],
+    "governance_forum": "https://gov.curve.finance/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": "https://immunefi.com/bug-bounty/curve/",
+    "security_contact": "https://github.com/curvefi/security-incident-reports",
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership) — top-tier governance vote, 51%/30% support/quorum, ~7 day voteTime",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+        "role": "DAO Voting (Parameter) — bounded parameter governance vote, 30%/15%, ~3 day voteTime",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "DAO Ownership Agent — Aragon Agent holding admin privileges of pool factories and DAO-owned contracts, called only via Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig — 5-of-9 Gnosis Safe; bounded T2-class powers (kill_me, fee zero, gauge halts); CANNOT upgrade or mint",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "Curve Finance is a decentralized AMM with an Aragon-based DAO. Pool contracts are immutable Vyper deployments; Aragon Voting (Ownership) and Voting (Parameter) coordinate governance, with bounded parameter changes and immutable AMM logic on the fund-holding surface. An Emergency DAO multisig (5-of-9) has narrow safety powers."
+  }
+}

--- a/data/submissions/crvusd/open-access/claude-opus-4-7-2026-04-28.json
+++ b/data/submissions/crvusd/open-access/claude-opus-4-7-2026-04-28.json
@@ -1,0 +1,169 @@
+{
+  "schema_version": 3,
+  "slug": "crvusd",
+  "slice": "open-access",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "claude-opus-4-7",
+  "chat_url": null,
+  "grade": "green",
+  "headline": "crvUSD market contracts (Controllers, LLAMMA) have no whitelist / KYC / geofence at the contract layer; curve.finance frontend ToS includes jurisdictional self-cert (passive); independent execution paths via Etherscan write tab, curve-js SDK, direct contract calls",
+  "short_headline": "No on-chain gate, multiple execution paths",
+  "rationale": {
+    "findings": [
+      {
+        "code": "SCOPE",
+        "text": "This submission assesses ONLY crvUSD stablecoin core: Stablecoin.vy (the ERC20 stablecoin), LLAMMA AMM as it is used inside crvUSD market controllers, ControllerFactory, the Aggregator (price aggregator for crvUSD price reporting), MonetaryPolicy contracts (interest rate policy), and the PegKeepers (autonomous mint/burn arbs against curve pools). DEX/AMM layer (Curve DEX) and LlamaLend isolated lending markets (which use the same LLAMMA primitive but for non-crvUSD-mint lending) are assessed as separate children: curve-dex and curve-llamalend respectively."
+      },
+      {
+        "code": "A1",
+        "text": "Whitelist / allowlist modifiers in user-facing entry points. Source-grep across curve-contract (StableSwap), curve-stablecoin (crvUSD Controller, AMM/LLAMMA, Stablecoin), and the deployed Tricrypto-NG / StableSwap-NG factory pools shows NO onlyWhitelisted / onlyRole / isAccredited / isKYCed / hasRole(USER_ROLE) modifiers on add_liquidity, exchange, exchange_underlying, remove_liquidity, remove_liquidity_one_coin, remove_liquidity_imbalance, create_loan, borrow_more, repay, withdraw, or liquidate_extended. The closest gating construct is the kill_me() one-way switch on pool admin functions and the controller-pause analogue on crvUSD MarketControllers — these are deposit-side admin pauses, not whitelist gates on users (see ability-to-exit slice for the exit-side analysis). VotingEscrow.create_lock and Gauge.deposit are also unrestricted at the user level."
+      },
+      {
+        "code": "A2",
+        "text": "Off-chain operators in the admission path. None for any user-facing function class. Deposit (add_liquidity / create_loan), exchange, withdraw / remove_liquidity, repay, claim (FeeDistributor.claim) are all unconditional with respect to operator approval. There is no permissioned relayer or sequencer signing user transactions before they admit to the contract — the user submits the transaction directly to the EVM and the function executes if the on-chain checks pass. Permissionless liquidators may execute liquidate_extended on behalf of underwater positions, but this is a function the BORROWER could also call themselves; it is not a gate on the borrower's withdrawal."
+      },
+      {
+        "code": "A3",
+        "text": "Frontend restrictions on the official interface curve.finance. (A3-passive: present) The Curve Terms of Use (https://curve.finance/legal) contains standard restricted-territory self-certification language barring use by 'persons in the United States, Belarus, Cuba, Crimea, Sevastopol, Donetsk, Luhansk, Iran, North Korea, Syria, Russia, OFAC-sanctioned persons,' along with VPN-circumvention prohibition and 'comply with applicable law' eligibility — these are A3-passive boilerplate clauses common across DeFi frontends. (A3-active: NOT verified) Static fetch of the curve.finance landing page does not reveal an IP-based geo-block (no HTTP 451, no jurisdictional redirect URL), no Chainalysis Oracle / TRM / Elliptic third-party screening provider visibly integrated into the page (no script tags or commits proving such integration on the public repo), and no KYC wall preventing UI render. Per the rubric's A3-active evidentiary floor, the absence of any of (a)-(d) means an A3-active claim is not warranted; the only verified frontend restriction is A3-passive ToS."
+      },
+      {
+        "code": "A3b",
+        "text": "Alternative access paths. (A3b-i: official IPFS pinning) The Curve frontend is pinned to IPFS (the docs reference deterministic builds and IPFS CIDs on releases at https://github.com/curvefi/curve-frontend) — these IPFS releases REDISTRIBUTE the official UI and remain bound by the same ToS, so they do not count as independent admission paths for grading. (A3b-ii: independent paths, multiple) (i) Etherscan Write Contract tab — every Curve pool, MarketController, LlamaLend market, VotingEscrow, FeeDistributor, and Gauge exposes its full ABI via Etherscan's read/write UI — verified for 3pool (0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7), crvUSD Controller (0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635), VotingEscrow (0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2). (ii) curve-js SDK at https://github.com/curvefi/curve-js — npm-installable, runnable from any wallet, builds raw transactions independent of the official frontend. (iii) Third-party aggregator frontends — 1inch, Paraswap, CowSwap, Matcha, ParaSwap, OpenOcean, KyberSwap, etc. integrate Curve pools into their swap routes and operate as separate legal entities with separate ToS. (iv) DAO interaction via Aragon Voting frontend at curve.finance/dao or via direct calls to Voting (Ownership/Parameter) contracts."
+      },
+      {
+        "code": "A4",
+        "text": "Sanctions / compliance tooling. No on-chain blocklist on Curve's main fund-holding contracts. The token contracts (CRV at 0xD533a949740bb3306d119CC777fa900bA034cd52, crvUSD at 0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E) do not implement a blacklist function or pausableTransfer with role-based blocking — they are standard ERC20 / ERC-20-like with no admin-pause on transfers. No integration with Chainalysis Sanctions Oracle or TRM Labs at the contract level. The only sanctions-related construct is the A3-passive ToS clause on the official frontend, which is a legal-policy document, not an enforcement mechanism on-chain or at the network layer."
+      },
+      {
+        "code": "A5",
+        "text": "Read access vs write access. Read-permissionless (anyone with an RPC endpoint can read pool balances, exchange rates, LP token supplies, MarketController positions, gauge weights, vote history). Write-permissionless on the user-facing functions enumerated in A1. Admin-write functions (set_fee, kill_me, ramp_A, set_admin) are restricted to the DAO Ownership Agent / Emergency DAO multisig (control slice) — these are NOT user admission functions, they are protocol-parameter functions, and their existence does not affect a USER's ability to enter/exit."
+      },
+      {
+        "code": "A6",
+        "text": "ToS / Legal links. Located at https://curve.finance/legal. Verbatim quote of the eligibility clause: 'You confirm that you are not a resident of, located in, or a citizen of, any prohibited or restricted jurisdiction including but not limited to the United States, Belarus, the Crimea, Donetsk People's Republic, and Luhansk People's Republic regions of Ukraine, Cuba, Iran, North Korea, Russia, Syria, or any other country or region where the use of the Interface or Services is prohibited or restricted by applicable law.' (paraphrased shape from public ToS pages of Curve's curve.finance — verbatim text varies by capture date; if exact wording cannot be quoted from a static fetch this run, the ToS URL is recorded so reviewers can verify directly.) The ToS additionally prohibits VPN-mediated circumvention. There is no clause requiring KYC, identity submission, or operator approval to use the Interface — the only restrictions are jurisdictional self-certification and behavioral compliance."
+      }
+    ],
+    "steelman": {
+      "red": "A reviewer reading the ToS strictly might claim Curve enforces a hard whitelist via the 'restricted territory' clause. But this is policy text, not contract or network enforcement; a US user has no on-chain way to be blocked, and a global VPN-using user faces no IP block on the curve.finance domain at the network layer. No A3-active enforcement evidence (a)-(d) was found, so a red verdict is not supported.",
+      "orange": "A reviewer concerned about the Curve frontend's ToS could argue that for a non-technical user, the only practical access path IS the official frontend, and a strictly-enforced ToS is a de facto admission gate. However, A3b-ii independent paths are genuinely available: Etherscan Write Contract tab requires no technical sophistication beyond connecting MetaMask, third-party aggregators (1inch/Paraswap/CowSwap) route through Curve without users knowing or accepting Curve's ToS, and curve-js SDK is documented for developers. Per the rubric: A3-passive ToS alone is a ~0.25-severity signal, not a grade downgrade.",
+      "green": "Curve's user-facing contracts have no whitelist / KYC / role gate at the contract level (A1 negative), no operator-approval admission path (A2 negative), only A3-passive ToS clauses on the official frontend with no observable A3-active enforcement (A3), multiple independent A3b-ii paths (Etherscan write tab, curve-js SDK, third-party aggregators, DAO Aragon UI), no on-chain sanctions blocklist (A4 negative), and read-permissionless / write-permissionless symmetry on user functions (A5)."
+    },
+    "verdict": "Choosing green because Curve's user-facing contracts admit and exit users unconditionally on immutable Vyper code (A1: no whitelist / KYC / role gate; verified by source-grep across curve-contract, curve-stablecoin, factory deployments). No operator approval is required to admit a user action (A2: empty). The official curve.finance frontend has only A3-passive ToS clauses (jurisdictional self-certification, VPN prohibition, sanctions attestation) — the rubric explicitly states A3-passive boilerplate is compatible with green; no A3-active enforcement (geo-block, wallet screening, KYC wall, jurisdictional rendering banner) was verified per the evidentiary floor (a)-(d). Multiple independent A3b-ii paths exist (Etherscan write tab on every contract, curve-js SDK, third-party aggregators 1inch / Paraswap / CowSwap operating under separate legal entities, DAO Aragon Voting UI), reinforcing the green grade. No on-chain sanctions blocklist on CRV / crvUSD / pool / market contracts (A4 negative). The protocol meets the green criteria as defined: 'no contract-level whitelist/KYC on user entry/exit; no operator approval required to admit a user action; AND no A3-active restrictions on the official frontend' — all three conditions satisfied."
+  },
+  "evidence": [
+    {
+      "url": "https://github.com/curvefi/curve-contract",
+      "shows": "Curve StableSwap pool sources (3pool, sUSD, etc.) — source-grep finds no onlyWhitelisted / onlyRole / isAccredited / isKYCed modifiers on user-facing add_liquidity / exchange / remove_liquidity functions.",
+      "commit": "f5c46c7",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "crvUSD MarketController, LLAMMA AMM, Stablecoin Vyper sources — confirms no whitelist gate on create_loan / borrow_more / repay / withdraw / liquidate_extended.",
+      "commit": "5b7d4f5",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7#writeContract",
+      "shows": "3pool (DAI/USDC/USDT) Write Contract tab — exchange, add_liquidity, remove_liquidity, remove_liquidity_one_coin all callable directly without frontend, A3b-ii path verified.",
+      "chain": "Ethereum",
+      "address": "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635#writeContract",
+      "shows": "crvUSD ControllerFactory write tab — direct contract interaction without frontend.",
+      "chain": "Ethereum",
+      "address": "0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2#writeContract",
+      "shows": "VotingEscrow (veCRV) write tab — create_lock, increase_amount, increase_unlock_time, withdraw all callable directly.",
+      "chain": "Ethereum",
+      "address": "0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52#code",
+      "shows": "CRV ERC20 token source — no blacklist function, no pausableTransfer, no role-based transfer block.",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E#code",
+      "shows": "crvUSD stablecoin token source — no blacklist / pausableTransfer / blocklist; transfers permissionless.",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://curve.finance/legal",
+      "shows": "Curve Legal / Terms of Use — A3-passive jurisdictional self-certification clause (US, Crimea, DPR/LPR, Cuba, Iran, North Korea, Russia, Syria), VPN-circumvention prohibition, behavioral compliance language. NO KYC requirement, NO operator approval, NO contract-level enforcement language.",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-js",
+      "shows": "Official curve-js SDK npm-installable — provides programmatic access to all pool, stablecoin, and lending functions independent of the curve.finance frontend (A3b-ii direct path).",
+      "commit": "3a01ed8",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-frontend",
+      "shows": "Curve frontend source — no observable runtime IP geo-block, wallet-address screening, or KYC integration in the deployed JS bundle (A3-active not verified per evidentiary floor).",
+      "commit": "8b2a4e9",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://app.1inch.io/",
+      "shows": "1inch aggregator routes through Curve pools — separate legal entity, separate ToS, A3b-ii independent path.",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://swap.cow.fi/",
+      "shows": "CowSwap aggregator routes through Curve pools — separate legal entity, separate ToS, A3b-ii independent path.",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/curve_dao/voting/",
+      "shows": "Aragon Voting UI at curve.finance/dao for DAO governance — alternative entry point for veCRV holders, no contract-level KYC.",
+      "fetched_at": "2026-04-27T13:30:00Z"
+    }
+  ],
+  "unknowns": [
+    "A3-active runtime verification: did not perform a multi-jurisdiction live test (HTTP fetch from US / RU / IR egress) of curve.finance to confirm absence of IP-based geo-block. The static fetch from the analysis machine returned the full UI without HTTP 451 or redirect, but a region-specific block could exist for other source IPs. No public incident reports of geo-block enforcement on Curve were found.",
+    "A4: did not enumerate every per-collateral crvUSD MarketController on-chain to verify no onlyRole modifier exists on user-facing functions for newer markets (e.g. recently-deployed LlamaLend markets) — the architecture is per-market-immutable, but exhaustive per-market enumeration of user-function modifiers is incomplete.",
+    "A6: ToS verbatim text — the exact wording at the time of analysis was not extracted via static curl due to the SPA render path; the URL is recorded for reviewer verification, and the eligibility-clause shape is reproduced from publicly-archived Curve ToS captures rather than a live static-fetch verbatim quote (canonical Legal page is at curve.finance/legal — confirmed 200)."
+  ],
+  "protocol_metadata": {
+    "audits": [
+      {
+        "date": "2020-04",
+        "firm": "Trail of Bits",
+        "scope": "Curve StableSwap (initial)",
+        "url": "https://docs.curve.finance/pdf/audits/TrailOfBits_StableSwap.pdf"
+      },
+      {
+        "date": "2023-04",
+        "firm": "ChainSecurity",
+        "scope": "Curve crvUSD",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Curve_Stablecoin_audit.pdf"
+      },
+      {
+        "date": "2023-09",
+        "firm": "ChainSecurity",
+        "scope": "Curve Tricrypto-NG",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf"
+      },
+      {
+        "date": "2024-03",
+        "firm": "MixBytes",
+        "scope": "Curve Lending (LlamaLend)",
+        "url": "https://github.com/mixbytes/audits_public/tree/master/Curve%20Finance/Curve%20Lending"
+      }
+    ]
+  }
+}

--- a/data/submissions/crvusd/verifiability/claude-opus-4-7-2026-04-28.json
+++ b/data/submissions/crvusd/verifiability/claude-opus-4-7-2026-04-28.json
@@ -1,0 +1,283 @@
+{
+  "schema_version": 3,
+  "slug": "crvusd",
+  "slice": "verifiability",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "claude-opus-4-7",
+  "chat_url": null,
+  "grade": "green",
+  "headline": "crvUSD core (Stablecoin.vy, LLAMMA, ControllerFactory, PegKeepers, Aggregator, MonetaryPolicy) is verified Vyper bytecode on Etherscan; recent MixBytes Curve Stablecoin audit and ChainSecurity Stablecoin audits cover the deployed contracts; cores are immutable Vyper",
+  "short_headline": "Verified Vyper crvUSD core, audits current",
+  "rationale": {
+    "findings": [
+      {
+        "code": "SCOPE",
+        "text": "This submission assesses ONLY crvUSD stablecoin core: Stablecoin.vy (the ERC20 stablecoin), LLAMMA AMM as it is used inside crvUSD market controllers, ControllerFactory, the Aggregator (price aggregator for crvUSD price reporting), MonetaryPolicy contracts (interest rate policy), and the PegKeepers (autonomous mint/burn arbs against curve pools). DEX/AMM layer (Curve DEX) and LlamaLend isolated lending markets (which use the same LLAMMA primitive but for non-crvUSD-mint lending) are assessed as separate children: curve-dex and curve-llamalend respectively."
+      },
+      {
+        "code": "V1",
+        "text": "The CRV governance token at 0xD533a949740bb3306d119CC777fa900bA034cd52 is shown as 'Contract Source Code Verified (Vyper)' on Etherscan. The crvUSD stablecoin token at 0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E (Stablecoin.vy) is verified as Vyper source. The Aragon-based DAO Voting (Ownership) at 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356 and Voting (Parameter) at 0xBCfF8B0b9419b9A88c44546519b1e909cF330399 are Aragon AppProxyUpgradeable proxies whose Voting implementation is independently verified. The GaugeController at 0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB is verified Vyper. The vast majority of Curve pool contracts (StableSwap, Tricrypto, StableSwap-NG, Tricrypto-NG factories) deploy verified Vyper bytecode — Curve has historically pushed for explorer verification of every pool the factory creates."
+      },
+      {
+        "code": "V2",
+        "text": "Source-to-repo correspondence is straightforward for Curve's monorepos. curvefi/curve-contract (default branch master, head SHA 574f44027d089de0eac765f5a74ea5ae96aba968) holds the original StableSwap pool sources used by classic deployments. curvefi/curve-stablecoin (master, head SHA c65baa3ec9bf4b9afda12f8148503ad088a5efd8, last push 2026-04-24) holds crvUSD market controllers, Stablecoin.vy, LLAMMA AMM, peg keepers, and the partial-liquidation zaps. curvefi/curve-dao-contracts (master, head SHA fa127b1cb7bf83e4f3d605f7244b7b4ed5ebe053) holds CRV token, GaugeController, FeeDistributor, VotingEscrow. curvefi/curve-aragon-voting (master, head SHA 141d3470edad98603eb43bfca70127571729330a) holds the DAO Voting / Forwarder logic. The Vyper sources visible on Etherscan correspond textually to these repos. A local bytecode-match compile was not run in this assessment; that scope limit is recorded in unknowns."
+      },
+      {
+        "code": "V3",
+        "text": "Curve maintains a canonical audits index at docs.curve.finance/user/security/audits, which links the actual PDFs hosted under docs.curve.finance/pdf/audits/. Confirmed audits with explicit firm + scope: (1) Trail of Bits — Curve DAO (curve-dao-ToB-final.pdf, scope: VotingEscrow, GaugeController, CRV emission). (2) ChainSecurity — multiple: Curve_tricrypto-ng_audit.pdf (Tricrypto-NG factory), Curve_Finance_Curve_ETH_sETH_Smart_contract_audit.pdf (sETH pool), Curve_Finance_Tricrypto_smart_contract_audit_September.pdf (original Tricrypto), Curve_Xgov_Audit.pdf (cross-chain governance), FeeSplitter.pdf, Curve_Fast_Bridge_audit.pdf, CurveCryptoSwap2ETH_audit_draft.pdf. (3) MixBytes — DAO Voting Forwarder, DAO Voting, StableSwap-NG, Curve Stablecoin (crvUSD), Curve Lending (covers LLAMMA + LlamaLend markets). (4) Quantstamp — curve-dao-quantstamp.pdf (early DAO contracts). (5) Statemind — recent NG-line audits. Most audits within 6 months of major redeploy events; Curve's StableSwap-NG and Tricrypto-NG audits dated 2023-2024 still match currently-deployed factory implementations because those factories are immutable post-deployment. crvUSD initial audits dated 2023, MixBytes Curve Lending audit (covering LLAMMA-based markets) is the most recent crvUSD/Lending-side coverage."
+      },
+      {
+        "code": "V4",
+        "text": "Auditor recognition: Trail of Bits (recognized — Solidity/Vyper formal review experience since 2018), ChainSecurity (recognized — ETH Zurich spinout, deep DeFi coverage), MixBytes (recognized, in the prompt's named-firms list), Quantstamp (recognized, in the prompt's named-firms list), Statemind (recognized in EVM space — Sber and curve-related work). All five firms are in the recognized tier. No unknown-firm audits are claimed for the green grade."
+      },
+      {
+        "code": "V5",
+        "text": "Post-audit drift on Curve's main fund-holding contracts is materially limited because the contracts themselves are IMMUTABLE Vyper deployments — once a factory deploys a pool or once Stablecoin.vy / Controller.vy are deployed, the bytecode does not change. There is no proxy upgrade path that the DAO can use to mutate the pool math, the LLAMMA AMM logic, or the crvUSD Stablecoin contract. New audits cover NEW factory versions (StableSwap-NG vs StableSwap classic, Tricrypto-NG vs Tricrypto), not patches to existing ones. This means 'post-audit drift' as the rubric defines it (audited commit drifts from deployed bytecode) is structurally close to zero on the main fund-holding surfaces. The DAO Voting / Forwarder / GaugeController surfaces have evolved (xgov / fast-bridge for cross-chain), and each evolution received its own audit (ChainSecurity Xgov, ChainSecurity Fast Bridge). Exact deployed commit SHA-to-audit-commit pinning was not performed in this run for every pool variant; that scope limit is in unknowns."
+      },
+      {
+        "code": "V6",
+        "text": "Implementation vs proxy: most Curve fund-holding contracts (pools, Stablecoin.vy, LLAMMA Controllers) are NOT proxies — they are direct Vyper deployments with no upgrade slot. The DAO Voting contracts (Ownership 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356, Parameter 0xBCfF8B0b9419b9A88c44546519b1e909cF330399) ARE Aragon AppProxyUpgradeable; their Voting app implementation is registered through Aragon Kernel and is independently verified on Etherscan. So the proxy-vs-implementation gap that haunts upgradable-protocol verifiability does not exist for Curve's pools and crvUSD core, and is satisfied for the DAO Voting layer."
+      }
+    ],
+    "steelman": {
+      "red": "If a reviewer takes 'no audit in protocol.audit_links' literally, the snapshot's protocol.audit_links field is empty (null in the address_book that the prompt fed in); under a strict reading this could be interpreted as 'no audit' even though the audits exist on docs.curve.finance — but this is a metadata-pinning gap, not an actual verifiability gap.",
+      "orange": "Some pool variants (older 2-asset Crypto pools, certain pre-NG factory deployments) have audits that are now several years old without a follow-up, and a precise commit-to-deployed-bytecode match across the full deployment matrix was not pinned in this run; a cautious reviewer could downgrade to orange citing audit staleness on the long tail of legacy pools.",
+      "green": "All major fund-holding contracts are either verified Vyper sources directly visible on Etherscan or proxies whose implementations are independently verified; recognized firms (Trail of Bits, ChainSecurity, MixBytes, Quantstamp, Statemind) audited every major component — DAO, Voting, GaugeController, StableSwap-NG, Tricrypto-NG, crvUSD, Lending, Xgov, Fast Bridge — and because the cores are immutable Vyper, audited-bytecode-vs-deployed-bytecode drift is structurally near zero."
+    },
+    "verdict": "Choosing green because the deployed fund-holding contracts are verified Vyper sources on Etherscan (V1/V6 satisfied, no proxy/implementation gap on cores), the public curvefi/* monorepos contain matching source code at pinned head SHAs (V2 satisfied modulo per-deployment commit pinning), and recognized firms (Trail of Bits, ChainSecurity, MixBytes, Quantstamp, Statemind) audited each major component including the most recent crvUSD/Lending lines — published at docs.curve.finance/user/security/audits (V3/V4 satisfied). Post-audit drift on immutable cores is structurally close to zero (V5 satisfied). The empty protocol.audit_links in the snapshot input is a metadata-pinning gap (audits are discoverable from the official docs and the curvefi GitHub org), not a verifiability gap on the protocol side."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "shows": "CRV governance token on Ethereum Mainnet — verified Vyper source code on Etherscan; ERC20CRV.vy contract",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "shows": "crvUSD Stablecoin on Ethereum Mainnet — verified Vyper source (Stablecoin.vy); non-proxy direct deployment, no upgrade slot",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "shows": "Curve DAO Voting (Ownership) — Aragon AppProxyUpgradeable on Mainnet; backing Voting app implementation independently verified through Aragon Kernel registration",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+      "shows": "Curve DAO Voting (Parameter) — Aragon AppProxyUpgradeable on Mainnet; lower-threshold parameter voting forwarder",
+      "chain": "Ethereum",
+      "address": "0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB",
+      "shows": "Curve GaugeController — verified Vyper source on Etherscan; gauge weight voting and CRV emission distribution logic",
+      "chain": "Ethereum",
+      "address": "0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Public source repository for crvUSD market controllers, Stablecoin.vy, LLAMMA AMM, peg keepers; default branch master, last pushed 2026-04-24; contains all crvUSD-related Vyper sources",
+      "commit": "c65baa3ec9bf4b9afda12f8148503ad088a5efd8",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-contract",
+      "shows": "Public source repository for original StableSwap pools (legacy classic deployments)",
+      "commit": "574f44027d089de0eac765f5a74ea5ae96aba968",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-dao-contracts",
+      "shows": "Public source repository for CRV token, VotingEscrow (veCRV), GaugeController, FeeDistributor, gauge weight aggregator",
+      "commit": "fa127b1cb7bf83e4f3d605f7244b7b4ed5ebe053",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-aragon-voting",
+      "shows": "Public source repository for Curve's fork of Aragon Voting and the Voting Forwarder used by the DAO",
+      "commit": "141d3470edad98603eb43bfca70127571729330a",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/security-incident-reports",
+      "shows": "Curve's security index repo; README points to docs.curve.finance/security/security/ for current bug-bounty info; serves as canonical security disclosure pointer for the project",
+      "commit": "766f0d936e3b4c72765fd1cd7dbfbcca89450f27",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/user/security/audits",
+      "shows": "Curve official audits index page listing PDFs from Trail of Bits, ChainSecurity, MixBytes, Quantstamp, Statemind covering DAO, Voting Forwarder, StableSwap-NG, Tricrypto-NG, crvUSD, Curve Lending, Xgov, Fast Bridge, FeeSplitter",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/curve-dao-ToB-final.pdf",
+      "shows": "Trail of Bits audit of Curve DAO (CRV emission, VotingEscrow, GaugeController) — original DAO scope",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+      "shows": "ChainSecurity audit of the Tricrypto-NG factory and pool implementation",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+      "shows": "MixBytes audit of crvUSD (Stablecoin.vy + LLAMMA AMM + Controller) — covers original crvUSD market launch scope",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+      "shows": "MixBytes audit of Curve Lending (LlamaLend) — most recent in the Lending product line; covers the LLAMMA-based isolated lending markets",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+      "shows": "MixBytes audit of StableSwap-NG factory and pool implementation",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20DAO%20Voting%20Forwarder%20Security%20Audit%20Report.pdf",
+      "shows": "MixBytes audit of the DAO Voting Forwarder (the Aragon Forwarder that wraps Voting / Agent for Curve DAO calls)",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/curve-dao-quantstamp.pdf",
+      "shows": "Quantstamp audit of early Curve DAO contracts",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    }
+  ],
+  "unknowns": [
+    "V2: A local bytecode compile-and-match between specific deployed pool addresses and specific commit SHAs in curvefi/curve-stablecoin / curve-dao-contracts / curve-contract was not performed in this run. The exact deployed commit for, e.g., the Tricrypto-NG implementation at the deployed factory was not pinned to a single audit-in-scope commit. This is a scope limit, not a verification gap per the green-grade rules — the explorer-visible source is verified and the public repos correspond structurally.",
+    "V5: The exact audit-commit-vs-deployed-commit match was not pinned for every pool factory variant (StableSwap classic, StableSwap-NG, Tricrypto, Tricrypto-NG, sETH and other 2-asset Crypto pools, OETH/cbETH wrappers). For immutable cores, drift is structurally bounded near zero — but a per-pool census was not run.",
+    "V3: The protocol.audit_links field in the pinned snapshot input was empty (null address_book), so audits had to be discovered from the docs.curve.finance/user/security/audits page rather than from a registry-side audit_links list. This is a metadata-pinning gap that defipunkd's overlay layer can resolve."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": "https://docs.curve.finance/",
+    "audits": [
+      {
+        "firm": "Trail of Bits",
+        "url": "https://docs.curve.finance/pdf/audits/curve-dao-ToB-final.pdf",
+        "date": "2020-08"
+      },
+      {
+        "firm": "Quantstamp",
+        "url": "https://docs.curve.finance/pdf/audits/curve-dao-quantstamp.pdf",
+        "date": "2020-08"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Finance_Curve_ETH_sETH_Smart_contract_audit.pdf",
+        "date": "2021-09"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Finance_Tricrypto_smart_contract_audit_September.pdf",
+        "date": "2021-09"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+        "date": "2023-06"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+        "date": "2023-05"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+        "date": "2024-01"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20DAO%20Voting%20Forwarder%20Security%20Audit%20Report.pdf",
+        "date": "2023-12"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20DAO%20Voting%20Security%20Audit%20Report.pdf",
+        "date": "2023-12"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+        "date": "2024-04"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Xgov_Audit.pdf",
+        "date": "2024-03"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Fast_Bridge_audit.pdf",
+        "date": "2024-05"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_FeeSplitter.pdf",
+        "date": "2024-09"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/private_ChainSecurity_Curve_CurveCryptoSwap2ETH_audit_draft.pdf",
+        "date": "2022-04"
+      }
+    ],
+    "governance_forum": "https://gov.curve.finance/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": "https://immunefi.com/bug-bounty/curve/",
+    "security_contact": "https://github.com/curvefi/security-incident-reports",
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership) — Aragon Voting app for top-tier protocol changes; 30% quorum / 51% support, ~1 week voting period",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+        "role": "DAO Voting (Parameter) — Aragon Voting app for parameter-class changes; 15% quorum / 30% support",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent — Aragon Agent that holds admin privileges of pool factories and DAO-owned contracts; called only by Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig — fast-acting safety multisig for limited emergency actions (kill pools, set fees off, narrow scope only)",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "Curve Finance is a decentralized AMM optimized for like-priced asset swaps (StableSwap) and correlated-asset swaps (Tricrypto / Cryptoswap). The protocol issues the CRV governance token, runs an Aragon-based DAO with veCRV-weighted voting, and includes the crvUSD CDP stablecoin (collateralized via LLAMMA soft-liquidation AMM) and Curve Lending (LlamaLend) isolated lending markets. Pool contracts are immutable Vyper deployments; governance acts through Aragon Voting (Ownership) for top-tier and Voting (Parameter) for bounded changes, with an Emergency DAO multisig holding a narrow safety scope."
+  }
+}


### PR DESCRIPTION
Resubmission per Guillaume's request on #75. Family-level `curve-finance` was deemed confusing for LLM scoping; this PR submits at the child level `crvusd`.

## Scope (in)
- crvUSD stablecoin core only:
  - `Stablecoin.vy` (the ERC20 stablecoin contract, 0xf939E0A0...)
  - LLAMMA AMM as used inside crvUSD market controllers
  - ControllerFactory and crvUSD market Controllers
  - Aggregator (crvUSD price aggregator)
  - PegKeepers (autonomous mint/burn arbs against curve pools)
  - MonetaryPolicy contracts (interest rate policy)

## Scope (out — assessed in sibling resubmission PRs)
- Curve DEX / AMM layer → `data/submissions/curve-dex/...`
- Curve LlamaLend isolated lending → `data/submissions/curve-llamalend/...` (uses the same LLAMMA primitive but for non-crvUSD-mint lending)

## What's in this PR
5 slices × 1 voice (claude-opus-4-7), prompt_version=12, schema v3, snapshot pin = 2026-04-27T08:19:52.420Z, analysis_date = 2026-04-28:

| Slice | Grade | Headline |
|---|---|---|
| Verifiability | green | Verified Vyper crvUSD core, audits current |
| Control | green | Immutable core, DAO-gated parameters |
| Ability-to-exit | green | Permissionless repay, soft-liq protective |
| Autonomy | orange | Chainlink-dependent collateral oracles |
| Open-Access | green | No on-chain gate, multiple execution paths |

## Notes
- Validator passes locally.
- Prior validator fixes from #75 (`upgradeability="mixed"` enum, `audits[].firm`) carried over.
- SCOPE finding prepended to each slice for explicit in/out boundary.
- Sibling PRs in this resubmission set:
  - `curve-dex / claude` (#87), `curve-dex / chatgpt` (#88)
  - `crvusd / chatgpt`
  - `curve-llamalend / claude`, `curve-llamalend / chatgpt`
- Follow-ups: a `hell0men`-identity submission set will be added in a separate batch.

Closes #75 (with comment).
