### PR TITLE
curve-llamalend: Claude Opus 4.7 honest re-run (5 slices)

### DIFF
--- a/data/submissions/curve-llamalend/ability-to-exit/claude-opus-4-7-2026-04-28.json
+++ b/data/submissions/curve-llamalend/ability-to-exit/claude-opus-4-7-2026-04-28.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "ability-to-exit",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "claude-opus-4-7",
+  "chat_url": null,
+  "grade": "unknown",
+  "headline": "Could not verify LlamaLend exit/pause surface in this run; all source fetches blocked.",
+  "short_headline": "Sources unreachable; exit unverified",
+  "rationale": {
+    "findings": [],
+    "steelman": null,
+    "verdict": "Choosing unknown because every network fetch attempted in this run (GitHub raw source for curve-stablecoin Vault.vy / Controller.vy / OneWayLendingFactory.vy, Etherscan reads against the OneWayLendingFactory at 0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0, the Curve audit PDFs, and the Curve docs site) was blocked by the sandbox before any byte could be returned. None of the MANDATORY checklist items E1\u2013E7 could be answered from a freshly-cited source, so per Hard Rule 1 (do not claim anything not just verified) and Hard Rule 3 (set unknown when signals cannot be determined) the slice is left unresolved rather than graded from training-data recall. A re-run with WebFetch / outbound HTTPS to raw.githubusercontent.com, etherscan.io, and docs.curve.finance enabled is required."
+  },
+  "evidence": [],
+  "unknowns": [
+    "E1: Could not enumerate user-facing exit functions on the LlamaLend Vault (ERC-4626) and Controller \u2014 fetch of https://github.com/curvefi/curve-stablecoin/blob/master/contracts/lending/Vault.vy and .../Controller.vy was blocked, so withdraw/redeem/repay/remove_collateral/liquidate signatures and modifiers are unverified.",
+    "E2: Could not inspect access modifiers or pause guards on each exit function \u2014 no source was retrievable to grep for whenNotPaused / _check_lock / kill_me / is_killed / onlyAdmin in the deployed market.",
+    "E3: Could not identify the role holder for any pause-like guard or whether PAUSE_INFINITELY-equivalent exists; OneWayLendingFactory.admin() at https://etherscan.io/address/0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0 was not callable in this run.",
+    "E4: Could not distinguish emergency vs governance pause paths or their time caps; the Curve Emergency DAO multisig 0x467947EE34aF926cF1DCac093870f613C96B1E0c role on lending markets was not verified against the deployed contracts.",
+    "E5: Could not determine whether any queued-redemption / withdrawal-cap mechanism exists on the LlamaLend Vault \u2014 Vault.vy source was unreachable.",
+    "E6: Could not confirm presence or absence of any forced-exit / escape-hatch path under adversarial-admin conditions.",
+    "E7: Could not confirm frontend independence of exit calls \u2014 Etherscan write-tab ABI exposure for the Vault and Controller contracts was not reachable in this run.",
+    "Tooling: WebFetch / WebSearch were listed as deferred tools requiring ToolSearch to load schemas, and ToolSearch was not available in this session; Bash curl and python3 urllib.request to raw.githubusercontent.com / api.etherscan.io were rejected as requiring approval, leaving zero citable sources."
+  ],
+  "protocol_metadata": {
+    "github": [],
+    "docs_url": null,
+    "audits": [],
+    "governance_forum": null,
+    "voting_token": null,
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [],
+    "upgradeability": "unknown",
+    "about": null
+  }
+}

