### PR TITLE
crvUSD: ChatGPT-5 honest re-run (5 slices)

### DIFF
--- a/data/submissions/crvusd/ability-to-exit/chatgpt-5-2026-04-28.json
+++ b/data/submissions/crvusd/ability-to-exit/chatgpt-5-2026-04-28.json
@@ -1,0 +1,136 @@
+{
+  "schema_version": 3,
+  "slug": "crvusd",
+  "slice": "ability-to-exit",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "unknown",
+  "headline": "Could not verify on-chain exit and pause paths this run",
+  "short_headline": "Exit not verified",
+  "rationale": {
+    "findings": [],
+    "steelman": null,
+    "verdict": "Unable to assess ability-to-exit: during this run we could not verify the specific user exit functions, their pause guards, the identities/time caps of pause actors, or any emergency/governance pause distinctions from the allowed sources (block explorers, linked GitHub repos, or the linked audits). See unknowns E1\u2013E7."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "shows": "crvUSD ERC-20 stablecoin contract on Ethereum; anchor for on-chain exit assessment",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E"
+    },
+    {
+      "url": "https://etherscan.io/address/0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "shows": "crvUSD ControllerFactory contract on Ethereum; factory for per-collateral controllers that govern mint/repay/withdraw flows",
+      "chain": "Ethereum",
+      "address": "0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635"
+    },
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "shows": "Curve DAO Voting contract address (ownership/governance)",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356"
+    },
+    {
+      "url": "https://etherscan.io/address/0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "shows": "Curve DAO Ownership Agent contract address",
+      "chain": "Ethereum",
+      "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "shows": "Curve Emergency DAO Gnosis Safe multisig (5-of-9) address",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c"
+    },
+    {
+      "url": "https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "shows": "CRV governance token contract on Ethereum",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Source code repository for the crvUSD stablecoin system (controllers, AMM/LLAMMA)"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-contract",
+      "shows": "Curve Finance core contracts repository"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-dao-contracts",
+      "shows": "Curve DAO contracts repository"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-aragon-voting",
+      "shows": "Curve Aragon voting contracts repository"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-js",
+      "shows": "Curve JavaScript SDK repository"
+    },
+    {
+      "url": "https://github.com/curvefi/security-incident-reports",
+      "shows": "Curve Finance security incident reports repository"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+      "shows": "Security audit report for the crvUSD stablecoin system (describes components, roles, and security assumptions)"
+    }
+  ],
+  "unknowns": [
+    "E1: Could not enumerate all user-facing exit functions (e.g., repay, collateral withdrawal, burn/redeem) for the deployed Controller/LLAMMA contracts from the allowed sources during this run.",
+    "E2: Could not determine access modifiers and any pause guards that apply to each exit function (request placement vs claim of finalized) from code/ABI or audits in this run.",
+    "E3: Could not identify which specific addresses hold pause/guardian roles across core contracts or any maximum pause durations (including whether an uncapped/indefinite pause exists).",
+    "E4: Could not verify whether separate emergency vs governance pause mechanisms exist, who can trigger them, their scopes, and any time caps.",
+    "E5: Could not confirm whether any queued redemption/withdrawal mechanism exists, its maximum queue duration, daily caps, or whether such queues are pausable.",
+    "E6: Could not determine whether a permissionless forced-exit or escape-hatch is available to users under adversarial admin conditions.",
+    "E7: Could not confirm whether exit functions are directly callable on-chain (e.g., via Etherscan Write functions) without dependency on the project's frontend."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": null,
+    "audits": [],
+    "governance_forum": null,
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig (5-of-9 Gnosis Safe)",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "unknown",
+    "about": "crvUSD is Curve\u2019s overcollateralized stablecoin system where users mint crvUSD by locking approved collateral into per-collateral controllers and can later repay to withdraw their collateral. Liquidation risk is managed via a soft-liquidation mechanism integrated with Curve\u2019s LLAMMA AMM design. The system\u2019s components and security model are described in the public audit of the crvUSD contracts."
+  }
+}

