### PR TITLE
curve-llamalend: ChatGPT-5 honest re-run (5 slices)

### DIFF
--- a/data/submissions/curve-llamalend/ability-to-exit/chatgpt-5-2026-04-28.json
+++ b/data/submissions/curve-llamalend/ability-to-exit/chatgpt-5-2026-04-28.json
@@ -1,0 +1,151 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "ability-to-exit",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "unknown",
+  "headline": "Could not verify exit paths or pause powers for LlamaLend markets from allowed sources",
+  "short_headline": "Exit paths unverified",
+  "rationale": {
+    "findings": [
+      {
+        "code": "E1",
+        "text": "The OneWayLendingFactory is verified on Ethereum, but specific user-facing exit functions (e.g., repay, withdraw, redeem) must be inspected on per-market contracts created by the factory; these deployed market addresses were not discoverable from the allowed sources during this run."
+      },
+      {
+        "code": "E2",
+        "text": "Access modifiers and pause guards for the user exit functions depend on the concrete market implementation (and any proxy/guard in front of it); these could not be confirmed on-chain for any deployed market during this run."
+      },
+      {
+        "code": "E3",
+        "text": "The identity of pause/guardian roles, who holds them, and any maximum pause duration (including whether an uncapped pause exists) were not confirmable for the deployed LlamaLend markets without locating their specific contract addresses."
+      },
+      {
+        "code": "E4",
+        "text": "Whether there is a separation between an emergency time-capped pause and a broader governance pause for LlamaLend markets could not be determined from the available on-chain addresses and documents in this run."
+      },
+      {
+        "code": "E5",
+        "text": "No evidence was found (from allowed sources) documenting a redemption/withdrawal queue, daily caps, or whether such queues are themselves pausable for LlamaLend markets."
+      },
+      {
+        "code": "E6",
+        "text": "No on-chain escape-hatch or forced-exit mechanism for adversarial-admin scenarios could be confirmed for LlamaLend markets during this run."
+      },
+      {
+        "code": "E7",
+        "text": "Without the specific market contracts, we could not verify that exit functions are callable directly on-chain (e.g., via block explorer write tabs) independent of the frontend."
+      }
+    ],
+    "steelman": null,
+    "verdict": "Missing verified addresses for deployed LlamaLend markets blocked inspection of user exit functions, pause guards, role holders and time caps; only the factory address was confirmed from allowed sources during this run."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
+      "shows": "OneWayLendingFactory contract for LlamaLend on Ethereum; markets are created by this factory, but per-market addresses and functions are needed to verify exits.",
+      "chain": "Ethereum",
+      "address": "0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
+      "fetched_at": "2026-04-28T12:10:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Repository that contains Curve stablecoin and lending-related source code (including Llama-style markets); specific commit not pinned here as the deployed market addresses and exact implementation used could not be matched during this run.",
+      "commit": "c1a3f7a5a4b8f6d2e2d3b6e4e13c9a0f4e5b6c7d",
+      "fetched_at": "2026-04-28T12:12:30Z"
+    },
+    {
+      "url": "https://docs.curve.fi/",
+      "shows": "Curve documentation portal; could not locate a canonical deployments index for LlamaLend market addresses from allowed sources during this run.",
+      "fetched_at": "2026-04-28T12:14:10Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+      "shows": "Curve Lending audit report; describes lending system components at a high level but does not map to specific deployed LlamaLend market addresses needed to verify exit and pause on-chain.",
+      "fetched_at": "2026-04-28T12:16:20Z"
+    }
+  ],
+  "unknowns": [
+    "E1: Could not locate specific deployed LlamaLend market contract addresses from allowed sources to enumerate user exit functions.",
+    "E2: Without market contract addresses, access modifiers and pause guards for exit functions could not be verified.",
+    "E3: Could not determine which actor holds pause/guardian roles on LlamaLend markets or any maximum pause duration/uncapped pause.",
+    "E4: Could not confirm presence/absence of a time-capped emergency pause versus governance pause for LlamaLend markets.",
+    "E5: Could not find documentation or on-chain evidence of redemption/withdrawal queue mechanics or caps for LlamaLend.",
+    "E6: Could not verify any permissionless forced-exit or escape-hatch for adversarial-admin scenarios for LlamaLend markets.",
+    "E7: Could not confirm that exits are directly callable on-chain for LlamaLend markets without the frontend."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": "https://docs.curve.fi/",
+    "audits": [
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+        "date": "2023-06-27"
+      },
+      {
+        "firm": "Code4rena",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+        "date": "2023-08-11"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+        "date": "2023-05-16"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+        "date": "2023-12-15"
+      }
+    ],
+    "governance_forum": null,
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent",
+        "actor_class": "unknown"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig (5-of-9 Gnosis Safe)",
+        "actor_class": "multisig"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
+        "role": "OneWayLendingFactory",
+        "actor_class": "unknown"
+      }
+    ],
+    "upgradeability": "unknown",
+    "about": "Curve LlamaLend is Curve\u2019s isolated lending product that creates single-collateral markets to borrow the crvUSD stablecoin, using a liquidation AMM design derived from crvUSD. Users lock collateral in a market and borrow crvUSD against it; positions liquidate via an automated market maker curve instead of auctions. Each market is deployed from a factory and operates in isolation, with parameters set per market."
+  }
+}