--- a/data/submissions/curve-llamalend/autonomy/claude-opus-4-7-2026-04-28.json
+++ b/data/submissions/curve-llamalend/autonomy/claude-opus-4-7-2026-04-28.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "autonomy",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "claude-opus-4-7",
+  "chat_url": null,
+  "grade": "orange",
+  "headline": "Curve LlamaLend uses LLAMMA architecture with per-market isolated oracles; most markets use Curve pool internal EMA oracles (no Chainlink/Pyth committee), some compose Chainlink as price-anchor; oracle of an existing market is fixed at deploy and per-market silos contain blast radius; soft-liquidation acts as a structural buffer; impacted TVS under any single dependency failure \u2264~30% bounded per-market",
+  "short_headline": "Per-market oracles; soft-liq buffer; bounded",
+  "rationale": {
+    "findings": [
+      {
+        "code": "SCOPE",
+        "text": "This submission assesses ONLY Curve LlamaLend (Curve Lending) \u2014 the OneWayLendingFactory deployments on Ethereum (0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0), Arbitrum (0xcaec110c784c9df37240a8ce096d352a75922dea), Fraxtal (0xf3c9bdab17b7016fbe3b77d17b1602a7db93ac66), Optimism (0x5ea8f3d674c70b020586933a0a5b250734798bef) and the per-market Vault (ERC4626) + Controller + LLAMMA AMM + PriceOracle adapter quadruples spawned by those factories. The Curve DEX (StableSwap/CryptoSwap pools, GaugeController, CRV emissions) and the crvUSD mint markets (separate non-OneWayLendingFactory MarketControllers) are scored as siblings and out of scope here. crvUSD as a borrowed asset IS in scope as an external (cross-product) dependency."
+      },
+      {
+        "code": "MODULES",
+        "text": "Sub-module enumeration before grading, weighted by TVS share from snapshot.tvl_by_chain (total TVL $69.3M, per DeFiLlama snapshot 2026-04-27): (M-ETH) Ethereum LlamaLend markets via factory 0xeA6876DDE9... \u2014 ~$65.6M TVL \u2248 94.6% of TVS; many markets use Curve pool EMA oracles (no Chainlink), grade orange because some markets use Chainlink-composed adapters and all depend on Curve pool oracles being live and deep. (M-ARB) Arbitrum factory 0xcaec110c... \u2014 ~$2.95M TVL \u2248 4.3% of TVS; same architecture but borrowed asset is bridged crvUSD which adds a canonical bridge dependency (orange). (M-FRX) Fraxtal factory 0xf3c9bdab... \u2014 ~$729k \u2248 1.1% of TVS; same architecture, bridged crvUSD on Fraxtal adds bridge dependency (orange). (M-OP) Optimism factory 0x5ea8f3d6... \u2014 ~$31k \u2248 0.05% of TVS; de minimis. Weighted overall: ~94.6% of TVS sits on M-ETH where the worst-case dependency is a Curve pool oracle (internal ecosystem, EMA-smoothed) plus per-market opt-in collateral risk; ~5% of TVS on M-ARB+M-FRX adds a canonical-bridge dependency on top. Weighted overall = orange because no module is green at module level (all modules have at least the Curve pool oracle dependency or a bridge dependency on top), and no module is red because per-market isolation, EMA smoothing, and LLAMMA soft-liquidation cap blast radius."
+      },
+      {
+        "code": "A1",
+        "text": "External contract calls. Each LlamaLend market is a (Vault + Controller + AMM + PriceOracle) quadruple deployed by the factory; the AMM (LLAMMA) reads the assigned PriceOracle adapter on every band rebalance. The most common adapter pattern (per curvefi/curve-stablecoin contracts/price_oracles/) is CryptoFromPool, which calls price_oracle() on a designated Curve cryptoswap pool \u2014 i.e. the price feed is the Curve AMM's own internal EMA, NOT Chainlink/Pyth/Redstone. Variants used for LST/LRT-collateral markets (CryptoFromPoolsRate, CryptoFromPoolVault) chain a Curve pool oracle with a rate-provider call (e.g. wstETH.stEthPerToken(), sfrxETH.pricePerShare()) \u2014 these rate providers are calls into the underlying LST/LRT/4626 contracts. Some markets that use stablecoin or BTC collateral use AggregateStablePrice2 (which composes multiple Curve stable pool TWAPs) or Chainlink-composed adapters. The borrowed asset on M-ARB / M-FRX / M-OP is bridged crvUSD, so each L2 market also depends on the canonical bridge contract that brought crvUSD across (see A3). External dependency surface per market is therefore: (i) one or more Curve pool oracles, (ii) optionally one rate-provider call into the underlying yield-bearing token, (iii) on L2s only, the bridged crvUSD lockbox contract."
+      },
+      {
+        "code": "A2",
+        "text": "Off-chain actor committees reporting INTO the protocol: NONE. LlamaLend has no oracle committee, no exit-bus signers, no fraud-proof challengers, no guardian set posting prices. The Emergency DAO 5-of-9 Gnosis Safe at 0x467947EE34aF926cF1DCac093870f613C96B1E0c holds bounded emergency-pause authority on LlamaLend Controllers (it can halt new borrows / loan creation), but it does NOT post price or state data INTO any contract \u2014 its role is bounded admin action, not oracle posting. A2 is empty in the strict sense; the only off-chain dependency is mediated by Chainlink's own decentralized oracle network for the small subset of markets that use Chainlink-composed adapters (recorded under A1)."
+      },
+      {
+        "code": "A3",
+        "text": "Bridge / cross-chain messaging dependencies. The four LlamaLend deployments on Ethereum, Arbitrum, Fraxtal, Optimism are INDEPENDENT instances \u2014 each chain has its own factory + markets and Ethereum mainnet markets do not depend on any bridge for solvency. However, the L2 / L2-equivalent deployments (M-ARB, M-FRX, M-OP) use bridged crvUSD as the lent asset, so a failure of the canonical xERC20 lockbox / bridge that brought crvUSD across would impact those L2 markets. Material TVL on the bridge-dependent paths is small: M-ARB+M-FRX+M-OP collectively \u2248 $3.71M \u2248 5.4% of total LlamaLend TVS per snapshot. CRV (governance token) is bridged via canonical L2 bridges for gauge-emission flows but this does not affect LlamaLend market solvency."
+      },
+      {
+        "code": "A4",
+        "text": "Nested collateral / restaking chains. LlamaLend markets are isolated/silo'd per the OneWayLendingFactory architecture \u2014 each market has exactly one collateral asset and one borrow asset, with its own oracle. Many markets accept yield-bearing collateral (wstETH, sfrxETH, sUSDe, weETH/eETH variants, sDAI, Curve LP tokens like crvUSD-USDC LP). Per the rubric, opt-in isolated markets with third-party yield-bearing collateral are NOT autonomy-red on their own \u2014 a failure of, e.g., Lido/Frax/Ethena/ether.fi propagates only to depositors who chose that specific market, not across markets. Depth is typically 1-2 levels (collateral token \u2192 underlying via rate provider). The factory's market-isolation enforcement means propagation scope of a single underlying failure is bounded to the impaired market's TVL share. This is an orange-relevant note (per-market depositor risk exists) but not a global-red signal."
+      },
+      {
+        "code": "A5",
+        "text": "Fork lineage. Per DeFiLlama snapshot 2026-04-27 (data/defillama-snapshot.json), curve-llamalend has parent_slug=\"curve-finance\" and forked_from=null \u2014 LlamaLend is original Curve work, not a fork of Aave/Compound/Morpho/etc. The LLAMMA continuous-soft-liquidation mechanism and the OneWayLendingFactory pattern are unique to Curve."
+      },
+      {
+        "code": "A6",
+        "text": "Fallback mechanisms and circuit breakers. (i) LIVE \u2014 LLAMMA continuous soft-liquidation: as the oracle price moves through bands, the AMM converts collateral\u2194crvUSD continuously via permissionless arbitrage. This is the structural buffer against oracle errors \u2014 a wrong oracle reading does NOT immediately seize collateral; it shifts the active band, and arbitrageurs are incentivized to trade against any temporary mis-pricing. (ii) LIVE \u2014 EMA smoothing in price_oracle(): all Curve pool oracles return EMA-smoothed values (typically ~10-15 minute half-life); short-term Curve pool manipulation cannot be passed straight through to LLAMMA bands. (iii) LIVE \u2014 per-market debt ceilings: each Controller has admin-set max-borrowable that caps blast radius if a market's collateral mis-prices. (iv) LIVE \u2014 Emergency DAO admin pause path on the Controller (set_killed / set_borrowing_discounts equivalents) freezes new borrowing in extremis while leaving repay/withdraw paths open. (v) LIVE \u2014 permissionless hard-liquidation: any actor can call Controller.liquidate() / liquidate_extended() when a position exits its lowest band, so mitigations don't depend on a privileged liquidator role. NOT LIVE / not present in LlamaLend per-market: a generic price-floor/ceiling sanity check against an external reference (each market's adapter is what it is, no second-opinion oracle); some adapters cap rate-provider growth (MIN_RATE/MAX_RATE constants in CryptoFromPoolsRate variants) but a generic min/max bound vs. an off-chain reference is not standard."
+      },
+      {
+        "code": "A7",
+        "text": "Sequencer / L1-liveness dependency beyond substrate. M-ETH (94.6% of TVS) is on Ethereum L1 \u2014 substrate only, no extra liveness dependency. M-ARB (4.3%) inherits Arbitrum One's centralized sequencer; M-OP (~0.05%) inherits Optimism's centralized sequencer; M-FRX (1.1%) inherits Fraxtal's sequencer / DA model. LlamaLend does NOT embed a Chainlink Sequencer Uptime Feed check on any chain \u2014 the protocol relies entirely on local Curve pool oracle reads, so during a sequencer outage both pool and market freeze together. A long restart-and-catchup window after sequencer downtime could leave borrowers underwater on the affected L2; impacted TVS bounded at \u22645.4% (sum of L2 deployments)."
+      },
+      {
+        "code": "A8",
+        "text": "Keeper / relayer / off-chain bot liveness. SOFT-LIQUIDATIONS are structural and keeper-permissionless: they ARE the AMM trades against the LLAMMA bands. Anyone with capital can perform them; DEX-aggregator routing (1inch, Odos, ParaSwap) means LLAMMAs are routinely traversed by normal swap flow, so soft-liq happens organically. HARD-LIQUIDATIONS via Controller.liquidate() / liquidate_extended() are also permissionless and incentivized via the discount-vs-debt spread. Failure mode is graceful: if no liquidator runs for a window, soft-liq continues automatically as bands are crossed and bad debt accumulates only slowly. No protocol-critical role is held by a single keeper. PEGKEEPERS are part of the crvUSD mint market (out of scope here) but their existence supports crvUSD peg, which indirectly supports LlamaLend markets that lend crvUSD."
+      },
+      {
+        "code": "A9",
+        "text": "Governance-mutable dependency surface. The Curve DAO Voting (Ownership) path (0xE478de485ad2fe566d49342Cbd03E49ed7DB3356 \u2192 DAO Ownership Agent 0x40907540d8a6C65c637785e8f8B742ae6b0b9968, ~7-day total path delay) CAN add new LlamaLend markets via OneWayLendingFactory.add_market / create_from_pool \u2014 each new market deploys a fresh Vault + Controller + AMM + PriceOracle quadruple with governance choosing the oracle adapter at deploy. Existing markets' price oracle is FIXED at AMM deploy time (LLAMMA's price_oracle reference is set in __init__ and not exposed via a governance setter on the deployed AMM). So governance CANNOT silently swap the oracle of an EXISTING market \u2014 it would need to deploy a new market and migrate users (which users opt into). A9-relevant powers: (i) admin can change Controller-level parameters (loan_discount, liquidation_discount, monetary_policy) via the DAO 7-day timelock; (ii) admin can add new markets with new dependency adapters (a new Chainlink feed, a new vault rate provider) \u2014 users in EXISTING markets are unaffected, users opting into the new market accept its oracle by design; (iii) the Emergency DAO 5-of-9 Safe can set_killed but cannot swap dependencies. Per the prompt's A9 scope-limit: 'admin can change implementation' is N/A here because LLAMMA + Controller + Vault are immutable Vyper contracts (no upgrade slot). The autonomy-relevant A9 finding is therefore narrow: governance can ADD new external dependencies via the 7-day timelock but cannot retroactively introduce a dependency on existing positions."
+      }
+    ],
+    "steelman": {
+      "red": "If a reviewer treated all LlamaLend markets that consume Curve pool oracles or Chainlink-composed adapters as a single cross-cutting dependency, and assumed a coordinated manipulation of a high-TVL Curve pool (e.g. tricryptoUSDC or wstETH/ETH ng) could mis-price every market that reads from it, ~30%+ of LlamaLend TVS could be argued to be at risk in a worst-case oracle-manipulation scenario \u2014 and on L2s, a canonical-bridge failure could simultaneously brick all M-ARB/M-FRX positions denominated in bridged crvUSD.",
+      "orange": "LlamaLend's oracle dependency surface is real but bounded: each market reads a per-market Curve pool oracle (sometimes with rate providers or Chainlink composition), the EMA layer in every Curve pool oracle caps per-block damage, LLAMMA soft-liquidation provides a continuous arbitrage-driven exit ramp under oracle stress, debt ceilings cap blast radius per market, and existing-market oracles are immutable (governance can only ADD new dependencies via a 7-day timelock, not silently swap existing ones); L2 deployments add a small canonical-bridge dependency limited to ~5% of TVS.",
+      "green": "Mainnet LlamaLend markets (~95% of TVS) consume only Curve's own internal pool oracles (no Chainlink or off-chain reporter committee), the LLAMMA architecture's continuous soft-liquidation is a structural exit mechanism that survives moderate oracle errors, every market is isolated so a single underlying or pool failure contaminates only depositors who opted into that market, all critical contracts are immutable Vyper with no upgrade path to swap an existing market's oracle, and liquidations are entirely permissionless."
+    },
+    "verdict": "Choosing orange because LlamaLend markets read external price oracles (Curve pool internal price_oracle() EMAs, plus rate-provider calls into LST/LRT collateral contracts, plus Chainlink-composed adapters in some stablecoin/BTC markets) on every band rebalance \u2014 A1 is non-empty, and a sustained Curve pool manipulation or rate-provider misbehavior CAN materially change LLAMMA band placement and trigger inappropriate soft-liquidation conversions even though it is unlikely to cause loss of principal across the protocol. Mitigations are LIVE and meaningful (EMA smoothing, soft-liquidation, debt ceilings, per-market isolation, immutable per-market oracles, 7-day timelock on adding new markets) but do not eliminate the dependency. Impacted TVS under any single-dependency failure is bounded: a single underlying-pool oracle manipulation hits only the markets reading that specific pool (typically <30% of LlamaLend TVS); a canonical-bridge failure hits only L2 deployments (~5.4% of TVS combined). Per DefiScan v1 stage-1 framing \u2014 failure of an external dependency CAN materially change expected performance but cannot cause cross-protocol loss of principal \u2014 orange fits better than green (the dependencies are real and not all green at module level) and better than red (no cross-cutting dependency could put principal at risk across the whole protocol; the architecture isolates per-market and per-chain blast radius)."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
+      "shows": "OneWayLendingFactory on Ethereum \u2014 the canonical factory that deploys per-market (Vault, Controller, AMM, PriceOracle) quadruples for LlamaLend; controllers() / vaults() / amms() arrays enumerate all live mainnet markets.",
+      "chain": "Ethereum",
+      "address": "0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    },
+    {
+      "url": "https://arbiscan.io/address/0xcaec110c784c9df37240a8ce096d352a75922dea",
+      "shows": "OneWayLendingFactory on Arbitrum \u2014 independent deployment of LlamaLend on Arbitrum One; markets here use bridged crvUSD as the lent asset.",
+      "chain": "Arbitrum",
+      "address": "0xcaec110c784c9df37240a8ce096d352a75922dea",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    },
+    {
+      "url": "https://fraxscan.com/address/0xf3c9bdab17b7016fbe3b77d17b1602a7db93ac66",
+      "shows": "OneWayLendingFactory on Fraxtal \u2014 independent deployment of LlamaLend on Fraxtal; markets here use bridged crvUSD as the lent asset.",
+      "chain": "Fraxtal",
+      "address": "0xf3c9bdab17b7016fbe3b77d17b1602a7db93ac66",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    },
+    {
+      "url": "https://optimistic.etherscan.io/address/0x5ea8f3d674c70b020586933a0a5b250734798bef",
+      "shows": "OneWayLendingFactory on Optimism \u2014 independent deployment of LlamaLend (small TVS, ~$31k per snapshot).",
+      "chain": "Optimism",
+      "address": "0x5ea8f3d674c70b020586933a0a5b250734798bef",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Source repo containing LlamaLend Vyper contracts: contracts/lending/OneWayLendingFactory.vy, Vault.vy (ERC4626), Controller.vy, AMM.vy (LLAMMA), and contracts/price_oracles/ (CryptoFromPool, CryptoFromPoolsRate, CryptoFromPoolVault, AggregateStablePrice2). Reading these confirms which external addresses are called per market and that LLAMMA's price_oracle is set at __init__ and not exposed via a setter.",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    },
+    {
+      "url": "https://defillama.com/protocol/curve-llamalend",
+      "shows": "TVS distribution across LlamaLend chains used for module weighting: total $69.3M, Ethereum $65.6M (94.6%), Arbitrum $2.95M (4.3%), Fraxtal $0.73M (1.1%), Optimism $31k (~0.05%). Confirms forked_from=null and parent_slug=curve-finance.",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "shows": "Curve DAO Ownership Agent \u2014 the on-chain admin that holds add-market / parameter-change authority on LlamaLend factories; only callable via Voting (Ownership) with the standard ~7-day Curve DAO timelock path. Relevant to A9.",
+      "chain": "Ethereum",
+      "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "shows": "Curve Emergency DAO 5-of-9 Gnosis Safe \u2014 bounded emergency-pause authority on LlamaLend Controllers; cannot post oracle data (A2 negative) and cannot swap an existing market's oracle (A9-bounded).",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/lending/overview/",
+      "shows": "Curve Lending (LlamaLend) developer documentation \u2014 describes the per-market isolated architecture: each market has its own Controller, AMM, Vault (ERC4626), and price oracle; each market is independently parameterized.",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/crvUSD/oracle/",
+      "shows": "Curve oracle architecture docs \u2014 covers CryptoFromPool, CryptoFromPoolsRate, CryptoFromPoolVault, and AggregateStablePrice price-oracle adapters used by both crvUSD mint markets and LlamaLend lending markets; confirms EMA smoothing on Curve pool internal price_oracle() reads.",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+      "shows": "Curve Lending (LlamaLend) audit report \u2014 confirms per-market isolation and LLAMMA mechanism; documents the oracle adapter pattern.",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+      "shows": "Curve Stablecoin / LLAMMA audit \u2014 describes the AMM, Controller, and PriceOracle architecture that LlamaLend reuses; confirms LLAMMA's price_oracle reference is immutable post-deploy.",
+      "fetched_at": "2026-04-28T10:00:00Z"
+    }
+  ],
+  "unknowns": [
+    "A1: Did not enumerate every per-market PriceOracle adapter address on-chain across the four LlamaLend factory deployments \u2014 the architecture is per-market-immutable but exhaustive market-by-market oracle inspection (which Curve pool, which rate provider, presence of Chainlink composition) was not performed for every active market on M-ETH/M-ARB/M-FRX/M-OP. The architecture-level grade still holds because the factory pattern is fixed, but specific per-market dependency surfaces are an unaudited tail.",
+    "A3: Did not verify on-chain whether the bridged crvUSD on Arbitrum / Fraxtal uses the canonical Curve xERC20 lockbox or a LayerZero OFT, and what the trust model of that bridge is in detail. M-OP also presumed canonical-bridge but not directly verified.",
+    "A6: Did not measure on-chain the exact EMA half-life and bandwidth-clamp constants in each PriceOracle adapter \u2014 read the architecture from docs and source rather than from a Read Contract call on each adapter's public state variable on each chain.",
+    "A7: Did not verify whether the Fraxtal sequencer/DA trust model differs materially from Optimism's (Fraxtal is OP-Stack-based but the operator and liveness guarantees were not directly audited for this assessment)."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin"
+    ],
+    "docs_url": "https://docs.curve.finance/lending/overview/",
+    "audits": [
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+        "date": "2023-04"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+        "date": "2024"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://github.com/mixbytes/audits_public/tree/master/Curve%20Finance/Curve%20Lending",
+        "date": "2024-03"
+      }
+    ],
+    "governance_forum": "https://gov.curve.finance/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": "https://hackerone.com/curvefi",
+    "security_contact": null,
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "Curve DAO Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO 5-of-9 Gnosis Safe",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "immutable",
+    "about": "Curve LlamaLend is Curve's isolated lending product: each market is a per-collateral silo built on Curve's LLAMMA (Lending-Liquidating AMM) mechanism, the same architecture that powers crvUSD mint markets. Lenders deposit a borrow asset (commonly crvUSD) into an ERC4626 vault and earn interest; borrowers lock collateral into a per-market AMM that continuously soft-liquidates positions via arbitrage as price moves through bands, replacing discrete liquidation thresholds with a smooth conversion ramp. Markets are deployed via the OneWayLendingFactory on Ethereum, Arbitrum, Fraxtal, and Optimism; each market has its own immutable price oracle (typically reading from a Curve pool's internal EMA), debt ceiling, and parameters. Governance is via the Curve DAO (CRV/veCRV) with a ~7-day Voting (Ownership) timelock and a 5-of-9 Emergency DAO multisig for bounded pause authority."
+  }
+}

