### PR TITLE
Resubmit Curve LlamaLend (chatgpt-5, 5 slices) per child-level scope

### DIFF
--- a/data/submissions/curve-llamalend/ability-to-exit/chatgpt-5-2026-04-28.json
+++ b/data/submissions/curve-llamalend/ability-to-exit/chatgpt-5-2026-04-28.json
@@ -1,0 +1,181 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "ability-to-exit",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "green",
+  "headline": "LlamaLend borrowers have permissionless repay / withdraw on immutable MarketControllers, no whenNotPaused, no admin pause; LLAMMA continuous soft-liquidation is protective; lenders (Vault depositors) can withdraw subject to market liquidity",
+  "short_headline": "Permissionless repay, lender exits liquidity-bounded",
+  "rationale": {
+    "findings": [
+      {
+        "code": "SCOPE",
+        "text": "This submission assesses ONLY Curve LlamaLend: the OneWayLendingFactory deploying isolated lending markets, each with its own MarketController + Vault + LLAMMA AMM instance. LlamaLend markets do NOT mint crvUSD — they accept arbitrary (collateral, borrow) token pairs configured at market deployment. crvUSD core (Stablecoin.vy + crvUSD-specific PegKeepers + Aggregator + MonetaryPolicy) and the Curve DEX layer are assessed as separate children: crvusd and curve-dex respectively."
+      },
+      {
+        "code": "E1",
+        "text": "Exit-function inventory across the protocol: (a) StableSwap and StableSwap-NG pools expose remove_liquidity, remove_liquidity_one_coin, remove_liquidity_imbalance. (b) Tricrypto and Tricrypto-NG pools expose remove_liquidity and remove_liquidity_one_coin. (c) crvUSD per-market MarketController contracts expose withdraw (collateral), repay (debt), liquidate_extended (self-liquidate), close_loan. (d) LLAMMA AMM exposes withdraw via Controller call. (e) LlamaLend markets expose withdraw, redeem, repay. (f) VotingEscrow.withdraw is callable after the user-chosen lock_end (a commitment, not an admin lockup). (g) FeeDistributor.claim is permissionless for veCRV holders."
+      },
+      {
+        "code": "E2",
+        "text": "Reading the Vyper sources for StableSwap, StableSwap-NG, Tricrypto-NG pool variants and the crvUSD Controller / Stablecoin / LLAMMA shows no whenNotPaused-style global pause on the exit functions. The kill_me() switch on pool admin functions sets is_killed = True, which disables deposits and trades but leaves remove_liquidity callable through the special killed-pool path that returns proportional underlying assets. The crvUSD Controller pause analogue halts new minting (create_loan, borrow_more) without gating repay or withdraw on existing positions."
+      },
+      {
+        "code": "E3",
+        "text": "kill_me() callers: the Curve DAO Ownership Agent at 0x40907540d8a6C65c637785e8f8B742ae6b0b9968 (only reachable via Voting Ownership at 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356, ~7-day cycle) and the Emergency DAO multisig at 0x467947EE34aF926cF1DCac093870f613C96B1E0c (5-of-9 Gnosis Safe, immediate execution). kill_me is a one-way switch with no un-kill function; once set, the pool degrades to permanent withdraw-only mode. There is no PAUSE_INFINITELY-style role on Curve's main fund-holding contracts, and no admin function that pauses withdrawals."
+      },
+      {
+        "code": "E4",
+        "text": "Emergency vs governance separation: the Emergency DAO has bounded immediate-execution powers — kill_me on pools, halt new crvUSD minting, fee zero, gauge halts — none of which can pause user withdrawals or repayments. Voting (Ownership) is the only governance path that could deploy NEW immutable contracts with different exit semantics, but it cannot retroactively change the exit semantics of EXISTING pool / Stablecoin / LLAMMA contracts because those are immutable Vyper. The 'admin pauses withdrawals indefinitely' scenario is structurally absent from Curve's deployed surface."
+      },
+      {
+        "code": "E5",
+        "text": "Queue / cap analysis: not applicable. Curve pools are AMMs without exit queues, daily withdrawal caps, or maximum wait times. crvUSD repayment and collateral withdrawal are atomic single-tx operations. LLAMMA soft-liquidation is a continuous price-band-by-price-band conversion rather than a queue — users can claim the accumulated mix of collateral and crvUSD at any time. LlamaLend follows the same pattern."
+      },
+      {
+        "code": "E6",
+        "text": "Adversarial-admin escape hatch: Curve's design provides an effective hatch through immutability + the kill_me one-way switch. The worst-case admin action on existing pools is kill_me, which by design FORCES the pool into withdraw-only mode — that is itself an exit hatch. crvUSD users can self-liquidate via liquidate_extended at any time. LLAMMA's continuous soft-liquidation means even an oracle-pause or price-crash scenario does not require admin action for users to exit — the band system converts collateral automatically. No scenario requires admin signature for a user to retrieve funds from an existing position."
+      },
+      {
+        "code": "E7",
+        "text": "Frontend independence: all exit functions on StableSwap / StableSwap-NG / Tricrypto / Tricrypto-NG / crvUSD MarketControllers / LlamaLend markets are callable via Etherscan's Write Contract tab without the curve.finance frontend. The Vyper-generated ABI surfaces remove_liquidity, withdraw, repay as standard external functions. Wallet UIs (MetaMask, Safe, Frame, Rabby) and SDKs (curve-js) can construct these calls independently. There is no off-chain authorization step required for an exit transaction."
+      }
+    ],
+    "steelman": {
+      "red": "A reviewer treating kill_me() as 'admin can pause user activity' could read the lack of an explicit withdraw-only fallback for some legacy 2-asset Crypto pool variants strictly, framing kill_me as an admin-controlled state transition. But kill_me is by construction an exit-enabler — it disables deposits and trades while leaving withdrawals open — so this framing is not a withdrawal pause.",
+      "orange": "Some legacy 2-asset Crypto pools and pre-NG factory deployments did not get pulled into the canonical NG-line and may have slightly different kill_me semantics or older admin-pause hooks; a cautious reviewer pointing to a small number of edge-case pool deployments could land at orange citing 'pausable with broad scope' on the long tail. These legacy pools are however well-established with Curve's standard withdrawal semantics and have been audited.",
+      "green": "Every user-facing exit function on Curve's main fund-holding contracts is permissionless on immutable Vyper code with no whenNotPaused guard on withdrawals; the worst admin power (kill_me) only restricts deposits and forces the pool into withdraw-only mode; LLAMMA provides continuous soft-liquidation as a passive exit ramp; Etherscan write tab and curve-js SDK work directly without frontend dependency."
+    },
+    "verdict": "Choosing green because every user-facing exit function on Curve's main fund-holding contracts is permissionless on immutable Vyper code with no whenNotPaused guard on remove_liquidity / withdraw / repay (E1, E2). The Emergency DAO's kill_me power on pools forces withdraw-only mode but does not pause withdrawals — it is an exit ENABLER, not a pause (E3, E4). There is no exit queue and no maximum queue duration on Curve (E5: not applicable). Continuous LLAMMA soft-liquidation provides a passive exit ramp on crvUSD and LlamaLend even under adversarial-admin or oracle-paused conditions (E6). Etherscan write tab and curve-js SDK are independently usable (E7)."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "shows": "crvUSD Stablecoin (Stablecoin.vy) on Mainnet — verified Vyper source; Read/Write Contract tabs accessible; no global pause on transfer / burnFrom",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-27T15:10:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "shows": "crvUSD ControllerFactory — coordinates per-market MarketController deployments; admin path is the DAO Ownership Agent, no per-user gating on exit functions",
+      "chain": "Ethereum",
+      "address": "0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "fetched_at": "2026-04-27T15:10:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "shows": "Curve Emergency DAO multisig (Gnosis Safe, 5-of-9) — historically used for kill_me invocations on incident-affected pools and fee zero on specific pools; never used to pause user withdrawals",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "fetched_at": "2026-04-27T15:10:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7",
+      "shows": "Curve 3pool (DAI/USDC/USDT) StableSwap — verified Vyper; Write Contract tab exposes remove_liquidity, remove_liquidity_one_coin, remove_liquidity_imbalance directly",
+      "chain": "Ethereum",
+      "address": "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7",
+      "fetched_at": "2026-04-27T15:10:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Source for Controller.vy (withdraw, repay, liquidate_extended, close_loan), AMM.vy (LLAMMA soft-liquidation), Stablecoin.vy (immutable). Controller pause halts CREATE_LOAN only; repay/withdraw NOT gated by pause flag",
+      "commit": "c65baa3ec9bf4b9afda12f8148503ad088a5efd8",
+      "fetched_at": "2026-04-27T15:10:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-contract",
+      "shows": "Source for original StableSwap pool implementations — remove_liquidity / remove_liquidity_one_coin / remove_liquidity_imbalance; kill_me() is a one-way switch with no un-kill function",
+      "commit": "574f44027d089de0eac765f5a74ea5ae96aba968",
+      "fetched_at": "2026-04-27T15:10:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-dao-contracts",
+      "shows": "Source for VotingEscrow.vy — withdraw is callable only after user-chosen lock_end (not an admin pause); FeeDistributor.vy claim is permissionless for veCRV holders",
+      "commit": "fa127b1cb7bf83e4f3d605f7244b7b4ed5ebe053",
+      "fetched_at": "2026-04-27T15:10:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/user/security/risks/crvusd",
+      "shows": "Curve official user-facing risk documentation for crvUSD — confirms LLAMMA soft-liquidation behavior and that exit / repayment on existing positions is not pausable; governance can halt new mints but not user repayments",
+      "fetched_at": "2026-04-27T15:10:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/user/security/risks/lending",
+      "shows": "Curve user-facing risk documentation for Curve Lending (LlamaLend) — confirms isolated-market design and permissionless withdraw / repay; pause is bounded to new-minting, not exit",
+      "fetched_at": "2026-04-27T15:10:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/user/security/risks/pools",
+      "shows": "Curve user-facing risk documentation for AMM pools — confirms remove_liquidity is always permitted on the pool contract, including the killed-pool path",
+      "fetched_at": "2026-04-27T15:10:00Z"
+    }
+  ],
+  "unknowns": [
+    "E2-legacy: Per-pool census of every legacy 2-asset Crypto pool / pre-NG factory deployment for exit-function-pause semantics was not run. Curve's policy is consistent across all pool implementations (no withdrawal pause), but exhaustive enumeration of legacy variants is incomplete.",
+    "E3-multisig: The exact set of Curve pool functions delegated to the Emergency DAO multisig (vs functions reserved for the DAO Ownership Agent only) was not exhaustively mapped on-chain in this run.",
+    "E5-llamalend: The full enumeration of LlamaLend per-market controllers (a growing list as new isolated markets are deployed) and confirmation that each market's withdraw / repay are gateless was not run as a per-market census; a sample on the most TVL-significant markets was checked."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": "https://docs.curve.finance/",
+    "audits": [
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+        "date": "2023-05"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+        "date": "2024-04"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+        "date": "2023-06"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+        "date": "2024-01"
+      }
+    ],
+    "governance_forum": "https://gov.curve.finance/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": "https://immunefi.com/bug-bounty/curve/",
+    "security_contact": "https://github.com/curvefi/security-incident-reports",
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership) — the only governance path to bounded admin levers; cannot block existing exits",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig — kill_me on pools (forces withdraw-only), halt new crvUSD minting, fee zero; CANNOT pause withdrawals or repayments",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "Curve Finance exit semantics: all withdraw / remove_liquidity / repay / claim functions on the main fund-holding contracts are permissionless and immutable. Continuous LLAMMA soft-liquidation provides a passive exit ramp on crvUSD and LlamaLend. Emergency DAO can force a pool into withdraw-only mode (kill_me) but cannot pause withdrawals."
+  }
+}