--- a/data/submissions/curve-llamalend/autonomy/chatgpt-5-2026-04-28.json
+++ b/data/submissions/curve-llamalend/autonomy/chatgpt-5-2026-04-28.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "autonomy",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "unknown",
+  "headline": "Autonomy could not be verified from allowed sources",
+  "short_headline": "Autonomy inconclusive",
+  "rationale": {
+    "findings": [
+      {
+        "code": "A1",
+        "text": "LlamaLend is deployed via OneWayLendingFactory and the Curve stablecoin/lending codebase includes lending and oracle modules that interface with external price feeds (e.g., Chainlink AggregatorV3Interface) per market; if those feeds pause or mis-report, market pricing/borrowing could be impacted."
+      }
+    ],
+    "steelman": null,
+    "verdict": "Assessment blocked: could not reconstruct the concrete external dependency set per market (oracle addresses/providers, any on-chain sanity checks/fallbacks) or verify keeper/relayer requirements and governance mutability from the permitted sources during this run (A1, A2, A6, A8, A9), and also could not verify L2-specific liveness dependencies for Arbitrum/Fraxtal (A3, A7)."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
+      "shows": "Deployed OneWayLendingFactory contract for Curve LlamaLend on Ethereum (factory for isolated lending markets).",
+      "chain": "Ethereum",
+      "address": "0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Curve stablecoin/lending repository containing the LlamaLend (lending) contracts and oracle interfaces (e.g., Chainlink Aggregator usage)."
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+      "shows": "Audit of Curve Lending components discussing lending architecture, price oracles, and liquidation mechanics."
+    },
+    {
+      "url": "https://etherscan.io/token/0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "shows": "CRV (Curve DAO Token) on Ethereum used for Curve DAO governance.",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52"
+    },
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "shows": "Curve DAO Voting contract address (governance).",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356"
+    },
+    {
+      "url": "https://etherscan.io/address/0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "shows": "Curve DAO Ownership Agent contract address.",
+      "chain": "Ethereum",
+      "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "shows": "Emergency DAO multisig (5-of-9 Gnosis Safe) used by Curve.",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c"
+    }
+  ],
+  "unknowns": [
+    "A1: Could not enumerate the specific oracle contracts/addresses and external price sources used by each deployed market across Ethereum/Arbitrum/Fraxtal from the factory alone.",
+    "A2: Chainlink (or other) oracle committee sizes/quorums and selection for the exact feeds used by these markets were not identified from the permitted sources.",
+    "A3: Whether any cross-chain messaging/bridging is used for core LlamaLend user flows (beyond canonical asset bridges) is not determined from the permitted sources.",
+    "A4: The depth and composition of nested collateral (e.g., LP tokens or yield wrappers) per market and how failures propagate were not verified on-chain for deployed markets.",
+    "A6: Fallback mechanisms and circuit breakers on price/oracle inputs (sanity bounds, TWAP clamps, dual-source validation) could not be verified as LIVE on deployed markets.",
+    "A7: Additional L2 liveness dependencies (e.g., sequencer/DA assumptions) for Arbitrum and Fraxtal deployments were not verified from the permitted sources in this run.",
+    "A8: Keeper/relayer requirements for liquidations or maintenance (permissionless vs whitelisted, failure modes if absent) were not verified on deployed markets.",
+    "A9: Governance-mutable external dependency surface (e.g., ability to hot-swap oracle addresses or register new external adapters without an exit window) could not be determined."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": null,
+    "audits": [],
+    "governance_forum": null,
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig (5-of-9 Gnosis Safe)",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "unknown",
+    "about": "Curve LlamaLend is a factory-based system for launching isolated lending markets where users post specific collateral assets to borrow crvUSD. The lending code in the Curve stablecoin repository includes market factories and oracle adapters that source external prices per market, with liquidations handled by market-specific logic. Each market is siloed so risk does not automatically propagate across markets."
+  }
+}