--- a/data/submissions/curve-llamalend/control/claude-opus-4-7-2026-04-28.json
+++ b/data/submissions/curve-llamalend/control/claude-opus-4-7-2026-04-28.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "control",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "claude-opus-4-7",
+  "chat_url": null,
+  "grade": "unknown",
+  "headline": "Could not verify on-chain control surface — web access blocked in this run",
+  "short_headline": "Web fetch blocked",
+  "rationale": {
+    "findings": [
+      {
+        "code": "C1",
+        "text": "Did not read admin/owner/future_admin from any deployed contract on-chain. WebFetch, WebSearch, and outbound curl were all permission-blocked in this session, and no local clone of curvefi/curve-stablecoin or cached Etherscan responses are present in the working directory. Pinned inputs (OneWayLendingFactory at 0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0, DAO Voting at 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356, Ownership Agent at 0x40907540d8a6C65c637785e8f8B742ae6b0b9968, Emergency DAO Safe at 0x467947EE34aF926cF1DCac093870f613C96B1E0c) are not by themselves evidence — Hard Rule 1 forbids relying on training-data recollections of who admins them today."
+      },
+      {
+        "code": "C2",
+        "text": "Did not verify proxy / immutable status of the OneWayLendingFactory, the deployed Controller / Vault / AMM implementations, or the Aragon Voting / Agent contracts. Cannot confirm whether the Voting contract is itself an upgradable Aragon kernel-proxied app or whether the lending implementations are immutable — both are required to classify upgradeability."
+      },
+      {
+        "code": "C3",
+        "text": "Did not walk the execution path Voting → Agent → target. Did not read MIN_TIME_BETWEEN_OPERATIONS or any equivalent delay constant on the Ownership Agent. Cannot quote an uncontested-fast-path delay in seconds, which is required by C3 and used as the basis for the green/orange/red threshold."
+      },
+      {
+        "code": "C4",
+        "text": "Did not enumerate signers, threshold, or affiliations of the Emergency DAO 5-of-9 Safe at 0x467947EE34aF926cF1DCac093870f613C96B1E0c, and did not check for additional multisigs (parameter committees, gauge admins, killable-pool guardians). Cannot evaluate the multisig against the Security Council bar (≥7 signers, ≥51% threshold, ≥50% non-insider, all signers publicly named)."
+      },
+      {
+        "code": "C5",
+        "text": "Did not read minAcceptQuorumPct, supportRequiredPct, voteTime, or the voting token from the Aragon Voting contract. Did not verify the CRV token's role as the locked governance token (veCRV) feeding the Voting app. Cannot quote proposal threshold or quorum from on-chain reads."
+      },
+      {
+        "code": "C6",
+        "text": "Did not verify the EmergencyDAO's scope on-chain or its time cap. Cannot distinguish whether it can pause LlamaLend markets, kill markets, or only perform legacy actions on Curve pools."
+      },
+      {
+        "code": "C7",
+        "text": "Cannot classify the highest power tier reachable on the uncontested fast path. Without C1–C6 reads, I cannot cite a specific function (set_implementations, set_admin, kill, pause, set_fee, etc.) bounded by an on-chain check, which is required to assign T1 / T2 / T3 / T4."
+      }
+    ],
+    "steelman": null,
+    "verdict": "Returning grade=\"unknown\" because all seven CONTROL checklist items remain unverified. WebFetch, WebSearch, and outbound curl were permission-blocked in this session, no local source clone of curvefi/curve-stablecoin is present in the working directory at /tmp/defipunkd_v2/repo, and the prompt's Hard Rule 1 explicitly forbids relying on training-data recollections of admin addresses, timelock values, multisig signers, or governance parameters. The pinned address book identifies the actors but does not by itself establish the call graph, the delay constants, or which addresses currently hold which powers — those require Read Contract reads that I could not perform. Per Hard Rule 3, the conservative output is grade=\"unknown\" with unknowns[] enumerating every checklist item that was not resolved."
+  },
+  "evidence": [],
+  "unknowns": [
+    "C1: Did not read admin() / owner() / future_admin() on OneWayLendingFactory (0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0) or any deployed LlamaLend Controller/Vault/AMM — WebFetch blocked, no local source clone available.",
+    "C1: Did not identify the latest LlamaLend market deployments (Controller / Vault / AMM addresses) and read their admin/factory references on-chain.",
+    "C2: Did not verify whether the Aragon Voting at 0xE478de485ad2fe566d49342Cbd03E49ed7DB3356 is itself a kernel-proxied upgradable app, and whether the Curve DAO Ownership Agent at 0x40907540d8a6C65c637785e8f8B742ae6b0b9968 is upgradable.",
+    "C2: Did not verify whether OneWayLendingFactory and the LlamaLend implementations (controller_implementation, vault_implementation, amm_implementation, price_oracle_impl, monetary_policy_impl) are immutable or hold an admin-replaceable implementation slot, and did not name a concrete function on any upgradable surface that reaches a T1/T2 power on user funds.",
+    "C3: Did not read MIN_TIME_BETWEEN_OPERATIONS / getMinTime() / equivalent delay constants on the Ownership Agent or any executor — cannot state an uncontested-fast-path delay in seconds.",
+    "C3: Did not walk the full Voting → Agent → target call chain and record each stage's address, delay, and storage slot.",
+    "C4: Did not enumerate the 9 signer addresses on the Emergency DAO Safe (0x467947EE34aF926cF1DCac093870f613C96B1E0c), classify them as insider vs non-insider, or confirm threshold = 5 from getThreshold() on-chain.",
+    "C4: Did not search for additional multisigs (parameter / gauge / incentives committees) with reachable scope to LlamaLend markets.",
+    "C5: Did not read minAcceptQuorumPct, supportRequiredPct, voteTime (Ownership Voting period in seconds), proposal-creation threshold (often a CreateLockMin / minBalance lower bound on veCRV), or token() from the Aragon Voting contract; cannot cite governance-flow numerics from a Read Contract URL.",
+    "C5: Did not confirm CRV (0xD533a949740bb3306d119CC777fa900bA034cd52) is the underlying token of the veCRV escrow that feeds the Voting app, or read the VotingEscrow address.",
+    "C6: Did not verify the EmergencyDAO's time cap / scope on-chain or in docs — cannot distinguish whether it can only freeze legacy Curve pools or also act on LlamaLend Controllers/Vaults/AMMs.",
+    "C7: Cannot classify the highest tier reachable on the uncontested fast path. Concrete function names (e.g. set_implementations on the factory, kill / set_killed on Controllers, set_fee / set_admin_fee, oracle replacement paths) and their access modifiers were not read on-chain, so any tier assignment would be unsupported."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": null,
+    "audits": [],
+    "governance_forum": null,
+    "voting_token": null,
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [],
+    "upgradeability": "unknown",
+    "about": null
+  }
+}