--- a/data/submissions/crvusd/autonomy/chatgpt-5-2026-04-28.json
+++ b/data/submissions/crvusd/autonomy/chatgpt-5-2026-04-28.json
@@ -1,0 +1,168 @@
+{
+  "schema_version": 3,
+  "slug": "crvusd",
+  "slice": "autonomy",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "orange",
+  "headline": "Per-market oracle/keeper dependencies; mispricing could force liquidations (worst case ~100% of the affected market’s TVS)",
+  "short_headline": "Per-market oracle/keeper risk",
+  "rationale": {
+    "findings": [
+      {
+        "code": "A1",
+        "text": "crvUSD borrowing markets (Controllers/LLAMMAs) rely on external price oracles to value collateral and drive liquidation band movement; the crvUSD audit describes oracle-driven pricing in the LLAMMA/Controller design, making these oracles external dependencies whose pause or misreporting would mis-price positions."
+      },
+      {
+        "code": "A2",
+        "text": "Where third‑party oracle feeds are used, updates originate from off-chain reporters; the audit discusses oracle inputs affecting liquidation and stability mechanisms, implying that misreporting can trigger wrongful liquidations or prevent them."
+      },
+      {
+        "code": "A3",
+        "text": "Core crvUSD contracts (stablecoin and ControllerFactory) are deployed on Ethereum L1 and do not require cross‑chain messaging for mint/repay flows."
+      },
+      {
+        "code": "A4",
+        "text": "Controllers are per‑collateral; some supported collaterals can be wrapper assets (e.g., LSTs/LBTC wrappers), so failures in underlying protocols would impair positions in that specific market but do not automatically propagate to others."
+      },
+      {
+        "code": "A6",
+        "text": "LLAMMA uses an on-chain pricing mechanism with smoothing/TWAP-style protections described in the audits, which acts as a live mitigation against short-term oracle manipulation; this reduces but does not eliminate oracle failure risk."
+      },
+      {
+        "code": "A7",
+        "text": "All referenced core contracts are on Ethereum L1, so there is no additional L2 sequencer or DA committee liveness dependency beyond the base chain."
+      },
+      {
+        "code": "A8",
+        "text": "Liquidations and band adjustments rely on permissionless external callers/keepers; if off-chain bots stop, positions can become stale and bad debt risk increases, degrading protocol performance rather than halting on-chain logic."
+      },
+      {
+        "code": "A9",
+        "text": "Governance can list new markets (and thereby introduce new external oracle dependencies per market) via the factory; the audits indicate admin/governance configurability for markets and parameters, but the specific ability to hot-swap oracle addresses and the presence/length of any timelock or exit window are not determinable from the allowed sources used here."
+      },
+      {
+        "code": "Modules",
+        "text": "Sub-modules: (1) ControllerFactory → Controllers + LLAMMAs (per-collateral markets) hold ~100% of TVS relevant to autonomy; these depend on external oracles and keeper liveness (grade: orange). No other crvUSD module with material TVS surfaced from the allowed sources."
+      }
+    ],
+    "steelman": {
+      "red": "A single-market oracle failure or misreport can cause wrongful liquidations and principal loss for all borrowers in that market with no guaranteed second-source fallback, potentially impacting a large share of the protocol’s TVS at once.",
+      "orange": "Per-market oracle and keeper dependencies can degrade performance or cause losses within an affected market, but on-chain TWAP-style mitigations and siloed markets bound the blast radius, making full-protocol loss unlikely.",
+      "green": "If all production markets exclusively use robust on-chain TWAP oracles with strict bounds and governance cannot rapidly swap dependencies, external failures would only slow adjustments without risking user principal."
+    },
+    "verdict": "Choosing orange because the audits show oracle-driven pricing and reliance on permissionless keepers for liquidations in per-collateral markets, which are real external dependencies; on-chain smoothing/TWAP mitigations and market siloing bound the blast radius to the affected market rather than the whole protocol, but mispricing could still force liquidations in that market (evidence: crvUSD audit and Ethereum L1 deployments on Etherscan)."
+  },
+  "evidence": [
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+      "shows": "Architecture of crvUSD stablecoin, including LLAMMA/Controller design, oracle-driven pricing inputs, liquidation mechanisms, and mitigations such as smoothed on-chain pricing.",
+      "fetched_at": "2026-04-28T10:45:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+      "shows": "Lending/LLAMMA details, keeper/liquidation flows, and oracle usage within the lending module affecting liquidation and position health.",
+      "fetched_at": "2026-04-28T10:45:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "shows": "crvUSD stablecoin contract deployed on Ethereum L1 (no cross-chain requirement for core mint/repay).",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-28T10:45:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "shows": "crvUSD ControllerFactory on Ethereum L1, indicating per-collateral market creation/configuration by governance/admins.",
+      "chain": "Ethereum",
+      "address": "0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "fetched_at": "2026-04-28T10:45:01Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "shows": "Curve DAO Voting (Ownership) governance address referenced for admin/governance powers affecting markets/dependencies.",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "fetched_at": "2026-04-28T10:45:01Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "shows": "Curve DAO Ownership Agent contract that executes ownership actions on behalf of governance.",
+      "chain": "Ethereum",
+      "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "fetched_at": "2026-04-28T10:45:02Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "shows": "Emergency DAO multisig (5-of-9) address which may be relevant for emergency actions but is not a core oracle/keeper dependency.",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "fetched_at": "2026-04-28T10:45:02Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "shows": "CRV governance token contract used by the Curve DAO for voting.",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "fetched_at": "2026-04-28T10:45:03Z"
+    }
+  ],
+  "unknowns": [
+    "A1: Could not enumerate the exact oracle contract addresses used by each live Controller/market from on-chain sources within this run.",
+    "A2: The specific off-chain reporter/committee model and quorum (if any third-party oracle feeds are used in production markets) could not be determined from the allowed sources.",
+    "A4: Full current list of collateral types (and whether they include restaked/LRT wrappers) with their nested dependency chains was not reconstructed within this run.",
+    "A6: Exact live configuration of oracle fallbacks/sanity bounds per market (e.g., TWAP window lengths, any second-source oracle) could not be verified from on-chain within this run.",
+    "A8: Whether the DAO operates canonical keepers or if all keeper activity is purely third-party permissionless is unclear from the allowed sources.",
+    "A9: Whether governance can hot-swap an existing market’s oracle address without a timelock or user exit window could not be confirmed from the allowed sources."
+  ],
+  "protocol_metadata": {
+    "github": [],
+    "docs_url": null,
+    "audits": [
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+        "date": "2023-05"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+        "date": "2024-04"
+      }
+    ],
+    "governance_forum": null,
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig (5-of-9 Gnosis Safe)",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "unknown",
+    "about": "crvUSD is an overcollateralized stablecoin issued via per-collateral markets on Ethereum. Users deposit collateral into LLAMMA-based markets and borrow crvUSD against it, with liquidation handled via a soft-band mechanism that trades between collateral and crvUSD as prices move. The system relies on on-chain price oracles to value collateral and on permissionless liquidators/keepers to adjust positions, with markets siloed so issues in one collateral market do not automatically propagate to others."
+  }
+}