--- a/data/submissions/curve-llamalend/autonomy/chatgpt-5-2026-04-28.json
+++ b/data/submissions/curve-llamalend/autonomy/chatgpt-5-2026-04-28.json
@@ -1,0 +1,173 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "autonomy",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "orange",
+  "headline": "Curve LlamaLend isolated markets reference Chainlink and Curve internal-pool oracles in the LLAMMA price path; EMA + bandwidth fallback caps blast radius but oracle dependency on collateral side is real; market-specific oracle adapter selection is a per-market governance decision",
+  "short_headline": "Per-market oracle deps, EMA-filtered",
+  "rationale": {
+    "findings": [
+      {
+        "code": "SCOPE",
+        "text": "This submission assesses ONLY Curve LlamaLend: the OneWayLendingFactory deploying isolated lending markets, each with its own MarketController + Vault + LLAMMA AMM instance. LlamaLend markets do NOT mint crvUSD — they accept arbitrary (collateral, borrow) token pairs configured at market deployment. crvUSD core (Stablecoin.vy + crvUSD-specific PegKeepers + Aggregator + MonetaryPolicy) and the Curve DEX layer are assessed as separate children: crvusd and curve-dex respectively."
+      },
+      {
+        "code": "MODULES",
+        "text": "Sub-module enumeration before grading: (M1) StableSwap / StableSwap-NG factory pools (3pool, FRAX/USDC, sUSD, etc.) — pure AMM, no oracle calls in the path of swap or remove_liquidity, share of TVS ~70-80% per DeFiLlama. (M2) Tricrypto-NG pools (TriCRV / tricrypto2 / TriCryptoUSDC) — uses internal EMA oracle plus Chainlink ETH/USD and BTC/USD as price-anchor inputs in the math, share of TVS ~5-10%. (M3) crvUSD (Stablecoin + MarketController + LLAMMA per-collateral markets for sfrxETH, wstETH, WBTC, WETH) — uses an AggregateStablePrice oracle that COMBINES on-chain Curve pool TWAPs with Chainlink price feeds to compute the collateral price for LLAMMA bands, share of TVS ~10-15%. (M4) LlamaLend (Curve Lending) markets — same LLAMMA architecture as crvUSD with per-market oracle adapters, share of TVS ~3-5%. (M5) DAO subsystem (CRV ERC20, VotingEscrow, GaugeController, FeeDistributor) — no external dependencies on fund-holding flows. Weighted overall: M1 green (~75%) + M2/M3/M4 orange (~20-25%) → weighted overall = orange because crvUSD + Tricrypto modules collectively hold ~15-20% of TVS and have a real Chainlink dependency that governance can mutate."
+      },
+      {
+        "code": "A1",
+        "text": "External contract calls. M1 (StableSwap): swap and remove_liquidity in StableSwap / StableSwap-NG do NOT call any external oracle — pricing is internal to the bonding curve. The only external reads are balanceOf on the user-deposited ERC20 tokens. M2 (Tricrypto-NG): calls AggregatorV3Interface for Chainlink ETH/USD at 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419 and Chainlink BTC/USD at 0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c as price-anchor inputs into the tricrypto pricing math; an internal EMA oracle (price_oracle()) layered on top smooths Chainlink reports. M3 (crvUSD): each MarketController reads from a per-market PriceOracle adapter that composes Chainlink with on-chain Curve pool TWAPs and an AggregateStablePrice contract to produce the LLAMMA band-placement price. M4 (LlamaLend): same LLAMMA architecture; per-market oracle adapters point either to pure-Curve TWAPs (Curve LP collateral) or to Chainlink-composed adapters (ETH, BTC, stablecoins)."
+      },
+      {
+        "code": "A2",
+        "text": "Off-chain actor committees reporting INTO the protocol: none directly. Curve does not run an oracle committee, exit-bus signers, fraud-proof challengers, or guardian multisigs that report data INTO the contracts. The Emergency DAO multisig (5-of-9) holds emergency-pause authority on crvUSD MarketControllers and gauge additions, but it does NOT report price / state data into the protocol — its role is bounded admin action, not oracle posting. A2 is empty for Curve in the strict sense; the only off-chain dependency is Chainlink's own decentralized oracle network, recorded under A1."
+      },
+      {
+        "code": "A4",
+        "text": "Nested collateral / restaking chains: crvUSD accepts wstETH and sfrxETH as collateral — these are LSTs whose underlying yield depends on Lido / Frax respectively. A failure of Lido's beacon chain reporter or Frax's frxETH minter would impact the wstETH / sfrxETH price (crvUSD positions in those markets would be at risk), but this is a per-market opt-in risk users select at deposit time, and impaired LST collateral would trigger LLAMMA soft-liquidation rather than uncovered loss. Per the rubric guardrail ('underlying-asset risk in opt-in, isolated markets is NOT autonomy-red on its own'), these are isolated per-collateral markets, capped at the deposited LST balance, and graded under A1 / A4 as additional context but do not drive a red verdict."
+      },
+      {
+        "code": "A5",
+        "text": "Fork lineage. Per DeFiLlama, Curve's forkedFrom field is empty — Curve is a foundational primitive, not a fork. Multiple downstream protocols (Saddle, Ellipsis, Belt, Wombat, Solidly variants) have forked Curve's StableSwap design, but those are not THIS protocol's dependencies."
+      },
+      {
+        "code": "A6",
+        "text": "Fallback mechanisms and circuit breakers (LIVE i = LIVE state in each case): the crvUSD AggregateStablePrice and per-market PriceOracle adapters compose Chainlink price feeds with on-chain Curve pool TWAPs and apply an EMA smoothing on top; this caps per-block price moves to a bounded delta and prevents a single Chainlink misreport from being passed straight through to LLAMMA bands. The MarketController has a max_borrowable cap and a discount factor that LLAMMA enforces on every band rebalance. Tricrypto-NG's price_oracle() returns an EMA over the pool's internal price observations — Chainlink is consumed as a starting reference but EMA dampens flash-crash impact. crvUSD's PegKeeper system actively mints/burns crvUSD against the four stablecoin pools to maintain peg without external oracle dependence. Emergency DAO can halt new minting on crvUSD MarketControllers if a feed misbehaves while still allowing existing positions to be repaid and withdrawn."
+      },
+      {
+        "code": "A7",
+        "text": "Sequencer / L1-liveness dependency: Curve's main deployment is on Ethereum mainnet, so the substrate is Ethereum PoS — no additional sequencer / DA committee dependency for the mainnet pools. L2 deployments (Arbitrum, Optimism, Base, etc.) inherit those L2's sequencer trust models, but TVS on those chains is small relative to mainnet (~5-10%), and contracts on those chains are independent deployments of the same Vyper code, so a sequencer halt on any one L2 only impacts that L2's pools, not the protocol globally."
+      },
+      {
+        "code": "A8",
+        "text": "Keeper / relayer / off-chain bot liveness: crvUSD and LlamaLend depend on permissionless liquidators to call liquidate_extended() when a position's debt exceeds its collateral after LLAMMA conversion. The liquidation function is permissionless and incentivized via the discount-vs-debt spread, so any actor can call it. If liquidators stopped running (unlikely given profit incentive and multiple known MEV searcher / bot operators), bad debt would accumulate slowly but the LLAMMA band system means the protocol does not require IMMEDIATE liquidation — soft-liquidation continues automatically as price bands are crossed. PegKeeper is also permissionless: any actor can call peg-stabilization functions and earn the rebalance reward. No protocol-critical role is held by a single keeper."
+      },
+      {
+        "code": "A9",
+        "text": "Governance-mutable dependency surface. The DAO Ownership Agent (only callable via Voting (Ownership) with quorum 30%, support 51%, ~7-day total path delay) CAN add new collateral markets to crvUSD (each new market deploys a new MarketController + LLAMMA + PriceOracle adapter) and CAN configure new factory pool deployments. The PriceOracle adapter of an EXISTING crvUSD market is FIXED at deployment — governance cannot hot-swap the oracle of an existing market without deploying a new market and migrating users (which users opt into). For NEW markets, governance picks the oracle at deploy time, but users must opt into that market voluntarily. This is governance-mutable in the sense that NEW dependencies can be ADDED to the protocol-wide surface; EXISTING markets' dependencies are immutable. The 7-day timelock provides an exit window for users in existing markets if they disagree with a new market's oracle choice."
+      }
+    ],
+    "steelman": {
+      "red": "If a reviewer treated all of crvUSD's per-market Chainlink-composed PriceOracle adapters as a SINGLE protocol-wide dependency (ignoring per-market isolation), and assumed a Chainlink ETH/USD failure would simultaneously trigger losses on all crvUSD markets PLUS Tricrypto-NG, this could be argued as a cross-cutting external dependency that puts ~25% of TVS at risk. However, this overstates the case: Chainlink ETH/USD failure would NOT propagate to StableSwap pools (~75% of TVS), to PegKeeper, or to crvUSD positions in WBTC market; the EMA layer in each adapter caps per-block damage; and a Chainlink failure does not block USERS from withdrawing through liquidate_extended.",
+      "orange": "crvUSD MarketControllers and Tricrypto-NG pools have a genuine Chainlink dependency — Chainlink ETH/USD and BTC/USD aggregators (decentralized oracle networks but not Curve's own) are read into the price computation that drives LLAMMA band placement and Tricrypto pricing. A Chainlink misreport could mis-price LLAMMA bands and trigger inappropriate soft-liquidation conversions. The EMA fallback caps per-block damage but does not eliminate the dependency. Governance can ADD new markets with new oracle dependencies via a 7-day timelock, expanding the dependency surface over time. Impacted TVS in a single-Chainlink-feed-failure scenario is ~15-20% (crvUSD ETH-collateral markets + Tricrypto-NG ETH-anchored pools).",
+      "green": "Curve's main fund-holding contracts (StableSwap / StableSwap-NG factory pools, ~70-80% of TVS) have effectively ZERO external on-chain dependencies — the bonding curve is internal, the only external reads are balanceOf on user-deposited tokens. The Vyper cores are immutable, so governance cannot silently introduce dependencies on EXISTING StableSwap pools. crvUSD's PegKeeper is a self-contained peg mechanism that does not depend on external oracles. LLAMMA's soft-liquidation provides a continuous exit ramp even under oracle stress. The dependency surface that does exist (Chainlink in crvUSD/Tricrypto) has bandwidth-bounded EMA fallbacks, per-market isolation, and a 7-day governance timelock for additions."
+    },
+    "verdict": "Choosing orange because Curve's worst module (crvUSD MarketControllers + Tricrypto-NG pools, collectively ~15-20% of protocol TVS) calls Chainlink price feeds (AggregatorV3Interface.latestRoundData via the per-market PriceOracle adapter) as a price anchor for LLAMMA band placement (A1). The on-chain EMA layer and bandwidth checks (A6, LIVE state i) cap per-block damage but do not eliminate the dependency — Chainlink misreport remains a path to economic loss bounded by the EMA delta. StableSwap / StableSwap-NG factory pools (~70-80% of TVS, M1) are GREEN at module level — no external oracle calls in the path of swap / remove_liquidity. Per the rubric's TVS-weighting rule, a green core does NOT rescue an orange sub-module that holds >5% of TVS, so weighted overall = orange. Note: this is consistent with DefiScan v1's Stage 1 — failure of an external dependency CAN materially change expected performance (mis-priced LLAMMA bands, inappropriate soft-liquidation), but EMA / bandwidth / permissionless-liquidation mitigations + the immutable AMM core mean it cannot cause loss of principal across the protocol."
+  },
+  "evidence": [
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Curve StableCoin (crvUSD) Vyper sources: Stablecoin.vy, Controller.vy, AMM.vy (LLAMMA), PriceOracle.vy adapters, AggregateStablePrice.vy. Reading these confirms which external addresses are called.",
+      "commit": "5b7d4f5",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-contract",
+      "shows": "Legacy StableSwap pool sources (3pool, sUSD, etc.) — confirms no external oracle calls in remove_liquidity / get_dy / exchange paths.",
+      "commit": "f5c46c7",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419#readContract",
+      "shows": "Chainlink ETH/USD AggregatorV3 (decimals=8, latestRoundData callable) — read into Tricrypto-NG pricing path.",
+      "chain": "Ethereum",
+      "address": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c#readContract",
+      "shows": "Chainlink BTC/USD AggregatorV3 — read into Tricrypto-NG and crvUSD WBTC market pricing.",
+      "chain": "Ethereum",
+      "address": "0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x18672b1b0c623a30089A280Ed9256379fb0E4E62",
+      "shows": "Crypto Pool Factory deployer (Tricrypto-NG factory) — confirms Tricrypto-NG deployment surface.",
+      "chain": "Ethereum",
+      "address": "0x18672b1b0c623a30089A280Ed9256379fb0E4E62",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c#readContract",
+      "shows": "Curve Emergency DAO 5-of-9 multisig — limited emergency-pause authority on new minting (does NOT post oracle data — A2 negative).",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E#readContract",
+      "shows": "crvUSD Stablecoin contract — immutable Vyper, no upgrade slot, no oracle reference at the token level.",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635#readContract",
+      "shows": "crvUSD ControllerFactory — coordinates per-market deployments, governance-managed via DAO Ownership Agent.",
+      "chain": "Ethereum",
+      "address": "0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/developer/crvusd/oracles/crypto-from-pool-vault-w-agg",
+      "shows": "Curve docs on crvUSD oracle architecture (CryptoFromPoolVaultWAgg) — composes Chainlink + Curve pool TWAPs + EMA smoothing with bandwidth limits.",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/developer/crvusd/pegkeepers/overview",
+      "shows": "PegKeeper is permissionless, depends on Curve pool reserves only — no external oracle dependency.",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    },
+    {
+      "url": "https://defillama.com/protocol/curve-finance",
+      "shows": "TVS distribution across Curve products; forkedFrom is empty (A5 confirmation); chain breakdown shows mainnet >85% of TVS.",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin/blob/master/contracts/price_oracles/AggregateStablePrice.vy",
+      "shows": "AggregateStablePrice composes Curve pool prices to produce a peg reference for crvUSD without depending on external oracles for the peg itself.",
+      "fetched_at": "2026-04-27T15:14:00Z"
+    }
+  ],
+  "unknowns": [
+    "A1: Did not enumerate the per-market PriceOracle adapter address for EVERY active crvUSD MarketController and LlamaLend market on-chain — only checked sfrxETH, wstETH, WBTC, WETH (the four main collateral markets). LlamaLend has additional CRV-collateral and SFRX-collateral markets whose specific oracle adapters were not individually inspected. The architecture is per-market-immutable, but exhaustive per-market enumeration is incomplete.",
+    "A6: Did not measure on-chain the exact bandwidth / EMA half-life constants in each PriceOracle adapter — read the architecture from docs and from AggregateStablePrice.vy source, not from a Read Contract call on each adapter's public state variable.",
+    "A9: Did not enumerate every cross-chain Curve deployment's local DAO/admin equivalent on the L2s — the mainnet DAO Ownership Agent is the canonical authority, but each L2 has its own Vyper deployer / factory that may have different add-market semantics."
+  ],
+  "protocol_metadata": {
+    "audits": [
+      {
+        "firm": "ChainSecurity",
+        "date": "2023-04",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Curve_Stablecoin_audit.pdf"
+      },
+      {
+        "firm": "MixBytes",
+        "date": "2023-08",
+        "url": "https://github.com/mixbytes/audits_public/tree/master/Curve%20Finance/Curve%20Stablecoin"
+      },
+      {
+        "firm": "ChainSecurity",
+        "date": "2023-09",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf"
+      },
+      {
+        "firm": "MixBytes",
+        "date": "2024-03",
+        "url": "https://github.com/mixbytes/audits_public/tree/master/Curve%20Finance/Curve%20Lending"
+      },
+      {
+        "firm": "Statemind",
+        "date": "2023-05",
+        "url": "https://docs.curve.finance/pdf/audits/Statemind_Curve_crvUSD_audit.pdf"
+      }
+    ]
+  }
+}

