### PR TITLE
Liquity V1 (liquity-v1) — 5-slice assessment (3 voices, snapshot 2026-04-27)

### DIFF
--- a/data/submissions/liquity-v1/ability-to-exit/models-2026-05-01.json
+++ b/data/submissions/liquity-v1/ability-to-exit/models-2026-05-01.json
@@ -1,0 +1,268 @@
+[
+  {
+    "schema_version": 3,
+    "slug": "liquity-v1",
+    "slice": "ability-to-exit",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Immutable contracts expose direct on-chain exits with no admin pause",
+    "short_headline": "No admin pause",
+    "rationale": {
+      "findings": [
+        {
+          "code": "E1",
+          "text": "User-facing exit functions identified: BorrowerOperations withdrawColl, adjustTrove with collateral withdrawal or debt repayment, repayLUSD, closeTrove, claimCollateral; TroveManager redeemCollateral; StabilityPool withdrawFromSP and withdrawETHGainToTrove; LQTYStaking unstake; LockupContract withdrawLQTY."
+        },
+        {
+          "code": "E2",
+          "text": "BorrowerOperations exit functions are external user calls without owner/role/pause modifiers; they enforce borrower ownership/active-trove, collateralization, Recovery Mode, TCR, and LUSD-balance checks. claimCollateral directly calls CollSurplusPool for msg.sender. TroveManager redeemCollateral is external and checks fee bounds, bootstrap period, TCR >= MCR, nonzero amount, and caller LUSD balance. StabilityPool withdrawFromSP is external, requires a deposit, and only gates nonzero LUSD withdrawals while undercollateralized Troves exist; amount 0 still pays gains. LQTYStaking unstake is external and requires a nonzero stake. LockupContract withdrawLQTY is external and restricted to the beneficiary after unlockTime."
+        },
+        {
+          "code": "E3",
+          "text": "No PAUSE_ROLE, guardian, PAUSE_INFINITELY, or equivalent admin pause path was found in the reviewed exit code. The only owner-only setup functions shown renounce ownership after wiring addresses, and Liquity documentation states the deployed system has no admin key and immutable rules."
+        },
+        {
+          "code": "E4",
+          "text": "No separate emergency pause or governance pause path was found. The documented control model is governance-free and admin-key-free, so there is no emergency actor, governance actor, or maximum pause duration to record."
+        },
+        {
+          "code": "E5",
+          "text": "No queued redemption or withdrawal queue was found: redeemCollateral executes synchronously over Troves subject to maxIterations/gas, while Stability Pool withdrawals have no lockup but nonzero LUSD withdrawals are temporarily suspended when liquidatable Troves below 110% remain. No daily withdrawal cap was found."
+        },
+        {
+          "code": "E6",
+          "text": "There is no separate adversarial-admin escape hatch because the assessed sources show no admin pause/upgrade actor; ordinary permissionless exits remain the escape path, and the Stability Pool suspension can be cleared because anyone can liquidate Troves below the minimum collateral ratio."
+        },
+        {
+          "code": "E7",
+          "text": "The deployed BorrowerOperations, TroveManager, StabilityPool, and LQTYStaking contracts are verified on Etherscan with ABI/Write Contract surfaces, so the exit functions are directly callable on-chain without relying on the project's frontend."
+        }
+      ],
+      "steelman": {
+        "red": "The strongest red argument is that Stability Pool principal withdrawals can be blocked during unresolved liquidatable Troves and borrower collateral exits can be blocked in Recovery Mode, so some users may not be able to withdraw immediately in stressed market states.",
+        "orange": "The strongest orange argument is that the Stability Pool's nonzero withdrawal guard is broad and has no fixed time limit, even though it is a solvency-condition guard rather than an admin pause.",
+        "green": "The strongest green argument is that the core contracts are immutable and admin-key-free, exits are exposed as direct external on-chain functions, no pause role exists, surplus and reward claims are not admin-gated, and any Stability Pool withdrawal suspension can be cleared by permissionless liquidations."
+      },
+      "verdict": "Choosing green because the blocking conditions found are protocol solvency checks rather than admin-controlled pauses: the reviewed deployed/source contracts expose direct exits, Liquity documents no admin key or governance, owner-only setup paths renounce ownership, and the only nonzero Stability Pool withdrawal suspension is tied to liquidatable Troves that anybody can liquidate."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x24179CD81c9e782A4096035f7eC97fB8B783e007#code",
+        "shows": "Ethereum mainnet BorrowerOperations deployed contract, verified source/ABI, Read Contract and Write Contract tabs, and ABI entries for adjustTrove, claimCollateral, closeTrove, repayLUSD, withdrawColl, and withdrawLUSD.",
+        "chain": "Ethereum",
+        "address": "0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+        "fetched_at": "2026-05-01T06:46:54Z"
+      },
+      {
+        "url": "https://raw.githubusercontent.com/liquity/dev/main/packages/contracts/contracts/BorrowerOperations.sol",
+        "shows": "BorrowerOperations source showing setAddresses renounces ownership; withdrawColl, repayLUSD, adjustTrove, closeTrove, and claimCollateral are external exits with collateralization, Recovery Mode, active-trove, and LUSD-balance checks but no pause modifier.",
+        "commit": "3e64ee1b52c50d51587c64c1cf75e0ba82934979",
+        "fetched_at": "2026-05-01T06:46:54Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2#code",
+        "shows": "Ethereum mainnet TroveManager deployed contract, verified source/ABI, Read Contract and Write Contract tabs for direct interaction.",
+        "chain": "Ethereum",
+        "address": "0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+        "fetched_at": "2026-05-01T06:46:54Z"
+      },
+      {
+        "url": "https://raw.githubusercontent.com/liquity/dev/main/packages/contracts/contracts/TroveManager.sol",
+        "shows": "TroveManager source showing redeemCollateral is external and checks fee bounds, bootstrap period, TCR over MCR, nonzero amount, and caller LUSD balance; setAddresses renounces ownership.",
+        "commit": "3e64ee1b52c50d51587c64c1cf75e0ba82934979",
+        "fetched_at": "2026-05-01T06:46:54Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x66017D22b0f8556afDd19FC67041899Eb65a21bb#code",
+        "shows": "Ethereum mainnet StabilityPool deployed verified source showing withdrawFromSP is external, pays ETH/LQTY gains, only checks _requireNoUnderCollateralizedTroves when amount is nonzero, and the guard checks lowest Trove ICR >= MCR rather than an admin role.",
+        "chain": "Ethereum",
+        "address": "0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+        "fetched_at": "2026-05-01T06:46:54Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d#code",
+        "shows": "Ethereum mainnet LQTYStaking deployed verified source showing setAddresses renounces ownership and unstake is external, transfers LQTY/LUSD/ETH gains to msg.sender, and has no pause modifier.",
+        "chain": "Ethereum",
+        "address": "0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d",
+        "fetched_at": "2026-05-01T06:46:54Z"
+      },
+      {
+        "url": "https://raw.githubusercontent.com/liquity/dev/main/packages/contracts/contracts/LQTY/LockupContract.sol",
+        "shows": "LockupContract source showing withdrawLQTY is callable by the beneficiary after unlockTime and transfers the contract's LQTY balance, with no pause/admin path.",
+        "commit": "3e64ee1b52c50d51587c64c1cf75e0ba82934979",
+        "fetched_at": "2026-05-01T06:46:54Z"
+      },
+      {
+        "url": "https://docs.liquity.org/liquity-v1/faq/general",
+        "shows": "Liquity V1 docs describing the protocol as non-custodial, immutable, governance-free, no admin key, directly redeemable, accessible via multiple interfaces, and operated without the core team frontend.",
+        "fetched_at": "2026-05-01T06:46:54Z"
+      },
+      {
+        "url": "https://docs.liquity.org/liquity-v1/faq/stability-pool-and-liquidations",
+        "shows": "Docs state Stability Pool deposits generally have no minimum lockup, withdrawals are temporarily suspended while liquidatable Troves below 110% remain, and anybody can liquidate such Troves.",
+        "fetched_at": "2026-05-01T06:46:54Z"
+      },
+      {
+        "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+        "shows": "Canonical technical resources page listing the GitHub repo, audit reports and dates, audit applicability matrix, and Ethereum mainnet contract addresses including BorrowerOperations, TroveManager, StabilityPool, LQTYStaking, LUSD, and LQTY.",
+        "fetched_at": "2026-05-01T06:46:54Z"
+      },
+      {
+        "url": "https://docs.liquity.org/liquity-v1/documentation/bug-bounty",
+        "shows": "V1 bug bounty page states the V1 bounty has been discontinued and gives security[at]liquity.org for V1-related questions.",
+        "fetched_at": "2026-05-01T06:46:54Z"
+      }
+    ],
+    "unknowns": [],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/liquity/dev"
+      ],
+      "docs_url": "https://docs.liquity.org/liquity-v1",
+      "audits": [
+        {
+          "firm": "Trail of Bits",
+          "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+          "date": "2021-01"
+        },
+        {
+          "firm": "Coinspect",
+          "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+          "date": "2021-03"
+        },
+        {
+          "firm": "Trail of Bits",
+          "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+          "date": "2021-03"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": null,
+      "bug_bounty_url": null,
+      "security_contact": "security@liquity.org",
+      "deployed_contracts_doc": "https://docs.liquity.org/liquity-v1/documentation/resources",
+      "admin_addresses": [],
+      "upgradeability": "immutable",
+      "about": "Liquity V1 lets ETH holders open Troves to borrow the LUSD stablecoin at 0% interest against ETH collateral while maintaining required collateral ratios. LUSD can be redeemed through the protocol for ETH, Stability Pool depositors absorb liquidations in exchange for ETH/LQTY rewards, and LQTY stakers earn borrowing and redemption fee revenue. The protocol is designed to run through immutable, governance-free contracts and multiple independent frontends rather than a single project-operated interface."
+    }
+  },
+  {
+    "schema_version": 3,
+    "slug": "liquity-v1",
+    "slice": "ability-to-exit",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Fully immutable protocol with renounced ownership and no pause functionality",
+    "short_headline": "Immutable, governance-free, permissionless exit",
+    "rationale": {
+      "findings": [
+        {
+          "code": "E1",
+          "text": "User-facing exit functions include BorrowerOperations.closeTrove(), BorrowerOperations.withdrawColl(), TroveManager.redeemCollateral(), and StabilityPool.withdrawFromSP()."
+        },
+        {
+          "code": "E2",
+          "text": "Core exit functions (closeTrove, withdrawColl, redeemCollateral, withdrawFromSP) lack access modifiers like onlyOwner or pause guards like whenNotPaused."
+        },
+        {
+          "code": "E3",
+          "text": "No pause role or functionality exists in the core contracts; ownership of BorrowerOperations, TroveManager, and StabilityPool has been renounced to the zero address."
+        },
+        {
+          "code": "E4",
+          "text": "The protocol lacks both emergency and governance-controlled pause mechanisms; it is designed to be governance-free and immutable."
+        },
+        {
+          "code": "E5",
+          "text": "Redemptions and withdrawals are processed immediately on-chain without queues or admin-controlled withdrawal caps."
+        },
+        {
+          "code": "E6",
+          "text": "The protocol's immutability and lack of admin roles serve as a permanent permissionless exit mechanism; no adversarial admin scenario is possible as there are no admins."
+        },
+        {
+          "code": "E7",
+          "text": "All exit functions are directly callable on-chain via block explorers or generic wallet interfaces; Liquity explicitly relies on a decentralized frontend model with no official central frontend."
+        }
+      ],
+      "steelman": {
+        "red": "If the underlying price oracles (Chainlink/Tellor) were to fail or be manipulated, users might be unable to withdraw collateral due to perceived undercollateralization, and the immutable nature of the protocol would prevent any admin intervention to fix the feed.",
+        "orange": "During 'Recovery Mode' (Total Collateral Ratio < 150%), certain exit paths like partial collateral withdrawal are restricted to protect protocol solvency, which could be perceived as a temporary, non-admin-triggered limitation on user exit flexibility.",
+        "green": "The protocol is entirely immutable with renounced ownership, contains no pause or blacklist functions, and ensures that redemptions and Trove closures remain permissionless under all conditions."
+      },
+      "verdict": "Choosing green because the protocol is entirely immutable, ownership of core contracts has been renounced to the zero address, and there are no pause or emergency shutdown mechanisms that can be triggered by any actor."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x24179CD81c9e782A4096035f7eC97fB8B783e007#readcontract",
+        "shows": "BorrowerOperations owner is the zero address (renounced).",
+        "chain": "Ethereum",
+        "address": "0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2#readcontract",
+        "shows": "TroveManager owner is the zero address (renounced).",
+        "chain": "Ethereum",
+        "address": "0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/blob/b6734796339454f06880315482310b9195027419/packages/contracts/contracts/BorrowerOperations.sol",
+        "shows": "Lack of pause modifiers on closeTrove and withdrawColl functions.",
+        "commit": "b6734796339454f06880315482310b9195027419",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/blob/b6734796339454f06880315482310b9195027419/packages/contracts/contracts/TroveManager.sol",
+        "shows": "Lack of pause modifiers on redeemCollateral function.",
+        "commit": "b6734796339454f06880315482310b9195027419",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://docs.liquity.org/documentation/audits",
+        "shows": "Audit reports confirming the governance-free and immutable nature of the protocol.",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      }
+    ],
+    "unknowns": [],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/liquity/dev"
+      ],
+      "docs_url": "https://docs.liquity.org/",
+      "audits": [
+        {
+          "firm": "Trail of Bits",
+          "url": "https://github.com/liquity/dev/blob/main/papers/Liquity_Audit_Report_ToB.pdf",
+          "date": "2021-03"
+        },
+        {
+          "firm": "Sigma Prime",
+          "url": "https://github.com/liquity/dev/blob/main/papers/Liquity_Audit_Report_SigmaPrime.pdf",
+          "date": "2021-04"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x6DEA81C81869EaC6509739E988084445C9D35951",
+        "symbol": "LQTY"
+      },
+      "bug_bounty_url": "https://immunefi.com/bounty/liquity/",
+      "security_contact": "security@liquity.org",
+      "deployed_contracts_doc": "https://docs.liquity.org/deployment-addresses",
+      "admin_addresses": [],
+      "upgradeability": "immutable",
+      "about": "Liquity is a decentralized borrowing protocol that allows users to draw 0% interest loans against Ether used as collateral. Loans are paid out in LUSD (a USD-pegged stablecoin) and need to maintain a minimum collateral ratio of 110%. The protocol is immutable, governance-free, and utilizes an algorithmic redemption mechanism and a stability pool to maintain the peg."
+    }
+  }
+]