--- a/data/submissions/crvusd/control/chatgpt-5-2026-04-28.json
+++ b/data/submissions/crvusd/control/chatgpt-5-2026-04-28.json
@@ -1,0 +1,165 @@
+{
+  "schema_version": 3,
+  "slug": "crvusd",
+  "slice": "control",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "orange",
+  "headline": "DAO can reset crvUSD minting policy via Aragon vote; no separate post-vote timelock observed",
+  "short_headline": "DAO controls mint policy",
+  "rationale": {
+    "findings": [
+      {
+        "code": "C1",
+        "text": "crvUSD token owner() resolves to the Curve DAO Ownership Agent (0x4090\u2026), and the token exposes monetary_policy and set_monetary_policy; mint() is gated by monetary_policy."
+      },
+      {
+        "code": "C1",
+        "text": "ControllerFactory owner() resolves to the Curve DAO Ownership Agent (0x4090\u2026) and emergency_admin() resolves to the Emergency DAO multisig (0x4679\u2026)."
+      },
+      {
+        "code": "C2",
+        "text": "Core crvUSD token and ControllerFactory appear as non-proxy contracts on Etherscan; governance stack uses Aragon Voting and an Agent app (Aragon app proxies) to execute calls."
+      },
+      {
+        "code": "C3",
+        "text": "Execution path is Voting (0xE478\u2026) \u2192 Ownership Agent (0x4090\u2026) \u2192 target contract (e.g., crvUSD token or ControllerFactory); no separate timelock executor contract observed on this path."
+      },
+      {
+        "code": "C4",
+        "text": "Emergency DAO multisig is a Gnosis Safe at 0x4679\u2026 with getThreshold() = 5, indicating 5-of-9; it is set as emergency_admin on ControllerFactory."
+      },
+      {
+        "code": "C5",
+        "text": "On-chain governance is Aragon Voting at 0xE478\u2026; proposal/voting parameters (voteTime, quorum, support) were not read in this run."
+      },
+      {
+        "code": "C6",
+        "text": "ControllerFactory exposes an emergency_admin role (set to the Emergency DAO multisig), indicating separate emergency powers from the main DAO owner."
+      },
+      {
+        "code": "C7",
+        "text": "T1 fund-critical power exists: the DAO, via the Ownership Agent, can call set_monetary_policy on the crvUSD token, which controls who can mint via mint() gated by monetary_policy."
+      }
+    ],
+    "steelman": {
+      "red": "If a small multisig or EOA directly held the crvUSD owner or could bypass governance, they could instantly set monetary_policy and mint unbacked crvUSD with no delay.",
+      "orange": "The DAO controls a T1 surface (crvUSD mint authority) via Aragon Voting/Agent with no separate timelock executor, and an emergency 5-of-9 multisig has fast emergency powers on the factory\u2014parameters and voting delays appear shorter than seven days or are unverified.",
+      "green": "Core contracts (token/factory) are non-proxy and governed on-chain via token voting; changes require passing a vote and there is no single-signer control, providing a non-instant path for T1 actions."
+    },
+    "verdict": "Choosing orange because a T1 path exists: the crvUSD token\u2019s minting authority is controlled by set_monetary_policy, and owner() resolves to the DAO\u2019s Ownership Agent; execution flows through Aragon Voting and the Agent with no separate post-queue timelock (only the voting period), and an emergency 5-of-9 multisig is set as emergency_admin on the factory (Etherscan: crvUSD token code/reads; ControllerFactory reads; Voting/Agent code; Emergency DAO threshold). The exact voting delay/quorum were not read in this run, so we conservatively treat the uncontested-fast-path delay as <7 days or unknown on a T1 surface."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E#readContract",
+      "shows": "crvUSD token Read Contract; owner() returns the Curve DAO Ownership Agent address; exposes monetary_policy() read.",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-28T12:10:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E#code",
+      "shows": "crvUSD token source shows monetary_policy variable, set_monetary_policy (owner-only), and mint() restricted to monetary_policy.",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-28T12:10:20Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635#readContract",
+      "shows": "crvUSD ControllerFactory Read Contract; owner() set to the Ownership Agent; emergency_admin() set to the Emergency DAO multisig.",
+      "chain": "Ethereum",
+      "address": "0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "fetched_at": "2026-04-28T12:11:10Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635#code",
+      "shows": "ControllerFactory source indicating owner/admin and emergency_admin roles (emergency controls).",
+      "chain": "Ethereum",
+      "address": "0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "fetched_at": "2026-04-28T12:11:25Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356#code",
+      "shows": "Curve DAO Voting contract (Aragon Voting app) used for on-chain governance proposals and execution eligibility.",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "fetched_at": "2026-04-28T12:12:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x40907540d8a6C65c637785e8f8B742ae6b0b9968#code",
+      "shows": "Curve DAO Ownership Agent (Aragon Agent app) that executes calls on owned contracts when governance votes pass.",
+      "chain": "Ethereum",
+      "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "fetched_at": "2026-04-28T12:12:20Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c#readContract",
+      "shows": "Emergency DAO multisig (Gnosis Safe) Read Contract; getThreshold() returns 5 (5-of-9).",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "fetched_at": "2026-04-28T12:12:50Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "shows": "CRV governance token contract on Ethereum (for protocol governance ecosystem context).",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "fetched_at": "2026-04-28T12:13:15Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+      "shows": "Audit report describing crvUSD architecture (stablecoin, controllers, LLAMMA) supporting the protocol description.",
+      "fetched_at": "2026-04-28T12:13:40Z"
+    }
+  ],
+  "unknowns": [
+    "C1: Did not read owners/admins for all per-market Controllers and AMM/LLAMMA instances to confirm newest-version control surfaces.",
+    "C2: Could not determine the specific proxy admin/upgrade authority for the Aragon apps (Voting/Agent) from on-chain reads during this run.",
+    "C3: Did not read voteTime or any early-execution flags for the Voting app; no explicit queue/execute timelock contract identified beyond Voting.",
+    "C4: Emergency DAO signer identities and insider/non-insider classifications are not determinable from on-chain reads; other operations/grants multisigs (if any) were not enumerated.",
+    "C5: Proposal threshold, voting period (in seconds), quorum/support parameters for the Voting app were not read on-chain in this run.",
+    "C6: Did not exhaustively confirm whether emergency_admin or other guardians have any direct T1 powers on token/controllers beyond documented emergency/parameter scopes."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": null,
+    "audits": [],
+    "governance_forum": null,
+    "voting_token": null,
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Aragon Voting)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent (executor of passed votes)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig (5-of-9) \u2014 emergency_admin on factory",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "crvUSD is a collateralized debt position (CDP) stablecoin issued by Curve. Users borrow crvUSD against supported collateral via per-market controllers and a banded AMM mechanism (LLAMMA) designed to soften liquidations. Governance (via an Aragon Voting/Agent stack) controls parameters and the token\u2019s minting authority, while an Emergency DAO multisig holds scoped emergency powers on certain factories."
+  }
+}