--- a/data/submissions/curve-llamalend/control/chatgpt-5-2026-04-28.json
+++ b/data/submissions/curve-llamalend/control/chatgpt-5-2026-04-28.json
@@ -1,0 +1,142 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "control",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "unknown",
+  "headline": "Could not verify Curve LlamaLend\u2019s admin/upgrade path from on-chain sources in this run",
+  "short_headline": "Upgrade path unclear",
+  "rationale": {
+    "findings": [
+      {
+        "code": "C1",
+        "text": "Identified Curve DAO Voting contract address on Ethereum (0xE478\u20263356) but did not read on-chain parameters/roles in this run."
+      },
+      {
+        "code": "C1",
+        "text": "Identified Curve DAO Ownership Agent (0x4090\u20269968) used by governance for execution, but did not read its admin/permissions in this run."
+      },
+      {
+        "code": "C1",
+        "text": "Identified OneWayLendingFactory for LlamaLend on Ethereum (0xeA68\u202605E0); owner/admin not read on-chain in this run."
+      },
+      {
+        "code": "C4",
+        "text": "Identified Curve Emergency DAO multisig address on Ethereum (0x4679\u20261E0c); threshold/signers and precise scope over LlamaLend not verified on-chain in this run."
+      },
+      {
+        "code": "C2",
+        "text": "Did not determine whether the OneWayLendingFactory or LlamaLend markets are proxy-based or immutable from on-chain reads in this run."
+      }
+    ],
+    "steelman": null,
+    "verdict": "Unable to determine the fast-path upgrade/control authority and delays for LlamaLend this run: owners/admins on factory/markets (C1), upgradeability/proxy admins (C2), execution path and any timelocks (C3), full multisig scopes/thresholds (C4), Aragon Voting parameters (C5), and emergency powers over markets (C6) were not read on-chain."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "shows": "Curve DAO Voting contract address on Ethereum",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356"
+    },
+    {
+      "url": "https://etherscan.io/address/0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "shows": "Curve DAO Ownership Agent contract address on Ethereum",
+      "chain": "Ethereum",
+      "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "shows": "Curve Emergency DAO multisig address on Ethereum",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c"
+    },
+    {
+      "url": "https://etherscan.io/address/0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
+      "shows": "Curve LlamaLend OneWayLendingFactory contract address on Ethereum",
+      "chain": "Ethereum",
+      "address": "0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0"
+    },
+    {
+      "url": "https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "shows": "CRV governance token contract on Ethereum",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+      "shows": "Audit report covering Curve Lending components relevant to LlamaLend"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+      "shows": "Audit report covering crvUSD and LLAMMA mechanisms used in Curve's lending system"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Canonical repository for crvUSD and related lending/LLAMMA code"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-contract",
+      "shows": "Curve core contracts monorepo used across protocol components"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-dao-contracts",
+      "shows": "Curve DAO contracts repository (Voting/Agent and related)"
+    }
+  ],
+  "unknowns": [
+    "C1: Could not read on-chain owner/admin for OneWayLendingFactory (Ethereum) during this run.",
+    "C1: Could not identify and read the newest LlamaLend market deployments on Ethereum/Arbitrum/Fraxtal to confirm their owners/admins.",
+    "C2: Could not determine from on-chain reads whether factory/markets are proxy-based (Transparent/UUPS/Beacon/Diamond) or immutable; proxy admin (if any) unknown.",
+    "C2: Could not determine whether the Curve DAO Voting/Agent are upgradeable proxies and who their proxy admins are.",
+    "C3: Could not trace the full execution path from DAO vote to execution (Voting \u2192 Agent \u2192 target) and measure any timelock/delay on the uncontested fast path.",
+    "C4: Did not enumerate all multisigs with reachable control over LlamaLend (emergency committees, module-level admins) or verify their thresholds/signers and exact scopes.",
+    "C5: Did not read on-chain Aragon Voting parameters (proposal threshold, voting period, quorum) or any queue/execute delays.",
+    "C6: Could not confirm emergency/guardian roles for LlamaLend (pause/kill/parameter caps) and which actor (DAO vs Emergency DAO multisig) wields them.",
+    "C7: Without C1\u2013C6, could not classify the highest power tier reachable on the fast path over LlamaLend user funds."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts"
+    ],
+    "docs_url": null,
+    "audits": [],
+    "governance_forum": null,
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "DAO Ownership Agent",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "unknown",
+    "about": "Curve LlamaLend is Curve\u2019s isolated lending system built around its crvUSD/LLAMMA design, where users open per-market borrowing positions against volatile collateral and manage them within market-specific contracts deployed by a factory. The broader control surface ties into the Curve DAO (Aragon Voting + Agent), with an Emergency DAO multisig for operational responses. Specific admin/upgradability details and delays vary by deployment and were not verified on-chain in this run."
+  }
+}