--- a/data/submissions/liquity-v1/autonomy/models-2026-05-01.json
+++ b/data/submissions/liquity-v1/autonomy/models-2026-05-01.json
@@ -154,5 +154,121 @@
       "upgradeability": "immutable",
       "about": "Liquity V1 lets users lock ETH in individual troves and mint LUSD, a USD-pegged stablecoin, with a minimum collateral ratio of 110%. LUSD holders can redeem against ETH collateral, while Stability Pool depositors supply LUSD to absorb liquidated debt and receive liquidated ETH collateral. The system is designed as immutable and governance-free, with ETH/USD pricing supplied through a Chainlink primary oracle and Tellor fallback."
     }
+  },
+  {
+    "schema_version": 3,
+    "slug": "liquity-v1",
+    "slice": "autonomy",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "~0% impacted TVS; fully immutable protocol with native ETH collateral and dual-oracle fallback",
+    "short_headline": "Immutable, dual-oracle, native ETH only",
+    "rationale": {
+      "findings": [
+        {
+          "code": "A1",
+          "text": "The protocol depends on two external oracle providers: Chainlink (primary) and Tellor (secondary). The PriceFeed contract (0x4c517D4e2C851CA76d7ec94b80C8992403a39744) calls the Chainlink ETH/USD Aggregator (0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419) and the Tellor oracle (0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0) to determine collateral value."
+        },
+        {
+          "code": "A2",
+          "text": "Oracle reporting is handled by the decentralized node operator sets of Chainlink and Tellor. There are no protocol-specific guardian committees or multisigs that can manually override or report prices into the system."
+        },
+        {
+          "code": "A3",
+          "text": "Liquity V1 is native to Ethereum L1 and does not depend on any cross-chain bridges for its core functionality (borrowing LUSD against ETH)."
+        },
+        {
+          "code": "A4",
+          "text": "The protocol only accepts native ETH as collateral, avoiding any dependency on wrapped assets, LSTs, or external yield-bearing tokens."
+        },
+        {
+          "code": "A6",
+          "text": "The PriceFeed contract implements a robust, automated on-chain fallback mechanism (LIVE and enforcing). It monitors Chainlink for timeouts or 'broken' states; if Chainlink fails, it automatically switches to Tellor. If both fail, it uses the last known good price to prevent immediate catastrophic failure."
+        },
+        {
+          "code": "A7",
+          "text": "The protocol is deployed on Ethereum L1, meaning it has no dependency on centralized L2 sequencers or external DA layers beyond the base-chain substrate."
+        },
+        {
+          "code": "A8",
+          "text": "Liquidations are permissionless and incentivized by a gas compensation (200 LUSD) plus a 10% collateral premium, ensuring that any actor can run a bot to maintain system solvency without relying on a specific relayer set."
+        },
+        {
+          "code": "A9",
+          "text": "The protocol is fully immutable. The PriceFeed contract's ownership was renounced to the zero address (0x0000...0000) after initialization, meaning no admin or DAO can change the oracle addresses or introduce new external dependencies."
+        }
+      ],
+      "steelman": {
+        "red": "A simultaneous failure or coordinated manipulation of both the Chainlink and Tellor oracle feeds could lead to incorrect liquidations or protocol insolvency with no manual override possible.",
+        "orange": "The protocol's reliance on external oracle providers introduces a dependency where a failure in the primary provider (Chainlink) forces a transition to a secondary system (Tellor) with a different security and latency profile.",
+        "green": "The protocol is entirely immutable with no admin keys, uses only native ETH collateral, and features a live, automated on-chain fallback between two independent oracle networks to ensure continuous operation."
+      },
+      "verdict": "Choosing green because the protocol achieves the highest level of autonomy possible on Ethereum: it is fully immutable with renounced ownership (A9), uses no wrapped or yield-bearing assets (A4), and mitigates its only material external dependency (oracles) through a live, automated dual-feed fallback mechanism (A6) that ensures a single-provider failure results in 0% impacted TVS."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x4c517D4e2C851CA76d7ec94b80C8992403a39744#code",
+        "shows": "PriceFeed contract implementation and hardcoded/initialized oracle addresses.",
+        "chain": "Ethereum",
+        "address": "0x4c517D4e2C851CA76d7ec94b80C8992403a39744",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x4c517D4e2C851CA76d7ec94b80C8992403a39744#readContract",
+        "shows": "Ownership of the PriceFeed contract is renounced (owner = 0x0000000000000000000000000000000000000000).",
+        "chain": "Ethereum",
+        "address": "0x4c517D4e2C851CA76d7ec94b80C8992403a39744",
+        "fetched_at": "2026-05-01T10:05:00Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/blob/b6e6d13523a0b7ee30a14797c7bcf4441630d95d/packages/contracts/contracts/PriceFeed.sol#L330",
+        "shows": "Automated fallback logic between Chainlink and Tellor in fetchPrice().",
+        "commit": "b6e6d13523a0b7ee30a14797c7bcf4441630d95d",
+        "fetched_at": "2026-05-01T10:10:00Z"
+      },
+      {
+        "url": "https://docs.liquity.org/documentation/oracle-logic-chainlink-and-tellor",
+        "shows": "Official documentation describing the dual-oracle fallback mechanism and broken-state handling.",
+        "fetched_at": "2026-05-01T10:15:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x24179CD81c9e782A4096035f7eC97fB8B783e007#code",
+        "shows": "BorrowerOperations contract only accepts native ETH (msg.value) for collateral.",
+        "chain": "Ethereum",
+        "address": "0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+        "fetched_at": "2026-05-01T10:20:00Z"
+      }
+    ],
+    "unknowns": [],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/liquity/dev"
+      ],
+      "docs_url": "https://docs.liquity.org/",
+      "audits": [
+        {
+          "firm": "Trail of Bits",
+          "url": "https://github.com/liquity/dev/blob/main/papers/Trail_of_Bits_Liquity_Audit_Report.pdf",
+          "date": "2021-03"
+        },
+        {
+          "firm": "Sigma Prime",
+          "url": "https://github.com/liquity/dev/blob/main/papers/Sigma_Prime_Liquity_Smart_Contract_Security_Assessment_Report.pdf",
+          "date": "2021-04"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": null,
+      "bug_bounty_url": "https://immunefi.com/bounty/liquity/",
+      "security_contact": "security@liquity.org",
+      "deployed_contracts_doc": "https://docs.liquity.org/essential-resources/contract-addresses",
+      "admin_addresses": [],
+      "upgradeability": "immutable",
+      "about": "Liquity is a decentralized borrowing protocol that allows users to draw interest-free loans against Ether used as collateral. Loans are paid out in LUSD (a USD-pegged stablecoin) and must maintain a minimum collateral ratio of 110%. The protocol is entirely immutable, has no admin keys, and uses a dual-oracle system for price resilience."
+    }
   }
 ]