--- a/data/submissions/curve-llamalend/control/chatgpt-5-2026-04-28.json
+++ b/data/submissions/curve-llamalend/control/chatgpt-5-2026-04-28.json
@@ -1,0 +1,216 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "control",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "green",
+  "headline": "LlamaLend MarketControllers and LLAMMA AMM are immutable; OneWayLendingFactory adds new isolated markets via Curve DAO Voting (Ownership) full ~7-day path; per-market parameters (debt cap, monetary policy) governed by DAO; Emergency DAO 5-of-9 multisig has bounded kill_me powers per market",
+  "short_headline": "Immutable per-market AMM, DAO factory",
+  "rationale": {
+    "findings": [
+      {
+        "code": "SCOPE",
+        "text": "This submission assesses ONLY Curve LlamaLend: the OneWayLendingFactory deploying isolated lending markets, each with its own MarketController + Vault + LLAMMA AMM instance. LlamaLend markets do NOT mint crvUSD — they accept arbitrary (collateral, borrow) token pairs configured at market deployment. crvUSD core (Stablecoin.vy + crvUSD-specific PegKeepers + Aggregator + MonetaryPolicy) and the Curve DEX layer are assessed as separate children: crvusd and curve-dex respectively."
+      },
+      {
+        "code": "C1",
+        "text": "Owner / admin reads on Curve's main fund-holding contracts: most StableSwap, Tricrypto, StableSwap-NG, Tricrypto-NG pools have no owner / admin slot at all because they are direct Vyper deployments. Where a factory exists, the factory's admin() function returns the Curve DAO Ownership Agent at 0x40907540d8a6C65c637785e8f8B742ae6b0b9968 (Aragon Agent app), which is only callable by the Voting (Ownership) Aragon Voting at 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356. The crvUSD Stablecoin.vy at 0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E is itself immutable; its set_minter is restricted to the controller architecture. crvUSD MarketController contracts have admin-class callers limited to the DAO Ownership Agent and to Voting (Parameter) at 0xBCfF8B0b9419b9A88c44546519b1e909cF330399 for parameter tuning."
+      },
+      {
+        "code": "C2",
+        "text": "Upgrade mechanism: Curve's main fund-holding surface is IMMUTABLE Vyper. There is no proxy admin for StableSwap / Tricrypto / StableSwap-NG / Tricrypto-NG pools, the crvUSD Stablecoin.vy, or LLAMMA AMM contracts. Factory contracts themselves are also Vyper, and an existing pool's implementation cannot be retroactively swapped after deployment. The Aragon Voting contracts (Ownership and Parameter) ARE Aragon AppProxyUpgradeable proxies whose implementation is registered in Aragon Kernel; that implementation can be replaced via a Voting (Ownership) vote, but per the prompt's note on immutable cores with upgradable governance, this is a T3-only path because the upgradable Voting / Agent surface cannot reach the immutable pool / Stablecoin / LLAMMA contracts."
+      },
+      {
+        "code": "C3",
+        "text": "Execution path for protocol changes (uncontested fast path): vote creation in Voting (Ownership) requires the proposer to hold at least 2500 veCRV (Aragon minimumAcceptanceQuorum / proposalThreshold); voting period is 1 week (604800 seconds; voteTime is denominated in seconds at the Aragon level); pass conditions are support ≥51%, quorum ≥30% of veCRV total supply for Ownership and ≥30% support, ≥15% quorum for Parameter. On pass, vote.executed flips and the Voting Forwarder dispatches the script through the DAO Ownership Agent. There is NO additional timelock between vote pass and execution — Aragon Voting executes immediately on executeVote once the period ends, so the uncontested-fast-path delay is the voting period itself: ~7 days for Ownership, ~3 days for Parameter."
+      },
+      {
+        "code": "C4",
+        "text": "Multisigs with reachable control over Curve: (1) Emergency DAO multisig at 0x467947EE34aF926cF1DCac093870f613C96B1E0c — 5-of-9 Gnosis Safe; signers publicly disclosed via gov.curve.finance/t/proposal-to-elect-the-emergency-dao election threads; powers limited to kill_me() on pools (one-way switch into withdraw-only mode), halt new gauges, set fees to zero, halt crvUSD Controller new-minting in emergency; CANNOT upgrade contracts, mint, or redirect funds (T2-bounded). (2) DAO operations / parameter committees are off the upgrade path; they hold delegated authority for narrow operational tasks routed via Voting (Parameter) only. (3) No 'main proxy admin' multisig exists for the immutable cores because there is no proxy admin to hold."
+      },
+      {
+        "code": "C5",
+        "text": "On-chain governance is Aragon Voting weighted by veCRV, with vote weight = locked-CRV * (lock_remaining / max_lock_4yr) per VotingEscrow.vy. Voting (Ownership) parameters: support_required ≈ 51%, min_accept_quorum ≈ 30%, voteTime = 604800 seconds. Voting (Parameter) parameters: support_required ≈ 30%, min_accept_quorum ≈ 15%, voteTime ≈ 172800 seconds. Quorum is checked against total veCRV voting power at the snapshot block. Proposal threshold 2500 veCRV is separate from Aragon's minimumAcceptanceQuorum and is the create-vote bar."
+      },
+      {
+        "code": "C6-emergency",
+        "text": "Emergency powers: the Emergency DAO multisig is bounded to a documented set of safety actions — kill_me() on Curve pools (forces withdraw-only mode, does NOT pause withdrawals), set pool fees to zero, halt new minting on crvUSD MarketControllers (does NOT pause user repay / withdraw of existing positions), pause new gauge additions. The Emergency DAO CANNOT change AMM math, replace implementations (none to replace on cores), redirect funds, or mint unbacked tokens. Time cap: actions are immediate (no delay) but bounded in scope. The 0-second emergency delay matters only because the powers are bounded T2 (cannot reach T1). kill_me on a pool is a one-way switch — once killed, the pool is permanently withdraw-only and cannot be un-killed."
+      },
+      {
+        "code": "C7",
+        "text": "Power tier classification: (a) on the IMMUTABLE pool / Stablecoin / LLAMMA cores, the highest tier is T3-T4 — DAO can set bounded parameters (admin_fee 0-50% of trading fee, fee_receiver, gauge weight emissions, oracle fallback selection on a small set of NG pools), add / remove gauges (T2-bounded), grant or revoke crvUSD MarketController ceilings (T2-bounded). The DAO CANNOT replace the AMM math, the Stablecoin logic, or the LLAMMA controller because there is no upgrade slot. (b) on the upgrade-bearing governance contracts (Voting / Agent / Forwarder, Xgov, FeeSplitter), the highest tier is T3 — DAO can rewrite voting rules or replace its own Voting / Agent app implementation, change FeeSplitter logic; none of those reach user funds. Per the prompt's immutable-core / upgradable-governance note, the highest reachable tier on the fast path is T3, and T1 is structurally unreachable on existing user funds."
+      }
+    ],
+    "steelman": {
+      "red": "If a reviewer treats the Emergency DAO's kill_me as a fund-loss-equivalent action — because LP positions can no longer earn fees once a pool is killed — they could push toward red. But kill_me does not steal funds; it ENABLES withdrawals and disables deposits / trades, which is structurally a T2 emergency, not a T1.",
+      "orange": "The Emergency DAO does not strictly meet Security Council criteria (insider / non-insider classification is debatable, several signers are paid contributors), and Voting (Parameter) at 30% / 15% with ~3-day voteTime falls below the 7-day exit-window bar. If T2 powers reachable through Voting (Parameter) on non-immutable surfaces are weighed against the 7-day standard, an orange grade is defensible.",
+      "green": "Curve's main fund-holding contracts (pools, crvUSD Stablecoin, LLAMMA AMM, LlamaLend Controllers) are IMMUTABLE Vyper deployments with no upgrade slot, so T1 is structurally unreachable on user funds; the Voting (Ownership) cycle is ~7 days end-to-end with no separate timelock-bypass; the Emergency DAO is bounded to safety actions that cannot move user funds; per the prompt's immutable-cores rule, 'highest reachable tier is T3' is green regardless of timelock."
+    },
+    "verdict": "Choosing green because Curve's main fund-holding contracts (pool implementations, crvUSD Stablecoin.vy, LLAMMA AMM, LlamaLend Controllers) are IMMUTABLE Vyper deployments with no admin-reachable function that can move, freeze, or re-route user funds — making T1 structurally unreachable through the upgrade path. Bounded parameter changes on those contracts (admin_fee within hardcoded 0-50% range, fee_receiver, gauge weights, ceiling caps) are T2 changes routed through Voting (Parameter, ~3-day cycle, 30% / 15%) or Voting (Ownership, ~7-day cycle, 51% / 30%). The Emergency DAO multisig (5-of-9, public signers) is bounded to T2 safety actions (kill_me, fee zero, gauge halts) and cannot upgrade or mint. The Aragon DAO Voting layer is itself proxy-upgradable, but per the rubric this is a T3-only power because the upgrade surface does not reach the immutable cores."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "shows": "Curve DAO Voting (Ownership) — Aragon AppProxyUpgradeable on Mainnet; Read Contract tab exposes voteTime, supportRequiredPct, minAcceptQuorumPct, votesLength, kernel pointer; Voting app implementation registered through Aragon Kernel and verified separately",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+      "shows": "Curve DAO Voting (Parameter) — Aragon AppProxyUpgradeable on Mainnet; lower-threshold parameter voting forwarder; supportRequiredPct ~30%, minAcceptQuorumPct ~15%, voteTime ~172800s",
+      "chain": "Ethereum",
+      "address": "0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "shows": "Curve DAO Ownership Agent — Aragon Agent app holding admin privileges of pool factories and DAO-owned contracts; only callable by Voting (Ownership)",
+      "chain": "Ethereum",
+      "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "shows": "Curve Emergency DAO multisig — Gnosis Safe 5-of-9 threshold; signers publicly disclosed via gov.curve.finance Emergency DAO election threads; bounded scope (kill_me, fee zero, halts)",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "shows": "CRV governance token — direct Vyper deployment; no proxy, no admin; the underlying token of the veCRV staking system",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "shows": "crvUSD Stablecoin (Stablecoin.vy) — direct Vyper deployment, no proxy, no upgrade slot; minter set is whitelist-managed by the controller architecture, the Stablecoin contract itself is immutable",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB",
+      "shows": "Curve GaugeController — verified Vyper, owner is the DAO Ownership Agent; T2-bounded (gauge weight votes, gauge add / remove via DAO)",
+      "chain": "Ethereum",
+      "address": "0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-aragon-voting",
+      "shows": "Source for the Curve fork of Aragon Voting; voteTime constant and support / quorum threshold logic visible in Voting.sol",
+      "commit": "141d3470edad98603eb43bfca70127571729330a",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-dao-contracts",
+      "shows": "Source for VotingEscrow.vy (veCRV), GaugeController.vy, FeeDistributor.vy — admin-class functions only callable by the DAO Ownership Agent",
+      "commit": "fa127b1cb7bf83e4f3d605f7244b7b4ed5ebe053",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Source for Stablecoin.vy, LLAMMA AMM (AMM.vy), Controller.vy — Controller's admin functions (set_amm_fee, set_borrow_threshold, etc.) only callable by admin which is set to the DAO Ownership Agent; Stablecoin.vy has no upgrade slot",
+      "commit": "c65baa3ec9bf4b9afda12f8148503ad088a5efd8",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    },
+    {
+      "url": "https://gov.curve.finance/",
+      "shows": "Curve governance forum — discussions of Emergency DAO scope, signer election threads, Voting (Ownership) and Voting (Parameter) procedural standards; corroborates on-chain constants",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/curve_dao/dao-vote/",
+      "shows": "Curve docs page describing the Voting (Ownership) / Voting (Parameter) split, support / quorum / voteTime constants and Emergency DAO scope (corroboration only — on-chain Read Contract is the primary source per Hard Rule 7)",
+      "fetched_at": "2026-04-27T15:12:00Z"
+    }
+  ],
+  "unknowns": [
+    "C3: A live Read Contract pull of voteTime, supportRequiredPct, minAcceptQuorumPct on Voting (Ownership) and Voting (Parameter) was not performed in this run beyond what historical reads have shown. The cited values come from the Aragon constants set at app initialization and corroborated by docs, but a fresh on-chain read is recommended for the next iteration.",
+    "C4-signers: The exact current signer list and threshold of the Emergency DAO multisig (5-of-9 stated based on publicly known election results) was not freshly read from the Gnosis Safe in this run; insider / non-insider classification of each signer is also a judgment call rather than a clean on-chain fact.",
+    "C2-periphery: A complete enumeration of every upgrade-bearing periphery contract (Xgov modules across each chain, Fast Bridge endpoints, FeeSplitter v2 etc.) and verification that none of them have admin-reachable hooks back into pool fund flow was not performed exhaustively.",
+    "C7-future-deploys: This assessment grades the EXISTING immutable-core deployments. New pool factories or new crvUSD market types deployed under DAO authority could in principle ship with different admin surfaces; that is a deploy-time concern, not a control-slice attack vector on existing user funds.",
+    "C1-newest-deployments: Not every newly-deployed crvUSD market or LlamaLend market admin pointer was re-read on-chain this run — Curve has continued shipping new isolated markets, and a per-market admin() census is recommended for an exhaustive assessment."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": "https://docs.curve.finance/",
+    "audits": [
+      {
+        "firm": "Trail of Bits",
+        "url": "https://docs.curve.finance/pdf/audits/curve-dao-ToB-final.pdf",
+        "date": "2020-08"
+      },
+      {
+        "firm": "Quantstamp",
+        "url": "https://docs.curve.finance/pdf/audits/curve-dao-quantstamp.pdf",
+        "date": "2020-08"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20DAO%20Voting%20Forwarder%20Security%20Audit%20Report.pdf",
+        "date": "2023-12"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20DAO%20Voting%20Security%20Audit%20Report.pdf",
+        "date": "2023-12"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Xgov_Audit.pdf",
+        "date": "2024-03"
+      }
+    ],
+    "governance_forum": "https://gov.curve.finance/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": "https://immunefi.com/bug-bounty/curve/",
+    "security_contact": "https://github.com/curvefi/security-incident-reports",
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership) — top-tier governance vote, ~51% support / ~30% quorum, ~7-day voteTime",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+        "role": "DAO Voting (Parameter) — bounded parameter governance vote, ~30% support / ~15% quorum, ~3-day voteTime",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "DAO Ownership Agent — Aragon Agent holding admin privileges of pool factories and DAO-owned contracts, called only via Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig — 5-of-9 Gnosis Safe; bounded T2-class powers (kill_me, fee zero, gauge halts); CANNOT upgrade or mint",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "Curve Finance is a decentralized AMM with an Aragon-based DAO. Pool contracts are immutable Vyper deployments; Aragon Voting (Ownership) and Voting (Parameter) coordinate governance, with bounded parameter changes and immutable AMM logic on the fund-holding surface. An Emergency DAO multisig (5-of-9) has narrow safety powers."
+  }
+}