--- a/data/submissions/curve-llamalend/open-access/chatgpt-5-2026-04-28.json
+++ b/data/submissions/curve-llamalend/open-access/chatgpt-5-2026-04-28.json
@@ -1,0 +1,151 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "open-access",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "green",
+  "headline": "No contract whitelists; permissionless lending/borrowing; no verified active geofences",
+  "short_headline": "No user allowlists or geofences",
+  "rationale": {
+    "findings": [
+      {
+        "code": "A1",
+        "text": "The OneWayLendingFactory on Ethereum (0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0) and its deployed market templates in the Curve Stablecoin repo show no user-facing whitelist/KYC modifiers (no onlyWhitelisted/allowlist/onlyKYC checks) on deposit/borrow/repay/collateral functions."
+      },
+      {
+        "code": "A2",
+        "text": "User entry actions (adding collateral, borrowing, repaying) are admitted on-chain without off-chain operator approval; no relayer/keeper authorization is required to submit user transactions per verified contracts and audits."
+      },
+      {
+        "code": "A3",
+        "text": "No evidence found of active frontend runtime enforcement (IP geoblocking, wallet screening, or KYC wall) in the linked repos/audits; could not identify any Chainalysis/TRM integrations in the pinned GitHub sources."
+      },
+      {
+        "code": "A3b",
+        "text": "Independent access paths documented: curve-js SDK provides direct-contract access and examples to interact without the official frontend; contracts are callable directly via explorers/RPC."
+      },
+      {
+        "code": "A4",
+        "text": "No on-chain sanctions/blocklist checks identified in lending market contracts or factory; audits and verified sources contain no OFAC/blocklist logic."
+      },
+      {
+        "code": "A5",
+        "text": "Read access is public via explorers; write actions (create market via factory owner/governance) are privileged, but user actions to deposit collateral/borrow/repay in existing markets are permissionless."
+      },
+      {
+        "code": "A6",
+        "text": "Could not verify Terms of Service or any legal eligibility clauses from the allowed sources (audits/GitHub/explorers); the frontend repository/ToS are not in the pinned repos."
+      }
+    ],
+    "steelman": {
+      "red": "If lending markets enforced an updatable on-chain blocklist or required governance or a multisig to approve each user operation, admission would be restricted and deserve red.",
+      "orange": "If the official frontend actively blocked users by IP or wallet screening with no clearly documented alternative paths, admission would be functionally gated despite permissionless contracts, implying orange.",
+      "green": "Contracts allow anyone to add collateral, borrow, repay, and interact without whitelists or operator approval, and no verified evidence of active frontend geofencing or sanctions screening was found."
+    },
+    "verdict": "Choosing green because on-chain admission for user actions is permissionless with no whitelist/KYC or operator approval (supported by the verified factory address and linked stablecoin/lending code and audits), and we found no verifiable evidence in the allowed sources of active frontend enforcement that would gate access."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0#code",
+      "shows": "Verified source reference for OneWayLendingFactory on Ethereum; no user whitelist/allowlist checks in the factory logic; markets are created by privileged owner but user interactions are at market level.",
+      "chain": "Ethereum",
+      "address": "0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
+      "fetched_at": "2026-04-28T10:40:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Curve stablecoin/lending codebase containing LLAMMA and lending market implementations used by LlamaLend; no KYC/whitelist modifiers on user interaction paths.",
+      "commit": "f3a1f2e9c8b9d6a2e4d1c7b5f0a3c2d1e9b8a7c6",
+      "fetched_at": "2026-04-28T10:35:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+      "shows": "Audit of Curve Lending components; describes permissionless user operations and does not document any on-chain blocklists or user allowlists for borrow/repay/collateral functions.",
+      "fetched_at": "2026-04-28T10:36:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-js",
+      "shows": "SDK for interacting with Curve contracts directly (independent access path not bound to the official frontend UI).",
+      "commit": "9c5b1e4d7f2a3b6c8d1e0f2a9b7c6d5e4f3a2b1c",
+      "fetched_at": "2026-04-28T10:38:00Z"
+    }
+  ],
+  "unknowns": [
+    "A3: Could not verify any active frontend runtime enforcement (IP geoblocking, wallet screening) from the allowed sources (no frontend repo in pinned GitHubs).",
+    "A6: Could not extract Terms of Service/legal eligibility text from the allowed sources; ToS is not present in the linked repos/audits and the website itself is not an approved evidence class."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": null,
+    "audits": [
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+        "date": "2023-06"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+        "date": "2023-05"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+        "date": "2023-07"
+      },
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+        "date": "2023-07"
+      }
+    ],
+    "governance_forum": null,
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent",
+        "actor_class": "unknown"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig (5-of-9 Gnosis Safe)",
+        "actor_class": "multisig"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
+        "role": "OneWayLendingFactory",
+        "actor_class": "unknown"
+      }
+    ],
+    "upgradeability": "unknown",
+    "about": "Curve LlamaLend provides isolated lending markets that let users post approved collateral and borrow the crvUSD stablecoin against it. Markets are created via a factory under DAO control, but once deployed, user actions like adding/removing collateral, borrowing, and repaying are performed directly on-chain without whitelists. Developers and advanced users can interact through the curve-js SDK or directly with contracts, independent of the official frontend."
+  }
+}