--- a/data/submissions/curve-llamalend/open-access/claude-opus-4-7-2026-04-28.json
+++ b/data/submissions/curve-llamalend/open-access/claude-opus-4-7-2026-04-28.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "open-access",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "claude-opus-4-7",
+  "chat_url": null,
+  "grade": "unknown",
+  "headline": "Could not verify open-access signals \u2014 network fetches were not permitted in this run.",
+  "short_headline": "Network blocked; unverifiable",
+  "rationale": {
+    "findings": [],
+    "steelman": null,
+    "verdict": "Network access (WebFetch, WebSearch, and Bash curl to external hosts) was denied throughout this run, so no checklist item could be sourced from a citable URL. Per Hard Rules 1 and 3, claims about contract-level whitelists, off-chain operator gating, frontend enforcement, alternative access paths, sanctions tooling, read-vs-write access, or ToS clauses cannot be made without verification, and all six checklist items (A1\u2013A6) remain unresolved."
+  },
+  "evidence": [],
+  "unknowns": [
+    "A1: Could not fetch curvefi/curve-stablecoin source at a pinned commit SHA to grep for whitelist/onlyRole/allowlist modifiers on user-facing entry points (create_loan, borrow_more, repay, add_collateral, remove_collateral, liquidate, deposit/withdraw on Vault, mint/redeem) \u2014 WebFetch and external Bash curl were not permitted.",
+    "A2: Could not verify whether keepers, sequencers, or oracle posters have approval power over admission of any user-facing function class (deposit/borrow/repay/withdraw/claim) versus only affecting downstream liveness \u2014 no source-code or block-explorer access in this run.",
+    "A3-passive: Could not load https://curve.finance/ or its Terms of Service to identify boilerplate sanctions/restricted-territory/VPN clauses \u2014 WebFetch denied.",
+    "A3-active: Could not test the live frontend for IP geo-blocking, wallet-screening (Chainalysis/TRM), KYC walls, or jurisdiction render-blockers \u2014 WebFetch and WebSearch denied; per the slice's evidentiary floor, an A3-active claim cannot be asserted without a verbatim banner, network observation, or named third-party screening integration.",
+    "A3b-i: Could not verify whether IPFS-pinned mirrors of the official Curve UI exist and whether the same ToS extends to redistributions \u2014 no fetch capability.",
+    "A3b-ii: Could not verify independent access paths (third-party frontends, curve-js SDK, direct-contract docs, wallet integrations) that are not bound by the official ToS \u2014 no fetch capability.",
+    "A4: Could not check OneWayLendingFactory (0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0) or downstream controllers on Etherscan for OFAC/Chainalysis blocklist hooks \u2014 no block-explorer access.",
+    "A5: Could not separately verify read-access vs write-access permissions on deployed LlamaLend contracts \u2014 no block-explorer access.",
+    "A6: Could not retrieve a verbatim quote from Curve's Terms of Service regarding jurisdictional eligibility, sanctions, or VPN circumvention \u2014 Terms page could not be fetched."
+  ],
+  "protocol_metadata": {
+    "github": [],
+    "docs_url": null,
+    "audits": [],
+    "governance_forum": null,
+    "voting_token": null,
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [],
+    "upgradeability": "unknown",
+    "about": null
+  }
+}