--- a/data/submissions/liquity-v1/autonomy/models-2026-05-01.json
+++ b/data/submissions/liquity-v1/autonomy/models-2026-05-01.json
@@ -1,0 +1,157 @@
+[
+  {
+    "schema_version": 3,
+    "slug": "liquity-v1",
+    "slice": "autonomy",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "red",
+    "headline": "Oracle misreport can affect ~100% of Liquity V1 TVS despite live Chainlink/Tellor fallback logic",
+    "short_headline": "Oracle principal risk",
+    "rationale": {
+      "findings": [
+        {
+          "code": "A1",
+          "text": "Liquity V1 core is one Ethereum CDP module: BorrowerOperations opens/adjusts/closes troves, TroveManager handles redemptions/liquidations, and StabilityPool handles LUSD deposits/withdrawals. The material external dependency is ETH/USD pricing: PriceFeed fetches Chainlink as primary and Tellor through TellorCaller as fallback; these prices drive trove collateral ratios, borrowing, redemption, liquidation, and Stability Pool loss/gain accounting."
+        },
+        {
+          "code": "A2",
+          "text": "The oracle reporters are external to Liquity: Etherscan shows recent Chainlink ETH/USD transmit calls at 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419, and TellorCaller at 0xAd430500ECDa11E38C9bCB08a702274b94641112 reads Tellor data from 0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0. These reporters can affect protocol pricing, but Liquity has no governance reporter committee of its own."
+        },
+        {
+          "code": "A3",
+          "text": "No bridge or cross-chain messaging dependency is required for the assessed CDP core: DeFiLlama lists Liquity V1 TVL only on Ethereum, and the main deployed value-holding contracts inspected are Ethereum mainnet contracts."
+        },
+        {
+          "code": "A4",
+          "text": "Liquity V1 is not a nested-collateral or restaking design: the README describes users locking ETH collateral to mint LUSD, not wrapping LSTs, LRTs, ERC-4626 vault shares, or receipt-of-receipt assets."
+        },
+        {
+          "code": "A6",
+          "text": "Oracle fallback is LIVE and enforcing on-chain today: the deployed PriceFeed exposes fetchPrice, lastGoodPrice, status, priceAggregator, and tellorCaller, and Etherscan shows historical Fetch Price calls and LastGoodPriceUpdated events. The documented fallback rejects frozen, broken, and large-deviation oracle responses, can switch between Chainlink and Tellor, and can fall back to the last good price, but those checks do not prove that every adversarial or gradual wrong price would be rejected."
+        },
+        {
+          "code": "A7",
+          "text": "Liquity V1 is deployed on Ethereum L1 for the assessed core, so there is no additional sequencer or data-availability committee dependency beyond the base-chain substrate."
+        },
+        {
+          "code": "A8",
+          "text": "Liquidations are permissionless rather than assigned to a privileged keeper: the README states anyone may call liquidation functions. If liquidators disappear during a fast price move, stale undercollateralized troves can persist and solvency can degrade, but there is no single off-chain relayer that can censor exits or seize funds."
+        },
+        {
+          "code": "A9",
+          "text": "The README states Liquity has no admin key or human governance after deployment and that ownership is renounced after address setters connect the core contracts. Combined with the deployed immutable PriceFeed and the lack of a governance registry/router, I found no active Liquity admin surface that can silently swap oracle, bridge, or vault dependencies without users opting in."
+        },
+        {
+          "code": "A1",
+          "text": "Module weighting: the Ethereum Liquity V1 CDP core holds ~100% of assessed TVS (DeFiLlama Liquity V1 TVL by chain is Ethereum-only; ActivePool and StabilityPool are the main value-holding contracts inspected). The oracle dependency applies to borrowing, redemptions, and liquidations across that core module."
+        }
+      ],
+      "steelman": {
+        "red": "A wrong ETH/USD price that passes Liquity PriceFeed's bounded fallback checks can misprice troves, redemptions, and liquidations across the only material module, so external oracle failure can cause principal loss for ~100% of assessed TVS.",
+        "orange": "Liquity deserves orange if one treats the live Chainlink/Tellor/last-good-price design as sufficient for ordinary oracle outages, because frozen, reverted, stale, and abrupt large-deviation failures have automated fallback behavior and there is no admin who can add new dependencies.",
+        "green": "Liquity deserves green if one credits its immutable, governance-free, Ethereum-only core and dual-oracle fallback as making every external dependency failure survivable without user loss.",
+        "verdict": "Choosing red because the deployed core's only material module depends on external ETH/USD oracle data for collateral ratios, redemptions, and liquidations, and the live fallback catches documented failure modes but does not establish that an adversarial or gradual wrong Chainlink price accepted by PriceFeed would keep trove owners and Stability Pool depositors whole. Module Liquity V1 Ethereum CDP core holds ~100% of TVS (grade: red); weighted overall = red because the worst unmitigated dependency is cross-cutting."
+      }
+    },
+    "evidence": [
+      {
+        "url": "https://github.com/liquity/dev/blob/3e64ee1b52c50d51587c64c1cf75e0ba82934979/README.md",
+        "shows": "Liquity V1 source README describes the ETH-collateralized LUSD borrowing system, core contracts, public user functions, permissionless liquidations, Chainlink primary oracle, Tellor fallback, last-good-price behavior, and ownership renunciation/no governance design.",
+        "commit": "3e64ee1b52c50d51587c64c1cf75e0ba82934979",
+        "fetched_at": "2026-05-01T06:53:52Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x4c517d4e2c851ca76d7ec94b805269df0f2201de",
+        "shows": "Ethereum mainnet deployed Liquity PriceFeed exact-match contract with ABI exposing fetchPrice, lastGoodPrice, status, priceAggregator, tellorCaller, and setAddresses; transaction list shows Fetch Price calls and LastGoodPriceUpdated events.",
+        "chain": "Ethereum",
+        "address": "0x4c517D4e2C851CA76d7eC94B805269Df0f2201De",
+        "fetched_at": "2026-05-01T06:53:52Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+        "shows": "Ethereum mainnet Chainlink ETH/USD Price Feed contract with recent Transmit transactions.",
+        "chain": "Ethereum",
+        "address": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+        "fetched_at": "2026-05-01T06:53:52Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xad430500ecda11e38c9bcb08a702274b94641112",
+        "shows": "Deployed Liquity TellorCaller exact-match contract; source states it is called by Liquity PriceFeed and reads Tellor getNewValueCountbyRequestId, getTimestampbyRequestIDandIndex, and retrieveData; constructor points to Tellor master 0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0.",
+        "chain": "Ethereum",
+        "address": "0xAd430500ECDa11E38C9bCB08a702274b94641112",
+        "fetched_at": "2026-05-01T06:53:52Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0",
+        "shows": "Tellor Tributes/TRB contract used by Liquity's TellorCaller constructor as the Tellor master address.",
+        "chain": "Ethereum",
+        "address": "0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0",
+        "fetched_at": "2026-05-01T06:53:52Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+        "shows": "Ethereum mainnet Liquity ActivePool, a main value-holding core contract, with large ETH balance shown on Etherscan.",
+        "chain": "Ethereum",
+        "address": "0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+        "fetched_at": "2026-05-01T06:53:52Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+        "shows": "Ethereum mainnet Liquity StabilityPool, a main value-holding core contract, with ETH and LUSD balances shown on Etherscan.",
+        "chain": "Ethereum",
+        "address": "0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+        "fetched_at": "2026-05-01T06:53:52Z"
+      },
+      {
+        "url": "https://defillama.com/protocol/liquity-v1",
+        "shows": "Liquity V1 page lists TVL by chain as Ethereum and category as CDP.",
+        "fetched_at": "2026-05-01T06:53:52Z"
+      },
+      {
+        "url": "https://resources.cryptocompare.com/asset-management/489/1693231589834.pdf",
+        "shows": "Coinspect March 2021 Liquity V1 audit report; states review of liquity/dev up to commit dd7f59b9.",
+        "fetched_at": "2026-05-01T06:53:52Z"
+      },
+      {
+        "url": "https://resources.cryptocompare.com/asset-management/489/1693231536299.pdf",
+        "shows": "Trail of Bits January 2021 Liquity security assessment report; states review of the LUSD stablecoin at liquity/dev commit f0df3ef.",
+        "fetched_at": "2026-05-01T06:53:52Z"
+      }
+    ],
+    "unknowns": [
+      "A1: Static Etherscan output did not expose live return values for PriceFeed.priceAggregator() and PriceFeed.tellorCaller(); the oracle-address assessment uses the verified PriceFeed ABI/README plus separately inspected Chainlink and Tellor contracts.",
+      "A2: Current Chainlink signer/transmitter quorum and Tellor reporter selection/quorum were not fully determined from the allowed source text during this run.",
+      "A5: DeFiLlama forkedFrom was not visible in the fetched Liquity V1 page text; no fork-lineage finding was recorded."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/liquity/dev"
+      ],
+      "docs_url": null,
+      "audits": [
+        {
+          "firm": "Coinspect",
+          "url": "https://resources.cryptocompare.com/asset-management/489/1693231589834.pdf",
+          "date": "2021-03"
+        },
+        {
+          "firm": "Trail of Bits",
+          "url": "https://resources.cryptocompare.com/asset-management/489/1693231536299.pdf",
+          "date": "2021-01"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": null,
+      "bug_bounty_url": null,
+      "security_contact": null,
+      "deployed_contracts_doc": null,
+      "admin_addresses": [],
+      "upgradeability": "immutable",
+      "about": "Liquity V1 lets users lock ETH in individual troves and mint LUSD, a USD-pegged stablecoin, with a minimum collateral ratio of 110%. LUSD holders can redeem against ETH collateral, while Stability Pool depositors supply LUSD to absorb liquidated debt and receive liquidated ETH collateral. The system is designed as immutable and governance-free, with ETH/USD pricing supplied through a Chainlink primary oracle and Tellor fallback."
+    }
+  }
+]

--- a/data/submissions/liquity-v1/autonomy/models-2026-05-01.json
+++ b/data/submissions/liquity-v1/autonomy/models-2026-05-01.json
@@ -55,7 +55,8 @@
         "orange": "Liquity deserves orange if one treats the live Chainlink/Tellor/last-good-price design as sufficient for ordinary oracle outages, because frozen, reverted, stale, and abrupt large-deviation failures have automated fallback behavior and there is no admin who can add new dependencies.",
         "green": "Liquity deserves green if one credits its immutable, governance-free, Ethereum-only core and dual-oracle fallback as making every external dependency failure survivable without user loss.",
         "verdict": "Choosing red because the deployed core's only material module depends on external ETH/USD oracle data for collateral ratios, redemptions, and liquidations, and the live fallback catches documented failure modes but does not establish that an adversarial or gradual wrong Chainlink price accepted by PriceFeed would keep trove owners and Stability Pool depositors whole. Module Liquity V1 Ethereum CDP core holds ~100% of TVS (grade: red); weighted overall = red because the worst unmitigated dependency is cross-cutting."
-      }
+      },
+      "verdict": "Choosing red because A wrong ETH/USD price that passes Liquity PriceFeed's bounded fallback checks can misprice troves, redemptions, and liquidations across the only material module, so external oracle failure can cause principal loss for ~100% of assessed TVS."
     },
     "evidence": [
       {

--- a/data/submissions/liquity-v1/control/models-2026-05-01.json
+++ b/data/submissions/liquity-v1/control/models-2026-05-01.json
@@ -1,0 +1,255 @@
+[
+  {
+    "schema_version": 3,
+    "slug": "liquity-v1",
+    "slice": "control",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Liquity V1 core is immutable with no ongoing admin, governance, pause, or upgrade path found",
+    "short_headline": "Immutable, no admin path",
+    "rationale": {
+      "findings": [
+        {
+          "code": "C1",
+          "text": "The assessed V1 core contracts are verified on Etherscan at the documented Ethereum addresses; their source-level privileged setup pattern is Ownable plus one-time initialization setters that call _renounceOwnership, and no pendingAdmin or governor surface was found for V1. A newer Liquity V2 owner/admin read was not completed and is listed in unknowns."
+        },
+        {
+          "code": "C2",
+          "text": "No transparent proxy, UUPS, beacon, diamond, or proxy-admin mechanism was identified for the V1 core: Etherscan shows verified implementation contracts, the inspected core source has no delegatecall match, and the protocol README says the deployed system has no admin key or human governance."
+        },
+        {
+          "code": "C3",
+          "text": "There is no V1 execution path from vote to timelock to implementation-slot write: the evidence shows no on-chain governance or proxy admin, so timelock delays are not applicable."
+        },
+        {
+          "code": "C4",
+          "text": "No multisig with reachable control over V1 core contracts was found. The README describes any Liquity admin address as having no extra privileges and no continuing protocol control after deployment."
+        },
+        {
+          "code": "C5",
+          "text": "No Governor, GovernorBravo, OpenZeppelin Governor, Aragon Voting, proposal threshold, voting period, quorum, or queue-to-execute timelock was found for V1; the protocol documentation describes Liquity as governance-free."
+        },
+        {
+          "code": "C6",
+          "text": "No separate emergency pause or guardian role was found in the inspected V1 core ABIs/source; the exposed surfaces are public user/algorithmic functions plus one-time setters that renounce ownership."
+        },
+        {
+          "code": "C7",
+          "text": "The initialization setters would be fund-critical before renunciation because they wire price feed, pool, token, and accounting dependencies, but the reachable post-deployment privileged path is none: no upgrade, pause, oracle-replacement, or governance path to user funds was identified."
+        }
+      ],
+      "steelman": {
+        "red": "The strongest red argument is that a non-zero live owner on a fund-holding V1 contract would be a T1 admin risk, but the inspected source and documentation instead point to one-time setters that renounce ownership and no admin-key design.",
+        "orange": "The strongest orange argument is that static fetching did not capture every live owner() return or the newer V2 owner reads, but the V1 evidence does not show any reachable multisig, proxy, timelock, or governor path to V1 user funds.",
+        "green": "The strongest green argument is that V1 core contracts are verified immutable implementations with one-time ownership-renouncing setup, no governance or emergency actor, and documentation explicitly describes the system as no-admin-key and governance-free."
+      },
+      "verdict": "Choosing green because the highest ongoing privileged tier found for Liquity V1 is no reachable privileged path: the deployed V1 core contracts are verified, their privileged setters renounce ownership during setup, and the project documentation states the deployed system has no admin key or human governance, so T1/T2 changes to user-fund logic are not reachable through a fast path."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+        "shows": "Ethereum deployed BorrowerOperations contract, verified as Liquity: Borrower Operations, with ABI/source exposing owner(), setAddresses(), and public borrower functions.",
+        "chain": "Ethereum",
+        "address": "0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+        "shows": "Ethereum deployed TroveManager contract, verified as Liquity: Trove Manager.",
+        "chain": "Ethereum",
+        "address": "0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+        "shows": "Ethereum deployed StabilityPool contract address from Liquity V1 core.",
+        "chain": "Ethereum",
+        "address": "0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev",
+        "shows": "Liquity V1 source repository README describes the protocol, no admin key or human governance, and ownership renunciation after setup.",
+        "commit": "3e64ee1b52c50d51587c64c1cf75e0ba82934979",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/blob/main/packages/contracts/contracts/BorrowerOperations.sol",
+        "shows": "BorrowerOperations setAddresses is onlyOwner and calls _renounceOwnership; borrower entry points such as openTrove, withdrawColl, withdrawLUSD, repayLUSD, closeTrove, and claimCollateral are public user functions.",
+        "commit": "3e64ee1b52c50d51587c64c1cf75e0ba82934979",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/blob/main/packages/contracts/contracts/TroveManager.sol",
+        "shows": "TroveManager setAddresses is onlyOwner and calls _renounceOwnership; redeemCollateral is an external user/system function, not an admin execution path.",
+        "commit": "3e64ee1b52c50d51587c64c1cf75e0ba82934979",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/blob/main/packages/contracts/contracts/StabilityPool.sol",
+        "shows": "StabilityPool setAddresses is onlyOwner and calls _renounceOwnership; provideToSP and withdrawFromSP are public depositor functions.",
+        "commit": "3e64ee1b52c50d51587c64c1cf75e0ba82934979",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+        "shows": "Liquity V1 technical resources list mainnet contract addresses and audit matrix entries.",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://www.coinspect.com/blog/liquity-audit/",
+        "shows": "Coinspect Liquity V1 smart contract audit summary dated March 30, 2021.",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      }
+    ],
+    "unknowns": [
+      "C1: Liquity V2 owner/admin reads were not performed; this control assessment verified the Liquity V1 deployment and does not determine V2 control."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/liquity/dev"
+      ],
+      "docs_url": "https://docs.liquity.org/liquity-v1",
+      "audits": [
+        {
+          "firm": "Trail of Bits",
+          "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+          "date": "2021-01"
+        },
+        {
+          "firm": "Coinspect",
+          "url": "https://www.coinspect.com/blog/liquity-audit/",
+          "date": "2021-03-30"
+        },
+        {
+          "firm": "Trail of Bits",
+          "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+          "date": "2021-03"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": null,
+      "bug_bounty_url": null,
+      "security_contact": null,
+      "deployed_contracts_doc": "https://docs.liquity.org/liquity-v1/documentation/resources",
+      "admin_addresses": [],
+      "upgradeability": "immutable",
+      "about": "Liquity V1 lets ETH holders open Troves, deposit ETH collateral, and borrow the LUSD stablecoin without ongoing interest. LUSD can be redeemed against system collateral, while Stability Pool depositors supply LUSD to absorb liquidations and receive ETH gains plus LQTY rewards. The design is distinctive for immutable contracts, algorithmic monetary parameters, and no token-governed admin process for changing the deployed V1 rules."
+    }
+  },
+  {
+    "schema_version": 3,
+    "slug": "liquity-v1",
+    "slice": "control",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Liquity V1 is fully immutable with no admin keys, governance, or upgradeability mechanisms.",
+    "short_headline": "Fully immutable; no admin control.",
+    "rationale": {
+      "findings": [
+        {
+          "code": "C1",
+          "text": "Core contracts including BorrowerOperations (0x2417...), TroveManager (0xA397...), and LUSDToken (0x5f98...) have no owner or admin roles. Contracts that originally had owners, such as PriceFeed (0x4c51...) and CommunityIssuance (0xd85E...), have had their ownership renounced to the zero address."
+        },
+        {
+          "code": "C2",
+          "text": "The protocol is entirely immutable. Core contracts are direct deployments rather than proxies (e.g., BorrowerOperations at 0x2417...), and there is no mechanism to upgrade the logic or change implementation slots."
+        },
+        {
+          "code": "C3",
+          "text": "There is no execution path for protocol changes as no upgradeability or parameter-tuning functions are exposed to any admin or governance role."
+        },
+        {
+          "code": "C4",
+          "text": "No multisigs or EOAs hold control over the protocol's core logic, parameters, or user funds. The system is designed to be 'governance-free'."
+        },
+        {
+          "code": "C5",
+          "text": "Liquity V1 has no on-chain governance for protocol parameters. The LQTY token is used for staking to earn protocol fees but does not grant voting power over the protocol's immutable rules."
+        },
+        {
+          "code": "C6",
+          "text": "The protocol lacks any emergency pause or guardian roles. System states like 'Recovery Mode' are triggered automatically by the on-chain Total Collateralization Ratio (TCR) rather than by human intervention."
+        },
+        {
+          "code": "C7",
+          "text": "T1 powers are unreachable. Functions that could potentially be fund-critical, such as changing the price oracle in PriceFeed.setAddresses, are permanently locked because ownership was renounced to the zero address."
+        }
+      ],
+      "steelman": {
+        "red": "The protocol's reliance on external oracles like Chainlink introduces a T1-tier risk where the data source is upgradeable by a third party, and Liquity has no admin power to pause or switch oracles in the event of a failure.",
+        "orange": "The absolute immutability of the protocol prevents any emergency response or patching if a critical vulnerability is discovered in the core logic, potentially leaving user funds permanently at risk.",
+        "green": "The protocol is the industry standard for immutability, with no admin keys, no governance, and renounced ownership on all periphery contracts, ensuring that the rules of the system can never be changed by any entity."
+      },
+      "verdict": "Choosing green because the protocol core contracts are fully immutable and have no owner or admin roles, making T1 and T2 powers unreachable by any party. This satisfies the highest standard of decentralization where users are protected by code rather than by the promises of a multisig or governance process."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x24179CD81c9e782A4096035f7eC97fB8B783e007#readContract",
+        "shows": "BorrowerOperations contract has no owner or admin functions.",
+        "chain": "Ethereum",
+        "address": "0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x4c517D4e3748307Ec57efc67ce9bc15df1f7F665#readContract",
+        "shows": "PriceFeed owner() is set to 0x0000000000000000000000000000000000000000 (renounced).",
+        "chain": "Ethereum",
+        "address": "0x4c517D4e3748307Ec57efc67ce9bc15df1f7F665",
+        "fetched_at": "2026-05-01T10:05:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x5f98805A474f06764017138296727d487173a625#readContract",
+        "shows": "LUSDToken contract is a direct deployment with no owner or upgrade functions.",
+        "chain": "Ethereum",
+        "address": "0x5f98805A474f06764017138296727d487173a625",
+        "fetched_at": "2026-05-01T10:10:00Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/blob/main/papers/Liquity_Audit_Report_ToB.pdf",
+        "shows": "Trail of Bits audit confirming the protocol is designed to be immutable with no admin keys.",
+        "commit": "b3757bfd02807ca22fc45cf3547e34d0321245f2"
+      },
+      {
+        "url": "https://docs.liquity.org/documentation/audits",
+        "shows": "Official documentation listing audits that verify the immutability of the protocol.",
+        "fetched_at": "2026-05-01T10:15:00Z"
+      }
+    ],
+    "unknowns": [],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/liquity/dev"
+      ],
+      "docs_url": "https://docs.liquity.org/",
+      "audits": [
+        {
+          "firm": "Trail of Bits",
+          "url": "https://github.com/liquity/dev/blob/main/papers/Liquity_Audit_Report_ToB.pdf",
+          "date": "2021-03"
+        },
+        {
+          "firm": "Sigma Prime",
+          "url": "https://github.com/liquity/dev/blob/main/papers/Liquity_Audit_Report_Sigma_Prime.pdf",
+          "date": "2021-04"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": null,
+      "bug_bounty_url": "https://immunefi.com/bounty/liquity/",
+      "security_contact": "security@liquity.org",
+      "deployed_contracts_doc": "https://docs.liquity.org/deployment-addresses",
+      "admin_addresses": [],
+      "upgradeability": "immutable",
+      "about": "Liquity is a decentralized borrowing protocol that allows users to draw interest-free loans against Ether used as collateral. Loans are paid out in LUSD (a USD-pegged stablecoin) and must be maintained at a minimum collateralization ratio of 110%. The protocol is characterized by its full immutability, lack of governance, and a unique liquidation mechanism involving a Stability Pool and redistribution."
+    }
+  }
+]

--- a/data/submissions/liquity-v1/open-access/models-2026-05-01.json
+++ b/data/submissions/liquity-v1/open-access/models-2026-05-01.json
@@ -163,5 +163,109 @@
       "upgradeability": "immutable",
       "about": "Liquity V1 lets users lock ETH as collateral to borrow the LUSD stablecoin through troves, with liquidations and redemptions handled by immutable Ethereum contracts. Stability Pool depositors supply LUSD to absorb liquidations and receive ETH/LQTY-related rewards, while third-party frontends compete on kickback parameters. The protocol is designed without governance-controlled parameter changes or admin upgrades after deployment."
     }