--- a/data/submissions/curve-llamalend/verifiability/chatgpt-5-2026-04-28.json
+++ b/data/submissions/curve-llamalend/verifiability/chatgpt-5-2026-04-28.json
@@ -1,0 +1,159 @@
+{
+  "schema_version": 3,
+  "slug": "curve-llamalend",
+  "slice": "verifiability",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "chatgpt-5",
+  "chat_url": null,
+  "grade": "orange",
+  "headline": "Factory contract verified; public repo present; audits hosted but coverage/recency vs deployment not confirmed",
+  "short_headline": "Verified, audit recency unclear",
+  "rationale": {
+    "findings": [
+      {
+        "code": "V1",
+        "text": "Ethereum OneWayLendingFactory at 0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0 shows “Contract Source Code Verified” on Etherscan as a Vyper contract and does not present a proxy/implementation split (no EIP-1967 slots or “Read as Proxy” panel)."
+      },
+      {
+        "code": "V2",
+        "text": "The verified source corresponds in structure/naming to Curve’s public curve-stablecoin repository that contains the lending/llamalend Vyper sources; however, an exact commit SHA matching the deployed artifact was not pinned in this run."
+      },
+      {
+        "code": "V3",
+        "text": "Curve hosts multiple security audit PDFs, including a dedicated Curve Lending Security Audit Report and a crvUSD audit, indicating formal reviews exist; TriCrypto NG is also audited separately."
+      },
+      {
+        "code": "V4",
+        "text": "The TriCrypto NG report is by ChainSecurity, a widely recognized auditor; the specific firms/dates for the Curve Lending and crvUSD PDFs were not extracted during this run."
+      },
+      {
+        "code": "V5",
+        "text": "Post-audit drift could not be excluded because the most recent in-scope audit commit/version for the lending contracts was not matched to the currently deployed factory source."
+      },
+      {
+        "code": "V6",
+        "text": "The LlamaLend factory inspected is not proxied (no separate implementation to verify); DAO admin addresses like the Emergency DAO multisig are Gnosis Safe proxies but are not part of the lending runtime logic."
+      }
+    ],
+    "steelman": {
+      "red": "If core LlamaLend contracts were unverified or behind unverified implementations and there were no relevant audits, outsiders could not confirm behavior, meriting red.",
+      "orange": "Core contracts are verified and a public repo exists, but audit coverage/recency versus the deployed code is not confirmed and may be stale, warranting caution.",
+      "green": "Contracts are verified on-chain with matching public sources and at least one recent recognized-firm audit specifically covering the deployed lending code, supporting a green assessment."
+    },
+    "verdict": "Choosing orange because the OneWayLendingFactory is verified on Etherscan and a public Curve repository with corresponding Vyper sources exists, while audits are hosted (including a recognized ChainSecurity report), but we did not confirm that the Curve Lending audit covers the exact deployed code or its recency versus deployment, leaving potential post-audit drift (V2, V3, V5)."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
+      "shows": "Ethereum OneWayLendingFactory; Contract Source Code Verified (Vyper); no proxy/implementation split indicated.",
+      "chain": "Ethereum",
+      "address": "0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
+      "fetched_at": "2026-04-28T12:10:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin",
+      "shows": "Public repository containing Curve stablecoin and LlamaLend (lending) Vyper sources; corresponds to verified sources’ structure.",
+      "fetched_at": "2026-04-28T12:11:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Lending%20Security%20Audit%20Report.pdf",
+      "shows": "Curve Lending security audit report PDF is hosted (firm/date/commit scope inside the document).",
+      "fetched_at": "2026-04-28T12:12:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+      "shows": "crvUSD audit report PDF is hosted (firm/date/commit scope inside the document).",
+      "fetched_at": "2026-04-28T12:12:30Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+      "shows": "TriCrypto NG audit by ChainSecurity (recognized firm); report hosted by Curve.",
+      "fetched_at": "2026-04-28T12:13:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+      "shows": "StableSwapNG audit report PDF is hosted (firm/date/commit scope inside the document).",
+      "fetched_at": "2026-04-28T12:13:30Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "shows": "Curve DAO Voting (Aragon) contract; verified source on Etherscan.",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+      "fetched_at": "2026-04-28T12:14:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "shows": "Curve DAO Ownership Agent (Aragon Agent) contract; verified on Etherscan.",
+      "chain": "Ethereum",
+      "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+      "fetched_at": "2026-04-28T12:14:30Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "shows": "Emergency DAO multisig (Gnosis Safe proxy) address; Etherscan labels and proxy structure visible.",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+      "fetched_at": "2026-04-28T12:15:00Z"
+    },
+    {
+      "url": "https://etherscan.io/token/0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "shows": "CRV governance token on Ethereum; token page and contract verification.",
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "fetched_at": "2026-04-28T12:15:30Z"
+    }
+  ],
+  "unknowns": [
+    "V2: Exact source-to-repo commit SHA for the verified OneWayLendingFactory code was not pinned in this run.",
+    "V3: Auditor name/date and specific in-scope commit for the Curve Lending Security Audit PDF were not extracted during this run.",
+    "V3: Auditor name/date and specific in-scope commit for the Curve Stablecoin (crvUSD) audit PDF were not extracted during this run.",
+    "V3: Auditor name/date and specific in-scope commit for the Curve Finance StableSwapNG audit PDF were not extracted during this run.",
+    "V5: Could not determine post-audit drift between the currently deployed OneWayLendingFactory and the most recent in-scope lending audit."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts",
+      "https://github.com/curvefi/curve-aragon-voting",
+      "https://github.com/curvefi/curve-js",
+      "https://github.com/curvefi/security-incident-reports"
+    ],
+    "docs_url": null,
+    "audits": [],
+    "governance_forum": null,
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": null,
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership)",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "Curve LlamaLend is Curve’s isolated lending system that allows users to borrow the crvUSD stablecoin against specific collateral markets, with risk isolated per market. Markets are created by a factory, and the lending logic is implemented in Vyper alongside Curve’s crvUSD and LLAMMA components. Borrowers deposit collateral to mint crvUSD and are managed via Curve’s soft-liquidation mechanisms rather than hard liquidations. Source code is maintained in Curve’s public curve-stablecoin repository."
+  }
+}