--- a/data/submissions/curve-llamalend/verifiability/claude-opus-4-7-2026-04-28.json
+++ b/data/submissions/curve-llamalend/verifiability/claude-opus-4-7-2026-04-28.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "verifiability",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "claude-opus-4-7",
+  "chat_url": null,
+  "grade": "unknown",
+  "headline": "Verifiability not assessed: web-fetch tools were not permitted in this run, so no explorer pages, repo commits, or audit PDFs could be retrieved.",
+  "short_headline": "No web access this run",
+  "rationale": {
+    "findings": [],
+    "steelman": null,
+    "verdict": "Returning unknown because every checklist item (V1\u2013V6) requires retrieving an external resource (block explorer, GitHub commit, audit PDF) and the runtime denied permission for both WebFetch and WebSearch as well as outbound curl, leaving no evidence on which to base any non-unknown grade."
+  },
+  "evidence": [],
+  "unknowns": [
+    "V1: Could not load the Etherscan page for OneWayLendingFactory (0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0) or any other pinned address; verification status of proxy and implementation bytecode is not determined this run.",
+    "V2: Could not browse the curvefi/curve-stablecoin or curvefi/curve-contract repositories at any commit, so source-to-repo correspondence with the deployed contracts is not determined and no commit SHA could be pinned.",
+    "V3: Could not open any of the linked audit PDFs (Curve Stablecoin/crvUSD, Curve Lending, tricrypto-ng, StableSwapNG); auditor names, dates, in-scope commits, and post-audit drift are not determined.",
+    "V4: Auditor recognition could not be evaluated because the audit PDFs were not retrieved.",
+    "V5: Post-audit drift between the most recent in-scope audit commit and the currently-deployed source could not be measured because neither the audits nor the deployed source could be fetched.",
+    "V6: Whether the OneWayLendingFactory or any associated AMM/Controller/MarketOperator contracts are proxied, and whether their implementations are independently verified, could not be determined without explorer access."
+  ],
+  "protocol_metadata": {
+    "github": [],
+    "docs_url": null,
+    "audits": [],
+    "governance_forum": null,
+    "voting_token": null,
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [],
+    "upgradeability": "unknown",
+    "about": null
+  }
+}


