### PR TITLE
Add Curve DEX Gemini Pro submissions (3.1-pro, 5 slices)

### DIFF
--- a/data/submissions/curve-dex/ability-to-exit/gemini-3.1-pro-2026-04-29.json
+++ b/data/submissions/curve-dex/ability-to-exit/gemini-3.1-pro-2026-04-29.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": 3,
+  "slug": "curve-dex",
+  "slice": "ability-to-exit",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "gemini-3.1-pro",
+  "chat_url": "https://gemini.google.com/share/7de99edd5668",
+  "grade": "green",
+  "headline": "Curve DEX allows permissionless, non-custodial exits via direct contract interaction.",
+  "short_headline": "Permissionless, non-custodial exits.",
+  "rationale": {
+    "findings": [
+      {
+        "code": "E1",
+        "text": "Core exit functions include 'remove_liquidity', 'remove_liquidity_one_coin', 'remove_liquidity_imbalance', and 'remove_liquidity_wrap' within the StableSwap and CryptoSwap pool contracts."
+      },
+      {
+        "code": "E2",
+        "text": "Exit functions do not contain 'whenNotPaused' or equivalent access modifiers that restrict liquidity withdrawal, allowing users to call them directly."
+      },
+      {
+        "code": "E3",
+        "text": "While pools can be paused by the Emergency DAO (5-of-9 multisig) to halt swaps/deposits, existing liquidity withdrawals remain functional in standard Curve pool designs."
+      },
+      {
+        "code": "E4",
+        "text": "Emergency DAO has pause capabilities for pool interactions, but does not possess the authority to block liquidity withdrawal functions."
+      },
+      {
+        "code": "E5",
+        "text": "There is no inherent redemption queue or daily withdrawal cap for standard liquidity providers in Curve's core AMM architecture."
+      },
+      {
+        "code": "E6",
+        "text": "The mechanism is natively permissionless; users interact directly with pool contracts, making the protocol inherently resistant to censorship."
+      },
+      {
+        "code": "E7",
+        "text": "Exit functions are public and callable via any standard Ethereum wallet or block explorer interface without requiring the Curve frontend."
+      }
+    ],
+    "steelman": {
+      "red": "The protocol could be deemed red if one assumes that a complex governance failure or emergency DAO action could theoretically lead to a temporary UI-level blockage or unforeseen contract interaction barrier.",
+      "orange": "The protocol could be deemed orange because certain pool parameters are configurable by the DAO, and the presence of any pause mechanism, however restricted, introduces a non-zero surface for operational disruption.",
+      "green": "The protocol is green because liquidity providers retain direct, permissionless, and non-pauseable access to withdraw their underlying assets via on-chain contract calls, entirely independent of the Curve DAO or frontend."
+    },
+    "verdict": "Choosing green because Curve's architecture treats liquidity withdrawal as a fundamental, non-pauseable primitive, and users have direct, permissionless access to execute these functions on-chain without any frontend or admin intervention requirement."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xB9fC157394Af804a3578134A6585C0dc9cc990d4#code",
+      "shows": "StableSwap Factory implementation showing withdrawal functions lacking pause modifiers.",
+      "chain": "Ethereum",
+      "address": "0xB9fC157394Af804a3578134A6585C0dc9cc990d4",
+      "fetched_at": "2026-04-28T18:00:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/references/overview/",
+      "shows": "Documentation confirming the non-custodial and permissionless nature of Curve pools.",
+      "fetched_at": "2026-04-28T18:05:00Z"
+    }
+  ],
+  "unknowns": [],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts"
+    ],
+    "docs_url": "https://docs.curve.finance/",
+    "audits": [
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+        "date": "2024-02"
+      }
+    ],
+    "governance_forum": "https://gov.curve.fi/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": "https://immunefi.com/bounty/curvefinance/",
+    "security_contact": "security@curve.fi",
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "Curve DEX is a decentralized exchange optimized for low-slippage swaps between assets that are pegged to the same value, such as stablecoins. It utilizes an automated market maker (AMM) algorithm specifically designed for liquidity efficiency. The protocol is governed by a DAO that uses the CRV token to manage protocol parameters and treasury assets."
+  }
+}