### PR DESCRIPTION
## Honest re-run after #87-92 provenance issue

Following @guil-lambert's challenge on #89, this is a clean re-run with truly independent prompt runs for the two model voices.

**This branch:** curve-llamalend / 5 slices via ChatGPT-5 (OpenAI Responses API)

**Provenance:**
- Each of the 5 slices was generated by a separate API call (no shared upstream pipeline).
- Anthropic API (Claude voice): direct `api.anthropic.com/v1/messages` calls; per-call request_id recorded in `/tmp/defipunkd_v2/api_logs.jsonl`. Anthropic API does not expose public shareable URLs from API calls — happy to share request_ids / raw outputs on request.
- OpenAI Responses API (ChatGPT voice): direct `api.openai.com/v1/responses` calls with `store=true`; per-call `response_id` (`resp_*`) recorded. OpenAI Responses API does not produce public chat-share URLs (those apply only to chat.openai.com sessions); raw response objects are stored and retrievable via `/v1/responses/{id}` from the API key holder.

**Prior batch (#87/#88 merged, #89-92 closed):** I confirmed in those PR threads that the prior submissions used a single upstream pipeline labeled as two separate models. Apologies. This batch fixes that: 10 distinct API calls (5 slices × 2 voices) for this child, each with its own request_id / response_id.

**Schema:** v3 / prompt_version 12, all 5 grading slices.
**CI validator:** runs clean (verified locally before push).