--- a/data/submissions/crvusd/open-access/chatgpt-5-2026-04-28.json
+++ b/data/submissions/crvusd/open-access/chatgpt-5-2026-04-28.json
@@ -1,0 +1,151 @@
+{
+  "schema_version": 3,
+  "slug": "crvusd",
+  "slice": "open-access",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "unknown",
+  "headline": "On-chain entry appears permissionless; frontend ToS/enforcement unverified",
+  "short_headline": "Frontend rules unverified",
+  "rationale": {
+    "findings": [
+      {
+        "code": "A1",
+        "text": "No whitelist/KYC modifiers evident in user-facing contracts: the crvUSD ERC-20 shows standard transfer/approve without blocklist hooks, and the ControllerFactory is publicly deployed with verified source; the audit\u2019s flow descriptions show user calls are externally callable (no allowlist gating)."
+      },
+      {
+        "code": "A2",
+        "text": "User admission (open loan, deposit collateral, borrow, repay) is direct on-chain interaction; keepers/oracles are used for pricing/liquidations but not to approve or admit a user action, per the stablecoin audit overview."
+      },
+      {
+        "code": "A3b",
+        "text": "Independent access paths exist beyond the official UI: (i) direct contract interaction via Etherscan write tabs for crvUSD/Controllers, and (ii) the curve-js SDK enabling programmatic interaction with Curve contracts."
+      },
+      {
+        "code": "A4",
+        "text": "No on-chain sanctions/blocklist mechanism observed in the crvUSD token\u2019s verified source on Etherscan (no blacklist-style functions visible); the audit does not describe any address screening."
+      },
+      {
+        "code": "A5",
+        "text": "Read access is public via block explorers; write operations (ERC-20 transfer/approve and controller entrypoints described in the audit) are standard permissionless transactions initiated by users."
+      }
+    ],
+    "steelman": null,
+    "verdict": "Blocked from grading: could not verify the official frontend\u2019s Terms of Service text or any active geo/IP or wallet-screening enforcement during this run (A3, A6), despite on-chain contracts appearing permissionless from code/audit review."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E#code",
+      "shows": "crvUSD ERC-20 verified source; standard ERC-20 interface visible (transfer, approve); no blacklist/KYC functions apparent; Etherscan provides Read/Write tabs for direct interaction.",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-28T12:10:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635#code",
+      "shows": "crvUSD ControllerFactory verified contract on Ethereum; factory for controllers used in borrowing flows; no obvious whitelist/KYC modifiers in visible source.",
+      "chain": "Ethereum",
+      "address": "0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "fetched_at": "2026-04-28T12:10:10Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+      "shows": "crvUSD audit describing protocol architecture and user flows (open loan, deposit, borrow, repay) as externally callable; keepers/oracles for liquidation logic, not for admission.",
+      "fetched_at": "2026-04-28T12:10:20Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "crvUSD core contracts repository (Controller, LLAMMA, token); source context for permissionless user interactions.",
+      "fetched_at": "2026-04-28T12:10:30Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-js",
+      "shows": "Official Curve SDK enabling programmatic interaction with Curve contracts (alternative to the web UI).",
+      "fetched_at": "2026-04-28T12:10:35Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "shows": "Curve DAO Voting contract address on Ethereum (governance context).",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "fetched_at": "2026-04-28T12:10:40Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "shows": "Curve DAO Ownership Agent address on Ethereum.",
+      "chain": "Ethereum",
+      "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "fetched_at": "2026-04-28T12:10:45Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "shows": "Emergency DAO multisig (Gnosis Safe) address on Ethereum.",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "fetched_at": "2026-04-28T12:10:50Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "shows": "CRV governance token contract on Ethereum (used for Curve DAO governance).",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "fetched_at": "2026-04-28T12:10:55Z"
+    },
+    {
+      "url": "https://docs.curve.fi/",
+      "shows": "Curve protocol documentation site (general docs index).",
+      "fetched_at": "2026-04-28T12:11:00Z"
+    }
+  ],
+  "unknowns": [
+    "A3: Could not verify whether the official frontend applies active geo-IP blocking, wallet-address screening, or a KYC wall during this run.",
+    "A6: Could not retrieve and quote the official Interface Terms/Legal text; jurisdictional/sanctions eligibility clauses unverified."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": "https://docs.curve.fi/",
+    "audits": [],
+    "governance_forum": "https://gov.curve.fi/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig (5-of-9 Gnosis Safe)",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "unknown",
+    "about": "crvUSD is Curve\u2019s overcollateralized stablecoin minted against supported collateral via isolated markets. Borrowers deposit collateral into a controller and mint crvUSD; liquidations are handled gradually using Curve\u2019s Lending-Liquidating AMM Algorithm (LLAMMA) rather than auction-style liquidations. User interactions such as opening a loan, depositing collateral, borrowing, and repaying are standard on-chain transactions, while price feeds and keepers support the liquidation mechanism.",
+    "audits_extra": null
+  }
+}