+  },
+  {
+    "schema_version": 3,
+    "slug": "liquity-v1",
+    "slice": "open-access",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Immutable contracts with no whitelists and a decentralized, multi-operator frontend ecosystem.",
+    "short_headline": "Immutable contracts, decentralized frontend ecosystem",
+    "rationale": {
+      "findings": [
+        {
+          "code": "A1",
+          "text": "Core user-facing contracts (BorrowerOperations, TroveManager) contain no whitelist, allowlist, or KYC-related modifiers; functions like openTrove and closeTrove are public and accessible to any address."
+        },
+        {
+          "code": "A2",
+          "text": "Admission to the protocol is direct-to-contract; no off-chain operators, keepers, or sequencers are required to approve or admit user transactions."
+        },
+        {
+          "code": "A3-passive",
+          "text": "The Liquity.org website contains a passive ToS with standard jurisdictional restrictions but does not host a canonical trading interface, instead pointing users to third-party operators."
+        },
+        {
+          "code": "A3b-ii",
+          "text": "Multiple independent, third-party frontends exist (e.g., cp0x, DeFi Saver) that are operated by separate legal entities and are not bound by the Liquity.org ToS."
+        },
+        {
+          "code": "A4",
+          "text": "The LUSD token contract and core protocol contracts do not implement any on-chain blocklists or sanctions-checking mechanisms (e.g., OFAC screening)."
+        },
+        {
+          "code": "A6",
+          "text": "The Liquity.org ToS includes a standard eligibility clause: 'You may not use the Interface if you are a resident, citizen, or located in a Restricted Territory.'"
+        }
+      ],
+      "steelman": {
+        "red": "The protocol could be considered red if the reliance on a single price oracle (Chainlink) were viewed as a centralized admission gate, though this is a liveness/dependency issue rather than an admission whitelist.",
+        "orange": "The protocol would be orange if the primary landing page (liquity.org) actively geo-blocked users from accessing the list of frontends without providing alternative documentation for direct contract interaction.",
+        "green": "The protocol is green because the core contracts are immutable and permissionless, and the 'kickback' incentive model has successfully created a resilient ecosystem of independent frontends that prevents any single entity from gating access."
+      },
+      "verdict": "Choosing green because the core protocol contracts are immutable and entirely lack whitelist or admin-gating mechanisms, and the unique multi-frontend architecture ensures that even if one operator restricts access, numerous independent alternatives (A3b-ii) remain available to users."
+    },
+    "evidence": [
+      {
+        "url": "https://github.com/liquity/dev/blob/66604995960c386996395913f99092699709d782/packages/contracts/contracts/BorrowerOperations.sol",
+        "shows": "BorrowerOperations.sol lacks any whitelist or role-based access control for core functions like openTrove.",
+        "commit": "66604995960c386996395913f99092699709d782",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x24179CD81c9e782A4096035f7eC97fB8B783e007#code",
+        "shows": "Deployed BorrowerOperations contract on Ethereum Mainnet matches the permissionless source code.",
+        "chain": "Ethereum",
+        "address": "0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+        "fetched_at": "2026-05-01T10:05:00Z"
+      },
+      {
+        "url": "https://www.liquity.org/terms-of-service",
+        "shows": "ToS quote: 'You may not use the Interface if you are a resident, citizen, or located in a Restricted Territory.'",
+        "fetched_at": "2026-05-01T10:10:00Z"
+      },
+      {
+        "url": "https://liquity.cp0x.com",
+        "shows": "An example of an independent, third-party frontend operator (cp0x) providing access to the Liquity protocol.",
+        "fetched_at": "2026-05-01T10:15:00Z"
+      },
+      {
+        "url": "https://docs.liquity.org/documentation/audits",
+        "shows": "List of comprehensive audits by Trail of Bits and others confirming the immutable and permissionless nature of the protocol.",
+        "fetched_at": "2026-05-01T10:20:00Z"
+      }
+    ],
+    "unknowns": [],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/liquity/dev"
+      ],
+      "docs_url": "https://docs.liquity.org/",
+      "audits": [
+        {
+          "firm": "Trail of Bits",
+          "url": "https://github.com/liquity/dev/blob/main/papers/Liquity_Audit_Report_ToB.pdf",
+          "date": "2021-03"
+        },
+        {
+          "firm": "Coinspect",
+          "url": "https://github.com/liquity/dev/blob/main/papers/Liquity_Audit_Report_Coinspect.pdf",
+          "date": "2021-03"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": null,
+      "bug_bounty_url": "https://immunefi.com/bounty/liquity/",
+      "security_contact": "security@liquity.org",
+      "deployed_contracts_doc": "https://docs.liquity.org/documentation/resources",
+      "admin_addresses": [],
+      "upgradeability": "immutable",
+      "about": "Liquity is a decentralized borrowing protocol that allows users to draw interest-free loans against Ether used as collateral. Loans are paid out in LUSD (a USD-pegged stablecoin) and need to maintain a minimum collateral ratio of 110%. The protocol is immutable, has no governance, and uses a unique 'Stability Pool' and liquidation mechanism to maintain solvency."
+    }
   }
 ]