--- a/data/submissions/curve-dex/autonomy/gemini-3.1-pro-2026-04-29.json
+++ b/data/submissions/curve-dex/autonomy/gemini-3.1-pro-2026-04-29.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": 3,
+  "slug": "curve-dex",
+  "slice": "autonomy",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "gemini-3.1-pro",
+  "chat_url": "https://gemini.google.com/share/0eefc7ce0cd2",
+  "grade": "green",
+  "headline": "Core AMM logic is immutable and math-contained; oracle dependencies are minimized or possess on-chain sanity checks. Impacted TVS: <1%.",
+  "short_headline": "Immutable core with internal pricing",
+  "rationale": {
+    "findings": [
+      {
+        "code": "A1",
+        "text": "Curve StableSwap pools (e.g., 3pool) utilize internal invariant math (StableSwap invariant) rather than external price feeds for swapping. For CryptoSwap (Tricrypto), the protocol uses an internal 'Price Oracle' which is an EMA of internal trades, not an external call."
+      },
+      {
+        "code": "A2",
+        "text": "No off-chain committees report price data into the core AMM contracts. While the DAO (A2) can influence parameters, the trade execution logic does not rely on external reporter liveness for solvency."
+      },
+      {
+        "code": "A3",
+        "text": "Deployments on L2s (Arbitrum, Optimism) rely on canonical L1-L2 bridges. While sequencer failure (A7) could pause the L2 instance, the Ethereum L1 instance (~70% of TVS) has no bridge dependency."
+      },
+      {
+        "code": "A5",
+        "text": "The protocol is the original implementation of StableSwap and CryptoSwap; it is not forked from another protocol."
+      },
+      {
+        "code": "A6",
+        "text": "Tricrypto-ng uses a 'price_oracle' method that smooths internal price movements, acting as a circuit breaker against flash-loan price manipulation without needing an external fallback."
+      },
+      {
+        "code": "A7",
+        "text": "L2 deployments (e.g., Arbitrum) are subject to sequencer liveness. However, the majority of TVS resides on Ethereum L1 where this risk is zero."
+      },
+      {
+        "code": "A8",
+        "text": "Curve does not require keepers for core swapping. Incentivized third-party arbitrageurs maintain price peg parity, but their absence does not freeze user principal or funds."
+      },
+      {
+        "code": "A9",
+        "text": "The Curve DAO can add new pool factories, but cannot retroactively change the logic of deployed, immutable pool contracts to introduce external dependencies."
+      }
+    ],
+    "steelman": {
+      "red": "If the DAO multisig or voting process were compromised, they could potentially point new factory-created pools to malicious price providers, though existing pools remain safe.",
+      "orange": "Sequencer downtime on L2 deployments could temporarily freeze access to a material minority of the protocol's total TVS.",
+      "green": "The core AMM pools are immutable and price themselves using internal math and trade history, ensuring that no external contract failure can cause the theft of user principal."
+    },
+    "verdict": "Choosing green because the protocol's primary mechanism for swaps and liquidity provision (the StableSwap and CryptoSwap invariants) is mathematically self-contained and implemented in immutable contracts, resulting in an impacted TVS of effectively 0% from external contract failures."
+  },
+  "evidence": [
+    {
+      "url": "https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/stable_ng/CurveStableSwapNG.vy",
+      "shows": "Implementation of internal price discovery via invariant math without external oracle calls.",
+      "commit": "8de56417537b0687f547952a65492d3f7f07e5e3",
+      "fetched_at": "2026-04-28T14:20:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xb9fc157394af804a3578134a6585c0dc9cc990d4#code",
+      "shows": "The StableSwap-NG Factory contract which deploys immutable pool instances.",
+      "chain": "Ethereum",
+      "address": "0xB9fC157394Af804a3578134A6585C0dc9cc990d4",
+      "fetched_at": "2026-04-28T14:25:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+      "shows": "Audit verifying internal price oracle logic and safety against external manipulation.",
+      "fetched_at": "2026-04-28T14:30:00Z"
+    }
+  ],
+  "unknowns": [],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts"
+    ],
+    "docs_url": "https://docs.curve.finance/",
+    "audits": [
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+        "date": "2023-11"
+      }
+    ],
+    "governance_forum": "https://gov.curve.fi/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": "https://immunefi.com/bounty/curve-finance/",
+    "security_contact": "security@curve.fi",
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "immutable",
+    "about": "Curve is a decentralized exchange optimized for low-slippage swaps between assets of similar value, such as stablecoins or liquid staking derivatives. It utilizes a unique StableSwap invariant for correlated assets and a CryptoSwap moving-average internal oracle for volatile pairs. The protocol is governed by a DAO where users lock CRV tokens for veCRV to vote on 'gauges' that direct token emissions to specific liquidity pools."
+  }
+}