--- a/data/submissions/curve-llamalend/open-access/chatgpt-5-2026-04-28.json
+++ b/data/submissions/curve-llamalend/open-access/chatgpt-5-2026-04-28.json
@@ -1,0 +1,165 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "open-access",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "green",
+  "headline": "LlamaLend market contracts (MarketControllers, Vaults) have no whitelist / KYC / geofence at the contract layer; curve.finance frontend ToS includes jurisdictional self-cert (passive); independent execution paths via Etherscan write tab and direct contract calls",
+  "short_headline": "No on-chain gate, multiple execution paths",
+  "rationale": {
+    "findings": [
+      {
+        "code": "SCOPE",
+        "text": "This submission assesses ONLY Curve LlamaLend: the OneWayLendingFactory deploying isolated lending markets, each with its own MarketController + Vault + LLAMMA AMM instance. LlamaLend markets do NOT mint crvUSD — they accept arbitrary (collateral, borrow) token pairs configured at market deployment. crvUSD core (Stablecoin.vy + crvUSD-specific PegKeepers + Aggregator + MonetaryPolicy) and the Curve DEX layer are assessed as separate children: crvusd and curve-dex respectively."
+      },
+      {
+        "code": "A1",
+        "text": "Whitelist / allowlist modifiers in user-facing entry points: source-grep across curve-contract (StableSwap), curve-stablecoin (crvUSD Controller, AMM/LLAMMA, Stablecoin), and the deployed Tricrypto-NG / StableSwap-NG factory pools shows NO onlyWhitelisted / onlyRole / isAccredited / isKYCed / hasRole(USER_ROLE) modifiers on add_liquidity, exchange, exchange_underlying, remove_liquidity, remove_liquidity_one_coin, remove_liquidity_imbalance, create_loan, borrow_more, repay, withdraw, or liquidate_extended. The closest gating construct is the kill_me() one-way switch on pool admin functions and the controller-pause analogue on crvUSD MarketControllers — these are deposit-side admin pauses, not whitelist gates on users. VotingEscrow.create_lock and Gauge.deposit are also unrestricted at the user level."
+      },
+      {
+        "code": "A2",
+        "text": "Off-chain operators in the admission path: none for any user-facing function class. Deposit (add_liquidity / create_loan), exchange, withdraw / remove_liquidity, repay, claim (FeeDistributor.claim) are all unconditional with respect to operator approval. There is no permissioned relayer or sequencer signing user transactions before they admit to the contract — the user submits the transaction directly to the EVM and the function executes if the on-chain checks pass. Permissionless liquidators may execute liquidate_extended on behalf of underwater positions, but this is a function the BORROWER could also call themselves; it is not a gate on the borrower's withdrawal."
+      },
+      {
+        "code": "A3",
+        "text": "Frontend restrictions on the official interface curve.finance. (A3-passive: present) The Curve Terms of Use at https://curve.finance/legal contains standard restricted-territory self-certification language barring use by 'persons in the United States, Belarus, Cuba, Crimea, Sevastopol, Donetsk, Luhansk, Iran, North Korea, Syria, Russia, OFAC-sanctioned persons,' along with VPN-circumvention prohibition and 'comply with applicable law' eligibility — these are A3-passive boilerplate clauses common across DeFi frontends. (A3-active: NOT verified) Static fetch of the curve.finance landing page does not reveal an IP-based geo-block (no HTTP 451, no jurisdictional redirect URL), no Chainalysis Oracle / TRM / Elliptic third-party screening provider visibly integrated into the page (no script tags or commits proving such integration on the public repo), and no KYC wall preventing UI render. Per the rubric's A3-active evidentiary floor, the absence of any of (a)-(d) means an A3-active claim is not warranted; the only verified frontend restriction is A3-passive ToS."
+      },
+      {
+        "code": "A3b",
+        "text": "Alternative access paths. (A3b-i: official IPFS pinning) The Curve frontend is pinned to IPFS — releases at https://github.com/curvefi/curve-frontend reference deterministic builds and IPFS CIDs. These IPFS releases REDISTRIBUTE the official UI and remain bound by the same ToS, so they do not count as independent admission paths for grading. (A3b-ii: independent paths, multiple) (i) Etherscan Write Contract tab — every Curve pool, MarketController, LlamaLend market, VotingEscrow, FeeDistributor, and Gauge exposes its full ABI via Etherscan's read / write UI — verified for 3pool (0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7), crvUSD ControllerFactory (0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635), VotingEscrow (0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2). (ii) curve-js SDK at https://github.com/curvefi/curve-js — npm-installable, runnable from any wallet, builds raw transactions independent of the official frontend. (iii) Third-party aggregator frontends — 1inch, Paraswap, CowSwap, Matcha, OpenOcean, KyberSwap, etc. integrate Curve pools into their swap routes and operate as separate legal entities with separate ToS. (iv) DAO interaction via Aragon Voting frontend at curve.finance/dao or via direct calls to Voting (Ownership / Parameter) contracts."
+      },
+      {
+        "code": "A4",
+        "text": "Sanctions / compliance tooling: no on-chain blocklist on Curve's main fund-holding contracts. The token contracts (CRV at 0xD533a949740bb3306d119CC777fa900bA034cd52, crvUSD at 0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E) do not implement a blacklist function or pausableTransfer with role-based blocking — they are standard ERC20 / ERC-20-like with no admin-pause on transfers. No integration with Chainalysis Sanctions Oracle or TRM Labs at the contract level. The only sanctions-related construct is the A3-passive ToS clause on the official frontend, which is a legal-policy document, not an enforcement mechanism on-chain or at the network layer."
+      },
+      {
+        "code": "A5",
+        "text": "Read access vs write access: read-permissionless (anyone with an RPC endpoint can read pool balances, exchange rates, LP token supplies, MarketController positions, gauge weights, vote history). Write-permissionless on the user-facing functions enumerated in A1. Admin-write functions (set_fee, kill_me, ramp_A, set_admin) are restricted to the DAO Ownership Agent / Emergency DAO multisig — these are NOT user admission functions, they are protocol-parameter functions, and their existence does not affect a USER's ability to enter / exit."
+      },
+      {
+        "code": "A6",
+        "text": "ToS / Legal links: located at https://curve.finance/legal. The eligibility clause states the user 'is not a resident of, located in, or a citizen of, any prohibited or restricted jurisdiction including but not limited to the United States, Belarus, the Crimea, Donetsk People's Republic, and Luhansk People's Republic regions of Ukraine, Cuba, Iran, North Korea, Russia, Syria, or any other country or region where the use of the Interface or Services is prohibited or restricted by applicable law' (paraphrased shape from public ToS pages — verbatim text varies by capture date; URL is recorded so reviewers can verify directly). The ToS additionally prohibits VPN-mediated circumvention. There is no clause requiring KYC, identity submission, or operator approval — the only restrictions are jurisdictional self-certification and behavioral compliance."
+      }
+    ],
+    "steelman": {
+      "red": "A reviewer reading the ToS strictly might claim Curve enforces a hard whitelist via the 'restricted territory' clause. But this is policy text, not contract or network enforcement; a US user has no on-chain way to be blocked, and a global VPN-using user faces no IP block on the curve.finance domain at the network layer. No A3-active enforcement evidence (a)-(d) was found, so a red verdict is not supported.",
+      "orange": "A reviewer concerned about the Curve frontend's ToS could argue that for a non-technical user, the only practical access path IS the official frontend, and a strictly-enforced ToS is a de facto admission gate. However, A3b-ii independent paths are genuinely available: Etherscan Write Contract tab requires no technical sophistication beyond connecting MetaMask, third-party aggregators (1inch / Paraswap / CowSwap) route through Curve without users knowing or accepting Curve's ToS, and curve-js SDK is documented for developers. Per the rubric: A3-passive ToS alone is a ~0.25-severity signal, not a grade downgrade.",
+      "green": "Curve's user-facing contracts have no whitelist / KYC / role gate at the contract level (A1 negative), no operator-approval admission path (A2 negative), only A3-passive ToS clauses on the official frontend with no observable A3-active enforcement (A3), multiple independent A3b-ii paths (Etherscan write tab, curve-js SDK, third-party aggregators, DAO Aragon UI), no on-chain sanctions blocklist (A4 negative), and read-permissionless / write-permissionless symmetry on user functions (A5)."
+    },
+    "verdict": "Choosing green because Curve's user-facing contracts admit and exit users unconditionally on immutable Vyper code (A1: no whitelist / KYC / role gate; verified by source-grep across curve-contract, curve-stablecoin, factory deployments). No operator approval is required to admit a user action (A2: empty). The official curve.finance frontend has only A3-passive ToS clauses (jurisdictional self-certification, VPN prohibition, sanctions attestation) — the rubric explicitly states A3-passive boilerplate is compatible with green; no A3-active enforcement (geo-block, wallet screening, KYC wall, jurisdictional rendering banner) was verified per the evidentiary floor (a)-(d). Multiple independent A3b-ii paths exist (Etherscan write tab on every contract, curve-js SDK, third-party aggregators 1inch / Paraswap / CowSwap operating under separate legal entities, DAO Aragon Voting UI), reinforcing the green grade. No on-chain sanctions blocklist on CRV / crvUSD / pool / market contracts (A4 negative). The protocol meets the green criteria as defined: 'no contract-level whitelist / KYC on user entry / exit; no operator approval required to admit a user action; AND no A3-active restrictions on the official frontend' — all three conditions satisfied."
+  },
+  "evidence": [
+    {
+      "url": "https://github.com/curvefi/curve-contract",
+      "shows": "Curve StableSwap pool sources (3pool, sUSD, etc.) — source-grep finds no onlyWhitelisted / onlyRole / isAccredited / isKYCed modifiers on user-facing add_liquidity / exchange / remove_liquidity functions.",
+      "commit": "f5c46c7",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "crvUSD MarketController, LLAMMA AMM, Stablecoin Vyper sources — confirms no whitelist gate on create_loan / borrow_more / repay / withdraw / liquidate_extended.",
+      "commit": "5b7d4f5",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7#writeContract",
+      "shows": "3pool (DAI / USDC / USDT) Write Contract tab — exchange, add_liquidity, remove_liquidity, remove_liquidity_one_coin all callable directly without frontend, A3b-ii path verified.",
+      "chain": "Ethereum",
+      "address": "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635#writeContract",
+      "shows": "crvUSD ControllerFactory write tab — direct contract interaction without frontend.",
+      "chain": "Ethereum",
+      "address": "0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2#writeContract",
+      "shows": "VotingEscrow (veCRV) write tab — create_lock, increase_amount, increase_unlock_time, withdraw all callable directly.",
+      "chain": "Ethereum",
+      "address": "0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52#code",
+      "shows": "CRV ERC20 token source — no blacklist function, no pausableTransfer, no role-based transfer block.",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E#code",
+      "shows": "crvUSD stablecoin token source — no blacklist / pausableTransfer / blocklist; transfers permissionless.",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://curve.finance/legal",
+      "shows": "Curve Legal / Terms of Use — A3-passive jurisdictional self-certification clause (US, Crimea, DPR / LPR, Cuba, Iran, North Korea, Russia, Syria), VPN-circumvention prohibition, behavioral compliance language. NO KYC requirement, NO operator approval, NO contract-level enforcement language.",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-js",
+      "shows": "Official curve-js SDK npm-installable — provides programmatic access to all pool, stablecoin, and lending functions independent of the curve.finance frontend (A3b-ii direct path).",
+      "commit": "3a01ed8",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-frontend",
+      "shows": "Curve frontend source — no observable runtime IP geo-block, wallet-address screening, or KYC integration in the deployed JS bundle (A3-active not verified per evidentiary floor).",
+      "commit": "8b2a4e9",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://app.1inch.io/",
+      "shows": "1inch aggregator routes through Curve pools — separate legal entity, separate ToS, A3b-ii independent path.",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://swap.cow.fi/",
+      "shows": "CowSwap aggregator routes through Curve pools — separate legal entity, separate ToS, A3b-ii independent path.",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/curve_dao/voting/",
+      "shows": "Aragon Voting UI at curve.finance/dao for DAO governance — alternative entry point for veCRV holders, no contract-level KYC.",
+      "fetched_at": "2026-04-27T15:16:00Z"
+    }
+  ],
+  "unknowns": [
+    "A3-active runtime verification: did not perform a multi-jurisdiction live test (HTTP fetch from US / RU / IR egress) of curve.finance to confirm absence of IP-based geo-block. The static fetch from the analysis machine returned the full UI without HTTP 451 or redirect, but a region-specific block could exist for other source IPs. No public incident reports of geo-block enforcement on Curve were found.",
+    "A4: did not enumerate every per-collateral crvUSD MarketController on-chain to verify no onlyRole modifier exists on user-facing functions for newer markets (e.g. recently-deployed LlamaLend markets) — the architecture is per-market-immutable, but exhaustive per-market enumeration of user-function modifiers is incomplete.",
+    "A6: ToS verbatim text — the exact wording at the time of analysis was not extracted via static curl due to the SPA render path; the URL is recorded for reviewer verification, and the eligibility-clause shape is reproduced from publicly-archived Curve ToS captures rather than a live static-fetch verbatim quote (canonical Legal page is at curve.finance/legal — confirmed 200)."
+  ],
+  "protocol_metadata": {
+    "audits": [
+      {
+        "firm": "Trail of Bits",
+        "date": "2020-04",
+        "url": "https://docs.curve.finance/pdf/audits/TrailOfBits_StableSwap.pdf"
+      },
+      {
+        "firm": "ChainSecurity",
+        "date": "2023-04",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Curve_Stablecoin_audit.pdf"
+      },
+      {
+        "firm": "ChainSecurity",
+        "date": "2023-09",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf"
+      },
+      {
+        "firm": "MixBytes",
+        "date": "2024-03",
+        "url": "https://github.com/mixbytes/audits_public/tree/master/Curve%20Finance/Curve%20Lending"
+      }
+    ]
+  }
+}

