### PR TITLE
chore(ci): disable weekly sourcecode enrichment cron

### DIFF
--- a/.github/workflows/fetch-sourcecode.yml
+++ b/.github/workflows/fetch-sourcecode.yml
@@ -1,9 +1,10 @@
 name: Sourcecode enrichment
 
 on:
-  schedule:
-    # Wednesdays 06:00 UTC, one day after Tuesday's adapter address extraction.
-    - cron: "0 6 * * WED"
+  # Weekly cron disabled: the script rewrites fetched_at/adapter_commit on every
+  # sourcecode.json each run, producing thousands of noise-diffs across ~5k slugs
+  # for almost no real change (verified-contract status is effectively immutable).
+  # Trigger manually after adapter.json changes that add new addresses.
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The script rewrites fetched_at/adapter_commit on every sourcecode.json each run, producing thousands of noise-diffs across ~5k slugs for essentially no real change. Keep workflow_dispatch for manual runs.