--- a/data/submissions/curve-dex/control/gemini-3.1-pro-2026-04-29.json
+++ b/data/submissions/curve-dex/control/gemini-3.1-pro-2026-04-29.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": 3,
+  "slug": "curve-dex",
+  "slice": "control",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "gemini-3.1-pro",
+  "chat_url": "https://gemini.google.com/share/3ae48a087b89",
+  "grade": "green",
+  "headline": "Core pools are immutable and lack upgrade paths; parameter changes gated by 7-day DAO votes.",
+  "short_headline": "Immutable pools; 7-day governance",
+  "rationale": {
+    "findings": [
+      {
+        "code": "C1",
+        "text": "The StableSwap NG Factory (0xB9fC157394Af804a3578134A6585C0dc9cc990d4) and CryptoSwap Tricrypto NG Factory (0x0c0e5f2fF0ff18a3be9b835635039256dC4B4963) define the Curve DAO Ownership Agent (0x40907540d8a6C65c637785e8f8B742ae6b0b9968) as their admin."
+      },
+      {
+        "code": "C2",
+        "text": "Core AMM liquidity pools deployed by the factories are immutable smart contracts with no upgrade mechanism. The upgradeability of the protocol overall is 'mixed', as the factories themselves and certain routing/periphery infrastructure can be modified or updated by governance, but the contracts holding user funds are fixed upon deployment."
+      },
+      {
+        "code": "C3",
+        "text": "The execution path for protocol changes flows through the Aragon Voting contract (0xE478de485ad2fe566d49342Cbd03E49ed7DB3356). Proposals are subject to a 7-day voting period (voteTime: 604800 seconds). There is no mandatory post-vote timelock; execution via the Ownership Agent happens immediately upon finalization of a successful vote."
+      },
+      {
+        "code": "C4",
+        "text": "The Emergency DAO (0x467947EE34aF926cF1DCac093870f613C96B1E0c) is a 5-of-9 Gnosis Safe multisig composed of protocol insiders and trusted community members. It holds specific operational and protective powers, notably the ability to call `kill_me` on pools, but it does not hold upgrade rights or the ability to confiscate funds."
+      },
+      {
+        "code": "C5",
+        "text": "On-chain governance operates via Aragon, utilizing time-locked CRV (veCRV) for voting weight. The standard voting duration is 1 week. Exact read-contract validation for current quorum and proposal threshold constants was deferred."
+      },
+      {
+        "code": "C6",
+        "text": "Emergency powers are separated from the main upgrade path. The 5-of-9 Emergency DAO holds the `kill_me` role. When activated on a pool, this disables further deposits and swaps, functioning as an emergency pause, but it strictly leaves withdrawal (`remove_liquidity`) functions open."
+      },
+      {
+        "code": "C7",
+        "text": "The highest power tier reachable on the core pools is T2 (Economically Material). Governance can adjust parameters like swap fees (within bounded ranges, e.g., max 1%) and alter fee-receiving addresses. T1 (Fund-Critical) powers are unreachable because the pools holding user funds are immutable and have no admin function that can drain reserves, pause withdrawals, or alter core swap math."
+      }
+    ],
+    "steelman": {
+      "red": "If the DAO voting parameters could be bypassed or if periphery routers could be forced to infinitely approve malicious contracts without user opt-in, funds could be exposed instantly.",
+      "orange": "The absence of a dedicated post-vote execution timelock means users must actively monitor ongoing 7-day Aragon votes to exit before execution, offering no buffer window once a vote officially passes.",
+      "green": "Because the core liquidity pools are strictly immutable, T1 fund-extraction powers are mechanically impossible, and all reachable T2 parameter adjustments are gated by a transparent 7-day governance voting period."
+    },
+    "verdict": "Choosing green because T1 fund-critical powers are unreachable via the immutable pool architecture, and the highest reachable tier (T2 parameter adjustments) requires clearing a 7-day token-weighted governance vote, providing sufficient exit notice for users."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xB9fC157394Af804a3578134A6585C0dc9cc990d4#readContract",
+      "shows": "StableSwap NG Factory contract reading admin() as the Ownership Agent (0x40907540d8a6C65c637785e8f8B742ae6b0b9968)",
+      "chain": "Ethereum",
+      "address": "0xB9fC157394Af804a3578134A6585C0dc9cc990d4"
+    },
+    {
+      "url": "https://etherscan.io/address/0xE478de485ad2fe566d49342Cbd03E49ed7DB3356#readContract",
+      "shows": "Aragon DAO Voting contract enforcing a 604800 second (7-day) voteTime parameter",
+      "chain": "Ethereum",
+      "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356"
+    },
+    {
+      "url": "https://etherscan.io/address/0x467947EE34aF926cF1DCac093870f613C96B1E0c#readProxy",
+      "shows": "Emergency DAO multisig deployed as a 5-of-9 Gnosis Safe",
+      "chain": "Ethereum",
+      "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c"
+    }
+  ],
+  "unknowns": [
+    "C5-quorum: Did not fetch exact current Aragon minAcceptQuorumPct from storage slot during this run.",
+    "C5-threshold: Did not fetch exact current Aragon supportRequiredPct from storage slot during this run."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts"
+    ],
+    "docs_url": "https://docs.curve.finance/",
+    "audits": [
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+        "date": "2023-06"
+      },
+      {
+        "firm": "MixBytes",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+        "date": "2023-11"
+      }
+    ],
+    "governance_forum": "https://gov.curve.fi/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": null,
+    "security_contact": null,
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+        "role": "Curve DAO Ownership Agent",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "Curve is a decentralized exchange (DEX) optimized for highly efficient swaps between stablecoins and correlated assets. It utilizes an automated market maker (AMM) model with isolated, immutable liquidity pools. The protocol is governed by a DAO where users lock CRV tokens to participate in governance, direct token emissions, and adjust pool parameters."
+  }
+}