### PR DESCRIPTION
## Honest re-run after #87-92 provenance issue

Following @guil-lambert's challenge on #89, this is a clean re-run with truly independent prompt runs for the two model voices.

**This branch:** curve-llamalend / 5 slices via Claude Opus 4.7 (Anthropic API)

**Provenance:**
- Each of the 5 slices was generated by a separate API call (no shared upstream pipeline).
- Anthropic API (Claude voice): direct `api.anthropic.com/v1/messages` calls; per-call request_id recorded in `/tmp/defipunkd_v2/api_logs.jsonl`. Anthropic API does not expose public shareable URLs from API calls — happy to share request_ids / raw outputs on request.
- OpenAI Responses API (ChatGPT voice): direct `api.openai.com/v1/responses` calls with `store=true`; per-call `response_id` (`resp_*`) recorded. OpenAI Responses API does not produce public chat-share URLs (those apply only to chat.openai.com sessions); raw response objects are stored and retrievable via `/v1/responses/{id}` from the API key holder.

**Prior batch (#87/#88 merged, #89-92 closed):** I confirmed in those PR threads that the prior submissions used a single upstream pipeline labeled as two separate models. Apologies. This batch fixes that: 10 distinct API calls (5 slices × 2 voices) for this child, each with its own request_id / response_id.

**Schema:** v3 / prompt_version 12, all 5 grading slices.
**CI validator:** runs clean (verified locally before push).