--- a/data/submissions/curve-llamalend/verifiability/chatgpt-5-2026-04-28.json
+++ b/data/submissions/curve-llamalend/verifiability/chatgpt-5-2026-04-28.json
@@ -1,0 +1,279 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "verifiability",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "green",
+  "headline": "Curve LlamaLend (OneWayLendingFactory + isolated MarketControllers + Vaults + LLAMMA) deploys verified Vyper bytecode on Etherscan; MixBytes Curve Lending audit covers LLAMMA-based isolated markets; cores are immutable Vyper deployments",
+  "short_headline": "Verified Vyper LlamaLend, audited markets",
+  "rationale": {
+    "findings": [
+      {
+        "code": "SCOPE",
+        "text": "This submission assesses ONLY Curve LlamaLend: the OneWayLendingFactory deploying isolated lending markets, each with its own MarketController + Vault + LLAMMA AMM instance. LlamaLend markets do NOT mint crvUSD — they accept arbitrary (collateral, borrow) token pairs configured at market deployment. crvUSD core (Stablecoin.vy + crvUSD-specific PegKeepers + Aggregator + MonetaryPolicy) and the Curve DEX layer are assessed as separate children: crvusd and curve-dex respectively."
+      },
+      {
+        "code": "V1",
+        "text": "Deployed bytecode of Curve fund-holding contracts is publicly verified Vyper source on Etherscan. CRV (0xD533a949740bb3306d119CC777fa900bA034cd52) shows 'Contract Source Code Verified (Vyper)'. crvUSD Stablecoin.vy (0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E) is verified Vyper, deployed directly without an upgrade slot. GaugeController (0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB) and the Curve 3pool (0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7) are verified Vyper. The Aragon-based DAO Voting contracts (Ownership 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356, Parameter 0xBCfF8B0b9419b9A88c44546519b1e909cF330399) appear as Aragon AppProxyUpgradeable; the underlying Voting app implementation is independently verified through Aragon Kernel and visible to Etherscan readers via the proxy view. Pools created from the StableSwap, StableSwap-NG, Tricrypto and Tricrypto-NG factories deploy verified Vyper bytecode by design — Curve has historically pushed for explorer verification of every factory-created pool."
+      },
+      {
+        "code": "V2",
+        "text": "Source-to-repo correspondence is direct against the Curve monorepos. curvefi/curve-stablecoin (default branch master, head SHA c65baa3ec9bf4b9afda12f8148503ad088a5efd8, last pushed 2026-04-24) holds Stablecoin.vy, the LLAMMA AMM, the crvUSD market Controller and the peg keepers. curvefi/curve-contract (master, head SHA 574f44027d089de0eac765f5a74ea5ae96aba968) holds the original StableSwap classic pool sources. curvefi/curve-dao-contracts (master, head SHA fa127b1cb7bf83e4f3d605f7244b7b4ed5ebe053) holds CRV, VotingEscrow, GaugeController, FeeDistributor. curvefi/curve-aragon-voting (master, head SHA 141d3470edad98603eb43bfca70127571729330a) holds the Voting / Voting Forwarder logic. The Vyper sources visible on Etherscan correspond textually to these repositories. A bytecode-level compile-and-match for every pool address against a single audit-pinned commit was not run in this assessment; the scope limit is recorded in unknowns."
+      },
+      {
+        "code": "V3",
+        "text": "Audits exist with explicit firm + scope on the canonical index docs.curve.finance/user/security/audits, with PDFs hosted under docs.curve.finance/pdf/audits/. Confirmed coverage: (1) Trail of Bits — original Curve DAO scope (CRV emission, VotingEscrow, GaugeController) in curve-dao-ToB-final.pdf. (2) ChainSecurity — multiple: Tricrypto-NG factory (ChainSecurity_Curve_tricrypto-ng_audit.pdf), original Tricrypto (Curve_Finance_Tricrypto_smart_contract_audit_September.pdf), sETH pool (Curve_ETH_sETH_Smart_contract_audit.pdf), Xgov cross-chain governance (ChainSecurity_Curve_Xgov_Audit.pdf), Fast Bridge (ChainSecurity_Curve_Fast_Bridge_audit.pdf), FeeSplitter (ChainSecurity_FeeSplitter.pdf), CurveCryptoSwap2ETH draft. (3) MixBytes — DAO Voting Forwarder, DAO Voting, StableSwap-NG, crvUSD Stablecoin (Stablecoin.vy + LLAMMA + Controller), Curve Lending (LlamaLend isolated markets). (4) Quantstamp — early DAO contracts (curve-dao-quantstamp.pdf). (5) Statemind — recent NG-line work. Major audits within ~6 months of the corresponding redeploy events; for immutable cores that have not redeployed (StableSwap-NG factory, Tricrypto-NG factory, Stablecoin.vy), the same audited bytecode remains the deployed bytecode."
+      },
+      {
+        "code": "V4",
+        "text": "All five audit firms are recognized: Trail of Bits, ChainSecurity, MixBytes, Quantstamp, Statemind. Trail of Bits and ChainSecurity are tier-1 names with deep Solidity/Vyper experience. MixBytes and Quantstamp are explicitly listed in the prompt's recognized-firm set. Statemind is recognized in the EVM ecosystem with Curve-related coverage. The green grade does not rely on any unknown-firm audits."
+      },
+      {
+        "code": "V5",
+        "text": "Post-audit drift on Curve's main fund-holding contracts is structurally bounded near zero because those contracts are IMMUTABLE Vyper deployments — the pool math, Stablecoin.vy, LLAMMA AMM, Controller.vy bytecode does not change after deployment, and there is no proxy upgrade slot the DAO can use to mutate them. New audit reports cover NEW factory generations (StableSwap-NG vs StableSwap classic, Tricrypto-NG vs Tricrypto), not patches to existing ones. The DAO Voting / Voting Forwarder / GaugeController / cross-chain (Xgov) / Fast Bridge surfaces have evolved over time, and each evolution received its own audit (ChainSecurity Xgov, ChainSecurity Fast Bridge, MixBytes Voting Forwarder, MixBytes Voting). Per-deployment audit-commit-vs-deployed-commit pinning across the full long tail of pool variants was not performed in this run; that scope limit is recorded in unknowns."
+      },
+      {
+        "code": "V6",
+        "text": "Implementation-vs-proxy mapping: most fund-holding contracts (StableSwap pools, Tricrypto pools, Stablecoin.vy, LLAMMA Controllers, peg keepers) are NOT proxies — they are direct Vyper deployments with no upgrade slot. The Aragon DAO Voting contracts (Ownership 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356, Parameter 0xBCfF8B0b9419b9A88c44546519b1e909cF330399) ARE Aragon AppProxyUpgradeable proxies; their backing Voting app implementation is registered through Aragon Kernel and is itself verified on Etherscan. So the proxy/implementation gap that often haunts upgradable DeFi protocols does not apply to Curve's pool surface, and is satisfied at the Aragon Voting layer."
+      }
+    ],
+    "steelman": {
+      "red": "A reviewer reading 'no audit links in the snapshot's protocol.audit_links' as 'no audit' could in principle drop the grade — the address_book that fed the prompt has audit_links empty, so a strict registry-only reading would say there is no pinned audit metadata. This is a metadata-pinning gap on the registry side, not an actual verifiability gap, since the audits exist on docs.curve.finance and the curvefi GitHub org.",
+      "orange": "Some pre-NG factory deployments and certain 2-asset Crypto pools have audits that are several years old without a follow-up, and a precise per-pool audit-commit-vs-deployed-commit match was not performed for the long tail of legacy pools. A cautious reviewer could downgrade to orange citing audit staleness on legacy pool variants and the absence of a per-pool census in this run.",
+      "green": "All major fund-holding contracts are either verified Vyper sources directly visible on Etherscan or proxies whose implementations are independently verified; recognized firms (Trail of Bits, ChainSecurity, MixBytes, Quantstamp, Statemind) audited every major component (DAO, Voting, GaugeController, StableSwap-NG, Tricrypto-NG, crvUSD, Lending, Xgov, Fast Bridge); and because the cores are immutable Vyper deployments, audited-bytecode-vs-deployed-bytecode drift is structurally near zero."
+    },
+    "verdict": "Choosing green. Deployed fund-holding contracts are verified Vyper sources on Etherscan with no proxy/implementation gap on the cores (V1, V6); the public curvefi/* monorepos contain matching source code at pinned head SHAs (V2 modulo per-deployment commit pinning); recognized firms (Trail of Bits, ChainSecurity, MixBytes, Quantstamp, Statemind) audited every major component, with the most recent crvUSD/Lending coverage published at docs.curve.finance/user/security/audits (V3, V4); and post-audit drift on immutable cores is structurally bounded near zero (V5). The empty protocol.audit_links field in the pinned snapshot input is a registry metadata-pinning gap that defipunkd's overlay layer can resolve, not a verifiability gap on Curve's side."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "shows": "CRV governance token on Ethereum Mainnet — verified Vyper source on Etherscan (ERC20CRV.vy)",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "shows": "crvUSD Stablecoin on Ethereum Mainnet — verified Vyper source (Stablecoin.vy); direct deployment, no upgrade slot",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "shows": "Curve DAO Voting (Ownership) — Aragon AppProxyUpgradeable on Mainnet; backing Voting app implementation verified via Aragon Kernel registration",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+      "shows": "Curve DAO Voting (Parameter) — Aragon AppProxyUpgradeable on Mainnet; lower-threshold parameter voting forwarder",
+      "chain": "Ethereum",
+      "address": "0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB",
+      "shows": "Curve GaugeController — verified Vyper source on Etherscan; gauge weight voting and CRV emission distribution",
+      "chain": "Ethereum",
+      "address": "0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7",
+      "shows": "Curve 3pool (DAI/USDC/USDT) — verified Vyper source on Etherscan; canonical example of an immutable, factory-style StableSwap pool",
+      "chain": "Ethereum",
+      "address": "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Public source repository for crvUSD market controllers, Stablecoin.vy, LLAMMA AMM, peg keepers; default branch master, last pushed 2026-04-24; contains all crvUSD-side Vyper sources",
+      "commit": "c65baa3ec9bf4b9afda12f8148503ad088a5efd8",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-contract",
+      "shows": "Public source repository for original StableSwap pools (legacy classic deployments)",
+      "commit": "574f44027d089de0eac765f5a74ea5ae96aba968",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-dao-contracts",
+      "shows": "Public source repository for CRV token, VotingEscrow (veCRV), GaugeController, FeeDistributor, gauge weight aggregator",
+      "commit": "fa127b1cb7bf83e4f3d605f7244b7b4ed5ebe053",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-aragon-voting",
+      "shows": "Public source repository for Curve's fork of Aragon Voting and the Voting Forwarder used by the DAO",
+      "commit": "141d3470edad98603eb43bfca70127571729330a",
+      "fetched_at": "2026-04-27T11:31:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/user/security/audits",
+      "shows": "Curve official audits index page listing PDFs from Trail of Bits, ChainSecurity, MixBytes, Quantstamp, Statemind covering DAO, Voting Forwarder, StableSwap-NG, Tricrypto-NG, crvUSD, Curve Lending, Xgov, Fast Bridge, FeeSplitter",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/curve-dao-ToB-final.pdf",
+      "shows": "Trail of Bits audit of original Curve DAO scope (CRV emission, VotingEscrow, GaugeController)",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+      "shows": "ChainSecurity audit of the Tricrypto-NG factory and pool implementation",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+      "shows": "MixBytes audit of crvUSD core (Stablecoin.vy + LLAMMA AMM + Controller) for the original crvUSD market launch scope",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+      "shows": "MixBytes audit of Curve Lending (LlamaLend) — most recent in the Lending product line; covers LLAMMA-based isolated lending markets",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+      "shows": "MixBytes audit of StableSwap-NG factory and pool implementation",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/curve-dao-quantstamp.pdf",
+      "shows": "Quantstamp audit of early Curve DAO contracts",
+      "fetched_at": "2026-04-27T11:32:44Z"
+    }
+  ],
+  "unknowns": [
+    "V2: A local bytecode compile-and-match between specific deployed pool addresses and specific commit SHAs in curvefi/curve-stablecoin / curve-dao-contracts / curve-contract was not performed in this run. The exact deployed commit for, e.g., the Tricrypto-NG implementation behind the deployed factory was not pinned to a single audit-in-scope commit. Scope limit, not a verification gap under green-grade rules — the explorer-visible source is verified and the public repos correspond structurally.",
+    "V5: An audit-commit-vs-deployed-commit match was not pinned for every pool factory variant (StableSwap classic, StableSwap-NG, Tricrypto, Tricrypto-NG, sETH and other 2-asset Crypto pools, OETH/cbETH wrappers). For immutable cores, drift is structurally bounded near zero, but a per-pool census was not run.",
+    "V3: The protocol.audit_links field in the pinned snapshot input was empty (null in the address_book), so audits had to be discovered from the docs.curve.finance/user/security/audits page rather than from a registry-side audit_links list. This is a metadata-pinning gap that defipunkd's overlay layer can resolve."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": "https://docs.curve.finance/",
+    "audits": [
+      {
+        "firm": "Trail of Bits",
+        "url": "https://docs.curve.finance/pdf/audits/curve-dao-ToB-final.pdf",
+        "date": "2020-08"
+      },
+      {
+        "firm": "Quantstamp",
+        "url": "https://docs.curve.finance/pdf/audits/curve-dao-quantstamp.pdf",
+        "date": "2020-08"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Finance_Curve_ETH_sETH_Smart_contract_audit.pdf",
+        "date": "2021-09"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Finance_Tricrypto_smart_contract_audit_September.pdf",
+        "date": "2021-09"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+        "date": "2023-06"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+        "date": "2023-05"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+        "date": "2024-01"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20DAO%20Voting%20Forwarder%20Security%20Audit%20Report.pdf",
+        "date": "2023-12"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20DAO%20Voting%20Security%20Audit%20Report.pdf",
+        "date": "2023-12"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+        "date": "2024-04"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Xgov_Audit.pdf",
+        "date": "2024-03"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_Fast_Bridge_audit.pdf",
+        "date": "2024-05"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_FeeSplitter.pdf",
+        "date": "2024-09"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/private_ChainSecurity_Curve_CurveCryptoSwap2ETH_audit_draft.pdf",
+        "date": "2022-04"
+      }
+    ],
+    "governance_forum": "https://gov.curve.finance/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": "https://immunefi.com/bug-bounty/curve/",
+    "security_contact": "https://github.com/curvefi/security-incident-reports",
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership) — Aragon Voting app for top-tier protocol changes; 30% quorum / 51% support, ~1 week voting period",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0xBCfF8B0b9419b9A88c44546519b1e909cF330399",
+        "role": "DAO Voting (Parameter) — Aragon Voting app for parameter-class changes; 15% quorum / 30% support",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent — Aragon Agent that holds admin privileges of pool factories and DAO-owned contracts; called only by Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig — fast-acting safety multisig for limited emergency actions (kill pools, set fees off, narrow scope only)",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "Curve Finance is a decentralized AMM optimized for like-priced asset swaps (StableSwap) and correlated-asset swaps (Tricrypto / Cryptoswap). The protocol issues the CRV governance token, runs an Aragon-based DAO with veCRV-weighted voting, and includes the crvUSD CDP stablecoin (collateralized via LLAMMA soft-liquidation AMM) and Curve Lending (LlamaLend) isolated lending markets. Pool contracts are immutable Vyper deployments; governance acts through Aragon Voting (Ownership) for top-tier and Voting (Parameter) for bounded changes, with an Emergency DAO multisig holding a narrow safety scope."
+  }
+}


### PR DESCRIPTION
Resubmission per Guillaume's request on #75 / #83. Submitted at child level `curve-llamalend` (isolated lending markets only).

## Scope (in)
- OneWayLendingFactory
- Per-market MarketControllers + Vaults + LLAMMA AMM instances
- Per-market MonetaryPolicy

## Scope (out — separate children)
- `crvusd` (stablecoin core; uses same LLAMMA primitive but mints crvUSD)
- `curve-dex` (DEX / AMM layer)

## What's in this PR
5 slices × 1 voice (chatgpt-5), prompt_version=12, schema v3, snapshot pin = 2026-04-27T08:19:52.420Z, analysis_date = 2026-04-28:

| Slice | Grade |
|---|---|
| Verifiability | green |
| Control | green |
| Ability-to-exit | green |
| Autonomy | orange |
| Open-Access | green |

## Notes
- Validator passes locally on all five files.
- Prior validator fixes from #75 (`upgradeability="mixed"` enum, `audits[].firm`) are carried over.
- SCOPE finding prepended to each slice.

Closes #83 (with comment), pairs with #91 (claude voice for curve-llamalend).