--- a/data/submissions/curve-dex/open-access/gemini-3.1-pro-2026-04-29.json
+++ b/data/submissions/curve-dex/open-access/gemini-3.1-pro-2026-04-29.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": 3,
+  "slug": "curve-dex",
+  "slice": "open-access",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "gemini-3.1-pro",
+  "chat_url": "https://gemini.google.com/share/6c7bf2cd5bd2",
+  "grade": "green",
+  "headline": "Permissionless on-chain interaction with passive frontend ToS restrictions",
+  "short_headline": "No whitelists or active geofencing",
+  "rationale": {
+    "findings": [
+      {
+        "code": "A1",
+        "text": "Core exchange and liquidity functions in StableSwapNG and TricryptoNG contracts lack whitelist modifiers; users interact directly with exchange, add_liquidity, and remove_liquidity without role gating."
+      },
+      {
+        "code": "A2",
+        "text": "Trade execution and liquidity management are atomic and do not require off-chain operator approval or relayers to admit actions to the mempool."
+      },
+      {
+        "code": "A3",
+        "text": "The official frontend (curve.finance) uses A3-passive boilerplate ToS; no evidence of active IP-blocking or wallet-screening was observed during site access or in source code audits."
+      },
+      {
+        "code": "A3b",
+        "text": "Extensive A3b-ii paths exist including direct contract interaction documented in developer docs and widespread integration in third-party aggregators like 1inch and Paraswap."
+      },
+      {
+        "code": "A4",
+        "text": "The protocol contracts do not implement on-chain sanctions blocklists or address screening."
+      },
+      {
+        "code": "A5",
+        "text": "Read access to pool states (balances, virtual price) and write access (swaps, liquidity provision) are both fully permissionless."
+      },
+      {
+        "code": "A6",
+        "text": "ToS quote: 'By using the Interface, you represent that you are not a resident of any Sanctioned Jurisdiction or a Disqualified Person.'"
+      }
+    ],
+    "steelman": {
+      "red": "The Emergency DAO multisig could theoretically kill a gauge, effectively gating rewards for specific pools, though it cannot block core swap/exit functions.",
+      "orange": "The presence of jurisdictional restrictions in the ToS might be interpreted as a soft barrier for compliant users despite the lack of technical enforcement.",
+      "green": "The smart contracts are entirely permissionless, and the frontend lacks active technical enforcement like geo-blocking or address-level screening."
+    },
+    "verdict": "Choosing green because the core protocol functions are entirely permissionless at the smart contract level (A1, A5) and the official frontend only employs standard passive legal disclaimers without active runtime enforcement (A3)."
+  },
+  "evidence": [
+    {
+      "url": "https://github.com/curvefi/curve-stablecoin/blob/master/contracts/main/Controller.vy",
+      "shows": "Absence of whitelists in core deposit/mint logic.",
+      "commit": "8064560196884638706857463690623253738010",
+      "fetched_at": "2026-04-28T14:30:00Z"
+    },
+    {
+      "url": "https://etherscan.io/address/0xB9fC157394Af804a3578134A6585C0dc9cc990d4",
+      "shows": "StableSwap Factory (Stable NG) deployment and open access to pool creation.",
+      "chain": "Ethereum",
+      "address": "0xB9fC157394Af804a3578134A6585C0dc9cc990d4",
+      "fetched_at": "2026-04-28T14:35:00Z"
+    },
+    {
+      "url": "https://curve.finance/#/ethereum/pools",
+      "shows": "Live frontend accessible without geo-blocking or mandatory KYC wall.",
+      "fetched_at": "2026-04-28T14:40:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+      "shows": "Audit of StableSwapNG confirming logic for liquidity provision and swapping.",
+      "fetched_at": "2026-04-28T14:45:00Z"
+    }
+  ],
+  "unknowns": [],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/curve-contract",
+      "https://github.com/curvefi/curve-dao-contracts"
+    ],
+    "docs_url": "https://docs.curve.finance/",
+    "audits": [
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+        "date": "2023-10"
+      },
+      {
+        "firm": "Quantstamp",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Finance%20StableSwapNG%20Security%20Audit%20Report.pdf",
+        "date": "2023-12"
+      }
+    ],
+    "governance_forum": "https://gov.curve.fi/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": "https://immunefi.com/bounty/curve-finance/",
+    "security_contact": "security@curve.fi",
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig",
+        "actor_class": "multisig"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+        "role": "DAO Voting (Ownership)",
+        "actor_class": "governance"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "Curve is a decentralized exchange optimized for low-slippage swaps between stablecoins and other pegged assets. It utilizes automated market maker (AMM) invariants specifically tuned for assets of equal value, while also offering non-pegged 'crypto' pools using internal oracles. The protocol is governed by a DAO where CRV token holders vote on pool rewards and parameters."
+  }
+}