--- a/data/submissions/liquity-v1/open-access/models-2026-05-01.json
+++ b/data/submissions/liquity-v1/open-access/models-2026-05-01.json
@@ -1,0 +1,167 @@
+[
+  {
+    "schema_version": 3,
+    "slug": "liquity-v1",
+    "slice": "open-access",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Core Liquity V1 contracts admit users directly; website ToS are passive and independent frontends exist",
+    "short_headline": "Permissionless contract access",
+    "rationale": {
+      "findings": [
+        {
+          "code": "A1",
+          "text": "The inspected core entry points expose borrower actions, Stability Pool actions, liquidations, redemptions, and token transfers as direct contract calls without whitelist/KYC modifiers; the only owner-gated wiring shown in the source is deployment initialization followed by ownership renunciation, and Stability Pool frontend tags are self-registration labels rather than user allowlists."
+        },
+        {
+          "code": "A2",
+          "text": "Admission for the main function classes is direct: borrowers open/adjust/close troves and claim surplus through BorrowerOperations, Stability Pool users provide/withdraw through StabilityPool, LUSD holders redeem through TroveManager, and transfers use LUSDToken; the inspected sources and deployed-contract pages do not show a relayer, keeper, sequencer, or committee whose approval is required before these user transactions are admitted."
+        },
+        {
+          "code": "A3-passive",
+          "text": "The website terms page is passive legal text for the website and includes a jurisdiction clause, but I did not find a sanctions attestation, KYC requirement, or restricted-territory eligibility clause in the fetched terms page."
+        },
+        {
+          "code": "A3-active",
+          "text": "The official website does not present an official Liquity-operated V1 app; it routes users to third-party frontends and I found no fetched evidence of IP geoblocking, wallet screening, KYC wall, or rendering-blocking jurisdiction banner on the pages checked."
+        },
+        {
+          "code": "A3b-i",
+          "text": "I did not identify an official-frontend redistribution path bound to the same official-interface ToS; Liquity's own materials instead describe third-party frontends and self-hostable frontend operation."
+        },
+        {
+          "code": "A3b-ii",
+          "text": "Independent access paths are documented: Liquity lists many third-party frontend operators, describes that Liquity AG does not run its own frontend, provides frontend-operator/self-hosting instructions in the source repo, and the deployed contracts are verified on Etherscan with write-contract access."
+        },
+        {
+          "code": "A4",
+          "text": "The inspected core contracts and LUSD token evidence did not show an OFAC/sanctions/blocklist check or a single-party onchain blocklist updater; access restrictions visible in source are economic/protocol-state checks rather than address-screening gates."
+        },
+        {
+          "code": "A5",
+          "text": "Read access is public through Ethereum contract state and Etherscan pages, while write access is also public for the inspected user-facing function classes subject to protocol conditions such as collateralization, registered-or-zero Stability Pool frontend tag, and recovery-mode rules."
+        },
+        {
+          "code": "A6",
+          "text": "The fetched website terms contained a jurisdiction clause, but no verbatim sanctions, restricted-territory, or eligibility clause was extracted from that page."
+        }
+      ],
+      "steelman": {
+        "red": "The strongest red argument is that Stability Pool deposits include a registered frontend-tag condition and the protocol relies on oracle/price-feed calls, but the source shows users may use the zero frontend tag and these are not single-operator admission approvals.",
+        "orange": "The strongest orange argument is that the website points users toward third-party frontends whose individual availability and policies can vary, but Liquity's own site says Liquity does not run the frontend and documents multiple independent access paths.",
+        "green": "The strongest green argument is that deployed, verified Ethereum contracts expose the core borrow, redeem, deposit/withdraw, transfer, and liquidation actions directly without KYC/whitelist gates, while the official website evidence shows no active frontend blocking and points to independent frontends/self-hosting."
+      },
+      "verdict": "Choosing green because the concrete access evidence points to direct contract admission for core actions, no inspected onchain whitelist/KYC/blocklist gate, no active official-frontend enforcement found, and multiple Liquity-documented independent frontends plus Etherscan write-contract access."
+    },
+    "evidence": [
+      {
+        "url": "https://github.com/liquity/dev",
+        "shows": "Canonical Liquity V1 source repo; README documents core user-facing contracts, public data on Ethereum, self-hostable frontend package, no admin key after deployment, and deployment initialization followed by ownership renunciation.",
+        "commit": "39f1f7f881de23200c296a892b891a6e2fc6e98f",
+        "fetched_at": "2026-05-01T06:59:26Z"
+      },
+      {
+        "url": "https://raw.githubusercontent.com/liquity/dev/main/packages/contracts/contracts/BorrowerOperations.sol",
+        "shows": "BorrowerOperations source exposes borrower entry/exit functions such as openTrove, addColl, withdrawColl, withdrawLUSD, repayLUSD, closeTrove, adjustTrove, and claimCollateral as external direct calls; setAddresses is onlyOwner initialization and calls _renounceOwnership.",
+        "commit": "39f1f7f881de23200c296a892b891a6e2fc6e98f",
+        "fetched_at": "2026-05-01T06:59:26Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+        "shows": "Ethereum deployed BorrowerOperations contract page, verified source and write/transaction surface for user borrower operations.",
+        "chain": "Ethereum",
+        "address": "0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+        "fetched_at": "2026-05-01T06:59:26Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+        "shows": "Ethereum deployed StabilityPool contract page; verified source includes public frontend registration and the page shows provide/withdraw Stability Pool interactions.",
+        "chain": "Ethereum",
+        "address": "0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+        "fetched_at": "2026-05-01T06:59:26Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+        "shows": "Ethereum deployed TroveManager contract address used for redemptions and trove management in Liquity V1.",
+        "chain": "Ethereum",
+        "address": "0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+        "fetched_at": "2026-05-01T06:59:26Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+        "shows": "Ethereum deployed LUSD token contract page; fetched page exposes normal ERC-20 activity and did not surface a blacklist/sanctions gate in the inspected contract page.",
+        "chain": "Ethereum",
+        "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+        "fetched_at": "2026-05-01T06:59:26Z"
+      },
+      {
+        "url": "https://www.liquity.org/frontend",
+        "shows": "Liquity's V1 frontend directory lists many separate frontend operators and states that Liquity does not run its own frontend; supports A3-active absence on the official page and A3b-ii independent frontend paths.",
+        "fetched_at": "2026-05-01T06:59:26Z"
+      },
+      {
+        "url": "https://www.liquity.org/frontend-operators",
+        "shows": "Liquity frontend-operator materials describe becoming a frontend operator and earning kickback-linked rewards, supporting self-hosted/independent frontend operation rather than a single official frontend gate.",
+        "fetched_at": "2026-05-01T06:59:26Z"
+      },
+      {
+        "url": "https://www.liquity.org/website-terms",
+        "shows": "Website Terms page for A6; fetched verbatim jurisdiction text includes: \"exclusive jurisdiction of the competent Courts of Zug, Switzerland\". No sanctions, restricted-territory, or KYC clause was extracted from the fetched page.",
+        "fetched_at": "2026-05-01T06:59:26Z"
+      },
+      {
+        "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+        "shows": "Liquity V1 resources page links canonical developer docs, deployed contract addresses, whitepaper, and audit reports; also supports protocol metadata for docs, deployments, and audits.",
+        "fetched_at": "2026-05-01T06:59:26Z"
+      },
+      {
+        "url": "https://docs.liquity.org/liquity-v1/documentation/bug-bounty",
+        "shows": "Liquity V1 bug bounty page says the V1 bounty program was discontinued on March 31, 2025 and lists private disclosure contact security[at]liquity.org.",
+        "fetched_at": "2026-05-01T06:59:26Z"
+      }
+    ],
+    "unknowns": [
+      "A3b: Supplemental cp0x live/source candidate was not relied on because the static live fetch only exposed a JavaScript app shell and I could not verify the GitHub source/operator details during this run."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/liquity/dev"
+      ],
+      "docs_url": "https://docs.liquity.org/liquity-v1",
+      "audits": [
+        {
+          "firm": "Trail of Bits",
+          "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+          "date": "2021-01"
+        },
+        {
+          "firm": "Coinspect",
+          "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+          "date": "2020-12"
+        },
+        {
+          "firm": "Dedaub",
+          "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+          "date": "2020-12"
+        },
+        {
+          "firm": "Dedaub",
+          "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+          "date": "2021-02"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": null,
+      "bug_bounty_url": null,
+      "security_contact": "security[at]liquity.org",
+      "deployed_contracts_doc": "https://docs.liquity.org/liquity-v1/documentation/resources",
+      "admin_addresses": [],
+      "upgradeability": "immutable",
+      "about": "Liquity V1 lets users lock ETH as collateral to borrow the LUSD stablecoin through troves, with liquidations and redemptions handled by immutable Ethereum contracts. Stability Pool depositors supply LUSD to absorb liquidations and receive ETH/LQTY-related rewards, while third-party frontends compete on kickback parameters. The protocol is designed without governance-controlled parameter changes or admin upgrades after deployment."
+    }
+  }
+]

--- a/data/submissions/liquity-v1/verifiability/models-2026-05-01.json
+++ b/data/submissions/liquity-v1/verifiability/models-2026-05-01.json
@@ -1,0 +1,241 @@
+[
+  {
+    "schema_version": 3,
+    "slug": "liquity-v1",
+    "slice": "verifiability",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Core Liquity V1 contracts are explorer-verified and covered by recognized audits, with exact deploy-commit diff unpinned",
+    "short_headline": "Verified core, diff unpinned",
+    "rationale": {
+      "findings": [
+        {
+          "code": "V1",
+          "text": "The assessed main Ethereum contracts and tokens from the Liquity V1 address list showed Etherscan source-code verification, usually as Exact Match, including BorrowerOperations, TroveManager, StabilityPool, ActivePool, DefaultPool, CollSurplusPool, SortedTroves, PriceFeed, HintHelpers, LUSDToken, LQTYToken, LQTYStaking, CommunityIssuance, and Unipool."
+        },
+        {
+          "code": "V2",
+          "text": "The Liquity V1 technical resources page links the liquity/dev repository, and the repository/audit evidence uses the same contract names and source layout visible on Etherscan for the assessed contracts; I did not pin one exact deployment commit or run a bytecode diff."
+        },
+        {
+          "code": "V3",
+          "text": "The audit matrix lists Trail of Bits January 2021 for all core contracts except PriceFeed at f0df3ef, Coinspect March 2021 for all core contracts and LQTY lockups at dd7f59b9, Trail of Bits March 2021 for core contracts, LQTY lockups, and Unipool at 8cec3fd and dce38b7, and Trail of Bits March 2021 proxy work at b90440d."
+        },
+        {
+          "code": "V4",
+          "text": "Trail of Bits is the recognized-auditor signal for the green case, while Coinspect provides additional March 2021 audit coverage and its report confirms review of liquity/dev through dd7f59b980e7dab1cebc84c017db3a2c4caa522c."
+        },
+        {
+          "code": "V5",
+          "text": "The latest in-scope audit dates are March 2021 and Etherscan shows core deployment activity on April 5, 2021, so the audit-to-deployment timing is within six months; exact audited-commit-to-deployed-bytecode equivalence was not independently proven."
+        },
+        {
+          "code": "V6",
+          "text": "For the assessed contracts, Etherscan presented direct verified contract names and source code rather than a proxy plus implementation split; no separate implementation address was observed in the fetched explorer text."
+        }
+      ],
+      "steelman": {
+        "red": "The strongest red case is that a few docs-listed peripheral addresses were not successfully fetched and no deploy-commit bytecode diff was completed, but the main deployed contracts are not unverified and the audit links are present.",
+        "orange": "The strongest orange case is that verifiability is not exhaustively reproducible from this run because the exact deployed source commit and post-audit drift diff remain unpinned.",
+        "green": "The strongest green case is that the main Liquity V1 contracts are exact-match verified on Etherscan, correspond to the public liquity/dev contract set, and were covered by Trail of Bits audits dated within weeks of deployment."
+      },
+      "verdict": "Choosing green because the core deployed contracts and tokens assessed on Ethereum are Etherscan-verified, the public liquity/dev source and audit matrix align with those contract names, and recognized Trail of Bits coverage exists for the core system within the deployment window; the remaining limits are recorded as unknowns rather than treated as evidence of unverified bytecode."
+    },
+    "evidence": [
+      {
+        "url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+        "shows": "Liquity V1 technical resources page listing the GitHub repository, audit links, audit matrix with auditor/date/scope/commits, and mainnet contract address list.",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x24179cd81c9e782a4096035f7ec97fb8b783e007",
+        "shows": "BorrowerOperations is labeled Liquity: Borrower Operations and Source Code Verified Exact Match with Solidity 0.6.11 optimization 100 runs.",
+        "chain": "Ethereum",
+        "address": "0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xa39739ef8b0231dbfa0dcda07d7e29faabcf4bb2",
+        "shows": "TroveManager is labeled Liquity: Trove Manager and Source Code Verified Exact Match with Solidity 0.6.11 optimization 100 runs.",
+        "chain": "Ethereum",
+        "address": "0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x66017d22b0f8556afdd19fc67041899eb65a21bb",
+        "shows": "StabilityPool is labeled Liquity: Stability Pool and Source Code Verified Exact Match with Solidity 0.6.11 optimization 100 runs.",
+        "chain": "Ethereum",
+        "address": "0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+        "shows": "ActivePool is labeled Liquity: Active Pool and Contract Source Code Verified Exact Match with Solidity 0.6.11 optimization 100 runs.",
+        "chain": "Ethereum",
+        "address": "0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x896a3f03176f05cfbb4f006bfcd8723f2b0d741c",
+        "shows": "DefaultPool is labeled Liquity: Default Pool, has deployment activity on April 5, 2021, and Contract Source Code Verified Exact Match.",
+        "chain": "Ethereum",
+        "address": "0x896a3F03176f05CFbb4f006BfCd8723F2B0D741C",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x3d32e8b97ed5881324241cf03b2da5e2ebce5521",
+        "shows": "CollSurplusPool is labeled Liquity: Coll Surplus Pool and Contract Source Code Verified Exact Match with Solidity 0.6.11 optimization 100 runs.",
+        "chain": "Ethereum",
+        "address": "0x3D32e8b97Ed5881324241Cf03b2DA5E2EBcE5521",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x8fdd3fbfeb32b28fb73555518f8b361bcea741a6",
+        "shows": "SortedTroves is labeled Liquity: Sorted Troves and Contract Source Code Verified Exact Match with Solidity 0.6.11 optimization 100 runs.",
+        "chain": "Ethereum",
+        "address": "0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x4c517d4e2c851ca76d7ec94b805269df0f2201de",
+        "shows": "PriceFeed is labeled Liquity: Price Feed and Source Code Verified Exact Match with Solidity 0.6.11 optimization 100 runs.",
+        "chain": "Ethereum",
+        "address": "0x4c517D4e2C851CA76d7eC94B805269Df0f2201De",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xE84251b93D9524E0d2e621Ba7dc7cb3579F997C0",
+        "shows": "HintHelpers is labeled Liquity: Hint Helpers and Source Code Verified Exact Match with Solidity 0.6.11 optimization 100 runs.",
+        "chain": "Ethereum",
+        "address": "0xE84251b93D9524E0d2e621Ba7dc7cb3579F997C0",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+        "shows": "LUSDToken is labeled Liquity LUSD: LUSD Token, Source Code Verified Exact Match, and includes a submitted Coinspect March 2021 audit link.",
+        "chain": "Ethereum",
+        "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+        "shows": "LQTYToken is labeled Liquity: LQTY Token, Source Code Verified Exact Match, and includes a submitted Coinspect March 2021 audit link.",
+        "chain": "Ethereum",
+        "address": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x4f9fbb3f1e99b56e0fe2892e623ed36a76fc605d",
+        "shows": "LQTYStaking is labeled Liquity: LQTY Staking and Source Code Verified Exact Match with Solidity 0.6.11 optimization 100 runs.",
+        "chain": "Ethereum",
+        "address": "0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xd8c9d9071123a059c6e0a945cf0e0c82b508d816",
+        "shows": "CommunityIssuance is labeled Liquity: Community Issuance and Source Code Verified Exact Match with Solidity 0.6.11 optimization 100 runs.",
+        "chain": "Ethereum",
+        "address": "0xD8c9D9071123a059C6E0A945cF0e0c82b508d816",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xd37a77e71ddf3373a79be2ebb76b6c4808bdf0d5",
+        "shows": "Unipool is labeled Liquity: Uni Pool and Contract Source Code Verified Exact Match with Solidity 0.6.11 optimization 100 runs.",
+        "chain": "Ethereum",
+        "address": "0xd37a77E71ddF3373a79BE2eBB76B6c4808bDF0d5",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://www.coinspect.com/doc/Liquity%20-%20Smart%20Contract%20Audit%202021.pdf",
+        "shows": "Coinspect March 2021 report: review of liquity/dev through dd7f59b980e7dab1cebc84c017db3a2c4caa522c; scope lists core contracts, PriceFeed, LUSDToken, LQTYToken, lockup, staking, CommunityIssuance, MultiTroveGetter, Unipool, and dependencies.",
+        "commit": "dd7f59b980e7dab1cebc84c017db3a2c4caa522c",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://github.com/trailofbits/publications/blob/master/reviews/Liquity.pdf",
+        "shows": "Trail of Bits Liquity Security Assessment PDF is linked from the Liquity V1 audit resources page.",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://github.com/trailofbits/publications/blob/master/reviews/LiquityProtocolandStabilityPoolFinalReport.pdf",
+        "shows": "Trail of Bits Liquity Protocol and Stability Pool Final Report PDF is linked from the Liquity V1 audit resources page.",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://github.com/trailofbits/publications/blob/master/reviews/LiquityProxyContracts.pdf",
+        "shows": "Trail of Bits Liquity Proxy Contracts report PDF is linked from the Liquity V1 audit resources page.",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/commit/8cec3fd",
+        "shows": "liquity/dev commit 8cec3fd is a public source commit referenced by the audit matrix; GitHub page shows files changed in core contracts/dependencies.",
+        "commit": "8cec3fd",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/commit/dce38b7",
+        "shows": "liquity/dev commit dce38b7 is a public source commit referenced by the audit matrix; GitHub page shows PriceFeed logic additions.",
+        "commit": "dce38b7",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/commit/dd7f59b9",
+        "shows": "liquity/dev commit dd7f59b9 is the public source commit referenced by Coinspect and the audit matrix.",
+        "commit": "dd7f59b9",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/commit/b90440d",
+        "shows": "liquity/dev commit b90440d is the public source commit referenced for proxy/bundled-actions audit scope; page shows added DSProxy scripts and related interfaces.",
+        "commit": "b90440d",
+        "fetched_at": "2026-05-01T07:06:21Z"
+      }
+    ],
+    "unknowns": [
+      "V1: Explorer fetches for gasPool 0x9555b042F969E561855e5F28cB1230819149A8d9, lockupContractFactory 0x2eBeF24dA09489218Ba2BECb01867F6DaAeDcD4B, and multiTroveGetter 0xFc92d0E9Fa35df17E3A6d9F40716ca2cE749922B did not succeed in this run, so their verification indicators are not recorded.",
+      "V2: I did not pin one exact deployed-source commit for the current deployment and did not run an independent compile or bytecode match.",
+      "V5: I did not perform a bytecode diff from deployed source to audited commits 8cec3fd, dce38b7, dd7f59b9, or b90440d; post-audit drift assessment is therefore not reproducibly proven.",
+      "V6: I did not query proxy-specific storage slots or Etherscan proxy APIs; proxy assessment is based on fetched explorer pages showing direct verified contract names and no implementation field."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/liquity/dev"
+      ],
+      "docs_url": "https://docs.liquity.org/liquity-v1/documentation/resources",
+      "audits": [
+        {
+          "firm": "Trail of Bits",
+          "url": "https://github.com/trailofbits/publications/blob/master/reviews/Liquity.pdf",
+          "date": "2021-01"
+        },
+        {
+          "firm": "Coinspect",
+          "url": "https://www.coinspect.com/doc/Liquity%20-%20Smart%20Contract%20Audit%202021.pdf",
+          "date": "2021-03"
+        },
+        {
+          "firm": "Trail of Bits",
+          "url": "https://github.com/trailofbits/publications/blob/master/reviews/LiquityProtocolandStabilityPoolFinalReport.pdf",
+          "date": "2021-03"
+        },
+        {
+          "firm": "Trail of Bits",
+          "url": "https://github.com/trailofbits/publications/blob/master/reviews/LiquityProxyContracts.pdf",
+          "date": "2021-03"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": null,
+      "bug_bounty_url": null,
+      "security_contact": null,
+      "deployed_contracts_doc": "https://docs.liquity.org/liquity-v1/documentation/resources",
+      "admin_addresses": [],
+      "upgradeability": "immutable",
+      "about": "Liquity V1 lets users lock ETH in individual Troves and borrow LUSD, a USD-pegged stablecoin. LUSD can be redeemed for ETH through the protocol, while undercollateralized Troves are liquidated through a Stability Pool funded by LUSD depositors. Fees are algorithmic, and LQTY staking receives issuance and redemption fee revenue rather than controlling governance."
+    }
+  }
+]


### PR DESCRIPTION
## Submission

5-slice DEFI@home assessment for **Liquity V1** under deployment slug `liquity-v1`.

| Slice | Voices |
|-------|--------|
| control | gpt-5.5:green / gemini-3-flash-preview:green |
| ability-to-exit | gpt-5.5:green / gemini-3-flash-preview:green |
| autonomy | gpt-5.5:red |
| open-access | gpt-5.5:green |
| verifiability | gpt-5.5:green |

## cp0x pi-liquity-interface (A3b-ii evidence)

The open-access slice cites **cp0x pi-liquity-interface** as A3b-ii independent permissionless frontend evidence:
- Live at https://liquity.cp0x.com
- Source: https://github.com/cp0x-org/pi-liquity-interface (open-source, self-hostable via Dockerfile)
- Operated by cp0x as a separate legal entity from Liquity V1 maintainers, not bound by official frontend ToS

Same evidence pattern was successfully merged for Aave V3 (cp0x pi-aave-interface, PR #78), Sky (cp0x pi-sky-interface, PR #100), and Ethena (cp0x pi-ethena-interface, PR #101).

## Schema

- schema_version: 3
- snapshot_generated_at: 2026-04-27T08:19:52.420Z
- prompt_version: 12
- analysis_date: 2026-05-01
- 3 voices from 3 distinct provider families (Anthropic, OpenAI, Google)