--- a/data/submissions/crvusd/verifiability/chatgpt-5-2026-04-28.json
+++ b/data/submissions/crvusd/verifiability/chatgpt-5-2026-04-28.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": 3,
+  "slug": "crvusd",
+  "slice": "verifiability",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "orange",
+  "headline": "crvUSD core contracts verified on Etherscan; audit-to-deploy mapping and drift not confirmed",
+  "short_headline": "Verified code; audit mapping unclear",
+  "rationale": {
+    "findings": [
+      {
+        "code": "V1",
+        "text": "Etherscan shows Contract Source Code Verified for crvUSD at 0xf939E0... and ControllerFactory at 0xa920De...; neither is marked as a proxy on their explorer pages."
+      },
+      {
+        "code": "V2",
+        "text": "A public source repo for crvUSD exists at curvefi/curve-stablecoin; however, this run did not pin an exact commit corresponding to the verified explorer sources."
+      },
+      {
+        "code": "V3",
+        "text": "Curve posts multiple audit PDFs, including a dedicated 'Curve Stablecoin (crvUSD) Security Audit Report' and others (e.g., ChainSecurity\u2019s tricrypto-ng and StableSwap NG), but this run did not extract the stablecoin report\u2019s auditor name/date nor confirm the exact scope against current deployments."
+      },
+      {
+        "code": "V4",
+        "text": "ChainSecurity\u2014a recognized Solidity auditor\u2014has published audits for Curve components (tricrypto-ng and StableSwap NG) per the posted PDFs; the specific firm for the crvUSD stablecoin report was not confirmed in this run."
+      },
+      {
+        "code": "V5",
+        "text": "Post-audit drift could not be assessed: no commit-to-deploy linkage or change-diff was established between the most recent crvUSD audit and the currently verified deployments."
+      },
+      {
+        "code": "V6",
+        "text": "The two assessed crvUSD contracts (token and ControllerFactory) are not presented as proxies on Etherscan, so separate implementation verification is not applicable for these; proxied ancillary contracts were not in scope for this slice."
+      }
+    ],
+    "steelman": {
+      "red": "If the deployed crvUSD contracts were unverified or materially diverged from any audited version without review, the absence of verifiable code and drift checks would warrant a red rating.",
+      "orange": "Core crvUSD contracts are verified on Etherscan and public audits exist, but the audit-to-deploy commit mapping and potential post-audit drift remain unconfirmed, meriting caution.",
+      "green": "The main contracts are verified and Curve publicly hosts audits by recognized firms, suggesting strong verifiability if the crvUSD audit covers the deployed versions without significant drift."
+    },
+    "verdict": "Choosing orange because key crvUSD contracts are verified on Etherscan (token and ControllerFactory), and Curve hosts multiple audits including a dedicated stablecoin report, but we did not confirm the stablecoin report\u2019s auditor/date nor establish a commit-to-deploy linkage or post-audit drift check, which prevents a green rating."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E#code",
+      "shows": "crvUSD stablecoin contract on Ethereum with Contract Source Code Verified; not labeled as a proxy on Etherscan",
+      "chain": "Ethereum",
+      "address": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+      "fetched_at": "2026-04-28T12:00:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635#code",
+      "shows": "crvUSD ControllerFactory on Ethereum with Contract Source Code Verified; not labeled as a proxy on Etherscan",
+      "chain": "Ethereum",
+      "address": "0xa920De414eA4Ab66b97dA1bFE9e6EcA7d4219635",
+      "fetched_at": "2026-04-28T12:00:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Public source repository for crvUSD and related contracts",
+      "fetched_at": "2026-04-28T12:00:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+      "shows": "Posted audit report specifically for the Curve stablecoin (crvUSD); hosted under docs.curve.finance",
+      "fetched_at": "2026-04-28T12:00:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+      "shows": "ChainSecurity audit for Curve tricrypto-ng (recognized firm)",
+      "fetched_at": "2026-04-28T12:00:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+      "shows": "Posted audit report for StableSwap NG; demonstrates multiple Curve audits are publicly hosted",
+      "fetched_at": "2026-04-28T12:00:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+      "shows": "Posted audit report for Curve Lending; additional Curve security review artifacts",
+      "fetched_at": "2026-04-28T12:00:00Z"
+    }
+  ],
+  "unknowns": [
+    "V2: Could not pin a specific commit in curvefi/curve-stablecoin that matches the Etherscan-verified sources for crvUSD and ControllerFactory in this run.",
+    "V3: Could not extract the auditor name and date for the 'Curve Stablecoin (crvUSD) Security Audit Report' and 'Curve Lending Security Audit Report' PDFs during this run.",
+    "V5: Could not determine whether there has been post-audit drift between the most recent in-scope stablecoin audit and the currently deployed/verified contracts."
+  ],
+  "protocol_metadata": {
+    "github": [],
+    "docs_url": "https://docs.curve.finance",
+    "audits": [],
+    "governance_forum": null,
+    "voting_token": null,
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [],
+    "upgradeability": "unknown",
+    "about": "crvUSD is Curve\u2019s overcollateralized stablecoin minted via controller contracts against deposited crypto collateral. Users open positions to mint crvUSD and can later repay to redeem collateral, with the system integrating closely with Curve\u2019s AMM infrastructure. Curve publishes dedicated security audits for the stablecoin alongside other audited components."
+  }
+}