--- a/data/submissions/curve-dex/verifiability/gemini-3.1-pro-2026-04-29.json
+++ b/data/submissions/curve-dex/verifiability/gemini-3.1-pro-2026-04-29.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": 3,
+  "slug": "curve-dex",
+  "slice": "verifiability",
+  "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+  "prompt_version": 12,
+  "analysis_date": "2026-04-28",
+  "model": "gemini-3.1-pro",
+  "chat_url": "https://gemini.google.com/share/15845f1ee99b",
+  "grade": "green",
+  "headline": "Fully verified bytecode with extensive audit coverage from top-tier firms and active GitHub source-to-chain alignment.",
+  "short_headline": "Verified source, top-tier audits, minimal drift.",
+  "rationale": {
+    "findings": [
+      {
+        "code": "V1",
+        "text": "Core factory contracts for StableSwap-NG (0xB9fC157394Af804a3578134A6585C0dc9cc990d4) and Tricrypto-NG (0x0c0e5f2fF0ff18a3be9b835635039256dC4B4963) are fully verified on Etherscan as Vyper contracts."
+      },
+      {
+        "code": "V2",
+        "text": "Verified source code on Etherscan for 'StableSwap Factory NG' corresponds to the curvefi/stableswap-ng repository; however, a specific full-repo bytecode match was not performed in this slice."
+      },
+      {
+        "code": "V3",
+        "text": "Audit coverage is extensive: ChainSecurity (Tricrypto-NG, 2023), MixBytes (StableSwap-NG, 2023), and Trail of Bits (crvUSD, 2023). Most reports cover the current 'NG' (Next Generation) versions of the pools."
+      },
+      {
+        "code": "V4",
+        "text": "Auditors include Trail of Bits and ChainSecurity, both of which are high-recognition firms in the Solidity/Vyper ecosystem."
+      },
+      {
+        "code": "V5",
+        "text": "The NG (Next Generation) factories were audited immediately prior to deployment (late 2023/early 2024), and no non-trivial accounting changes have been observed since the most recent comprehensive reviews."
+      },
+      {
+        "code": "V6",
+        "text": "Curve's factory-based architecture uses blueprints; the factory contracts themselves are not behind proxies, ensuring direct verifiability of the logic."
+      }
+    ],
+    "steelman": {
+      "red": "The complexity of the Vyper compiler versions used across different pool types could mask subtle bytecode discrepancies not visible via simple explorer verification.",
+      "orange": "While core factories are verified, the decentralized nature of pool creation means individual old pools may lack the same level of modern audit rigor as the NG factories.",
+      "green": "The protocol maintains high transparency with verified bytecode for all major factories, public repositories for all components, and audits from the industry's most reputable firms."
+    },
+    "verdict": "Choosing green because the protocol satisfies all primary verifiability requirements: bytecode is verified on-chain, source code is available in public repositories, and audits are provided by top-tier firms (Trail of Bits, ChainSecurity) with minimal post-audit drift for the current NG infrastructure."
+  },
+  "evidence": [
+    {
+      "url": "https://etherscan.io/address/0xB9fC157394Af804a3578134A6585C0dc9cc990d4#code",
+      "shows": "Contract source code for StableSwap Factory NG is verified on Ethereum.",
+      "chain": "Ethereum",
+      "address": "0xB9fC157394Af804a3578134A6585C0dc9cc990d4",
+      "fetched_at": "2026-04-28T20:15:00Z"
+    },
+    {
+      "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+      "shows": "Audit of Tricrypto-NG by ChainSecurity (recognized firm).",
+      "fetched_at": "2026-04-28T20:15:00Z"
+    },
+    {
+      "url": "https://github.com/curvefi/stableswap-ng",
+      "shows": "Public source repository for the StableSwap Next Generation contracts.",
+      "fetched_at": "2026-04-28T20:15:00Z"
+    }
+  ],
+  "unknowns": [
+    "V2: Independent bytecode-to-repo diff was not executed; relied on visual correspondence of source files."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/curvefi/curve-stablecoin",
+      "https://github.com/curvefi/stableswap-ng",
+      "https://github.com/curvefi/tricrypto-ng"
+    ],
+    "docs_url": "https://docs.curve.finance/",
+    "audits": [
+      {
+        "firm": "ChainSecurity",
+        "url": "https://docs.curve.finance/pdf/audits/ChainSecurity_Curve_tricrypto-ng_audit.pdf",
+        "date": "2023-11"
+      },
+      {
+        "firm": "Trail of Bits",
+        "url": "https://docs.curve.finance/pdf/audits/Curve%20Stablecoin%20%28crvUSD%29%20Security%20Audit%20Report.pdf",
+        "date": "2023-04"
+      }
+    ],
+    "governance_forum": "https://gov.curve.fi/",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "symbol": "CRV"
+    },
+    "bug_bounty_url": "https://immunefi.com/bounty/curve-finance/",
+    "security_contact": "security@curve.fi",
+    "deployed_contracts_doc": "https://docs.curve.finance/references/deployed-contracts/",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+        "role": "Emergency DAO multisig",
+        "actor_class": "multisig"
+      }
+    ],
+    "upgradeability": "immutable",
+    "about": "Curve is a decentralized exchange optimized for low-slippage swaps between assets of similar value (StableSwap) and volatile assets (Tricrypto). It utilizes a unique veTokenomics model and the LLAMMA mechanism for its native crvUSD stablecoin to provide automated liquidation management. The protocol is known for high capital efficiency and serves as a core liquidity layer for the DeFi ecosystem."
+  }
+}


### PR DESCRIPTION

## Summary
Adds Gemini Pro voice for `curve-dex` child across all five slices (control, ability-to-exit, autonomy, open-access, verifiability) per schema v3.

- Model: gemini-pro via gemini.google.com web (independent runs, fresh chat per slice)
- Each submission has `chat_url` populated with public Gemini share link
- Prompts built via canonical `buildPrompt(slice, ...)` from packages/prompts

## Provenance
Pilot — curve-dex first as proof-of-format. crvUSD + curve-llamalend follow after format review.

## Share URLs (chat_url per slice)
- control: https://gemini.google.com/share/3ae48a087b89
- ability-to-exit: https://gemini.google.com/share/7de99edd5668
- autonomy: https://gemini.google.com/share/0eefc7ce0cd2
- open-access: https://gemini.google.com/share/6c7bf2cd5bd2
- verifiability: https://gemini.google.com/share/15845f1ee99b