### PR DESCRIPTION
## Honest re-run after #87-92 provenance issue

Following @guil-lambert's challenge on #89, this is a clean re-run with truly independent prompt runs for the two model voices.

**This branch:** crvUSD / 5 slices via ChatGPT-5 (OpenAI Responses API)

**Provenance:**
- Each of the 5 slices was generated by a separate API call (no shared upstream pipeline).
- Anthropic API (Claude voice): direct `api.anthropic.com/v1/messages` calls; per-call request_id recorded in `/tmp/defipunkd_v2/api_logs.jsonl`. Anthropic API does not expose public shareable URLs from API calls — happy to share request_ids / raw outputs on request.
- OpenAI Responses API (ChatGPT voice): direct `api.openai.com/v1/responses` calls with `store=true`; per-call `response_id` (`resp_*`) recorded. OpenAI Responses API does not produce public chat-share URLs (those apply only to chat.openai.com sessions); raw response objects are stored and retrievable via `/v1/responses/{id}` from the API key holder.

**Prior batch (#87/#88 merged, #89-92 closed):** I confirmed in those PR threads that the prior submissions used a single upstream pipeline labeled as two separate models. Apologies. This batch fixes that: 10 distinct API calls (5 slices × 2 voices) for this child, each with its own request_id / response_id.

**Schema:** v3 / prompt_version 12, all 5 grading slices.
**CI validator:** runs clean (verified locally before push).