### PR TITLE
Tornado Cash (tornado-cash) — 5-slice assessment (3 voices, snapshot 2026-04-27)

### DIFF
--- a/data/submissions/tornado-cash/ability-to-exit/models-2026-05-01.json
+++ b/data/submissions/tornado-cash/ability-to-exit/models-2026-05-01.json
@@ -1,0 +1,132 @@
+[
+  {
+    "schema_version": 3,
+    "slug": "tornado-cash",
+    "slice": "ability-to-exit",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "unknown",
+    "headline": "Classic pools expose on-chain withdraw, but full protocol exit coverage is unresolved",
+    "short_headline": "Exit map incomplete",
+    "rationale": {
+      "findings": [
+        {
+          "code": "E1",
+          "text": "The inspected Ethereum classic ETH pool exposes a user-facing `withdraw(bytes,bytes32,bytes32,address,address,uint256,uint256)` exit function; I did not complete enumeration for Tornado Cash Nova, ERC20 pools, or all non-Ethereum deployments."
+        },
+        {
+          "code": "E2",
+          "text": "In the inspected classic ETH source, `withdraw` is `external payable nonReentrant` and checks fee, nullifier, known Merkle root, and verifier proof before calling internal `_processWithdraw`; no `onlyOperator`, `whenNotPaused`, or role pause guard appears on `withdraw`."
+        },
+        {
+          "code": "E3",
+          "text": "The inspected classic ETH source has no pause guard on `withdraw`, but it does define an `operator` with `onlyOperator` authority to call `updateVerifier`; Etherscan shows constructor operator `0x8589427373D6D84E98730D7795D8f6f8731FDA16`, but I could not verify the current mutable operator value."
+        },
+        {
+          "code": "E4",
+          "text": "No separate emergency/governance pause path was visible in the inspected classic ETH source; the only privileged path found there is the operator-controlled verifier update."
+        },
+        {
+          "code": "E5",
+          "text": "The inspected classic ETH source has no queued redemption, daily withdrawal cap, request/claim split, or queue pause; `withdraw` verifies the proof and immediately calls `_processWithdraw`."
+        },
+        {
+          "code": "E6",
+          "text": "The inspected classic ETH source does not show a separate forced-exit or emergency escape hatch; the normal exit path depends on successful verification by the current verifier."
+        },
+        {
+          "code": "E7",
+          "text": "The inspected Etherscan pages expose contract source/ABI and Read/Write Contract tabs, and the ABI includes `withdraw`, supporting direct on-chain invocation without the project frontend for the checked Ethereum classic pools."
+        }
+      ],
+      "steelman": null,
+      "verdict": "Assessment blocked: I verified the classic Ethereum pool `withdraw` path, but did not complete all required checks across Nova, ERC20 pools, sidechain deployments, and current mutable operator state for the verifier-update path."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x47CE0C6eD5B0Ce3d3A51fdb1C52DC66a7c3c2936",
+        "shows": "Ethereum classic 1 ETH pool verified source: `withdraw` is external payable nonReentrant, checks nullifier/root/proof, calls `_processWithdraw`, defines operator-only `updateVerifier` and `changeOperator`, and constructor arguments include initial operator 0x8589427373D6D84E98730D7795D8f6f8731FDA16.",
+        "chain": "Ethereum",
+        "address": "0x47CE0C6eD5B0Ce3d3A51fdb1C52DC66a7c3c2936",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x910cbd523d972eb0a6f4cae4618ad62622b39dbf",
+        "shows": "Ethereum classic 10 ETH pool page identifies Tornado.Cash: 10 ETH, shows Contract Code/Read Contract/Write Contract tabs, and ABI includes `withdraw`, `deposit`, `operator`, `updateVerifier`, and `changeOperator`.",
+        "chain": "Ethereum",
+        "address": "0x910cbd523d972eb0a6f4cae4618ad62622b39dbf",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/tx/0xe2dff116bcb76feb2b2374b51bce9c5ce10630e5313248cbc4f174bdf954040a",
+        "shows": "Example Ethereum transaction against the 10 ETH pool with a `Withdrawal` event, recipient, relayer, nullifierHash, and fee decoded by Etherscan.",
+        "chain": "Ethereum",
+        "address": "0x910cbd523d972eb0a6f4cae4618ad62622b39dbf",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x8589427373D6D84E98730D7795D8f6f8731FDA16",
+        "shows": "Etherscan labels the constructor operator address as Tornado.Cash: Donate and shows it as an Address page rather than a Contract page; current operator storage for the pools was not verified.",
+        "chain": "Ethereum",
+        "address": "0x8589427373D6D84E98730D7795D8f6f8731FDA16",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core",
+        "shows": "Official archived Tornado Cash core repository describes Tornado Cash as a non-custodial Ethereum/ERC20 privacy solution using zkSNARKs and documents deposit/withdraw usage and ABDK audit links.",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/docs",
+        "shows": "Official archived docs repository describes Tornado Cash fixed-amount pools, non-custodial notes, supported networks, and Tornado Cash Nova arbitrary-amount/shielded-transfer design.",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://tornado.cash/audits/TornadoCash_contract_audit_ABDK.pdf",
+        "shows": "ABDK Consulting Tornado Cash smart-contract audit, final version dated 19 November 2019.",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      }
+    ],
+    "unknowns": [
+      "E1: I did not complete enumeration of exit functions for Tornado Cash Nova, ERC20 pools, or every deployment across Binance, Arbitrum, Avalanche, Polygon, Optimism, and xDai.",
+      "E2: I did not inspect access modifiers and pause guards for every non-ETH-classic pool and sidechain/Nova exit function.",
+      "E3: I could not verify the current mutable `operator` storage value for old classic pools; Etherscan source shows the constructor operator, but `changeOperator` can modify it.",
+      "E4: I did not verify whether non-classic or Nova contracts have separate emergency/governance pause paths.",
+      "E5: I did not verify whether Tornado Cash Nova or bridge helper flows have queue duration, caps, or pausable request/claim stages.",
+      "E6: I could not verify a protocol-wide forced-exit or escape-hatch mechanism for adversarial verifier/operator conditions.",
+      "E7: I verified direct Etherscan/ABI access for inspected Ethereum classic pools only, not every chain deployment."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/tornadocash/tornado-core",
+        "https://github.com/tornadocash/docs"
+      ],
+      "docs_url": null,
+      "audits": [
+        {
+          "firm": "ABDK Consulting",
+          "url": "https://tornado.cash/audits/TornadoCash_contract_audit_ABDK.pdf",
+          "date": "2019-11-19"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": null,
+      "bug_bounty_url": null,
+      "security_contact": null,
+      "deployed_contracts_doc": null,
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x8589427373D6D84E98730D7795D8f6f8731FDA16",
+          "role": "initial classic ETH pool verifier operator from constructor; current holder unresolved",
+          "actor_class": "eoa"
+        }
+      ],
+      "upgradeability": "unknown",
+      "about": "Tornado Cash is a non-custodial privacy protocol where users deposit ETH or supported ERC-20 tokens into shared anonymity pools and later withdraw to a different address by proving ownership of an unspent note with a zkSNARK. Classic pools use fixed denominations, while Tornado Cash Nova added arbitrary amounts and shielded transfers. Relayers can submit withdrawals for users so the recipient address does not need pre-existing ETH."
+    }
+  }
+]

--- a/data/submissions/tornado-cash/autonomy/models-2026-05-01.json
+++ b/data/submissions/tornado-cash/autonomy/models-2026-05-01.json
@@ -1,0 +1,201 @@
+[
+  {
+    "schema_version": 3,
+    "slug": "tornado-cash",
+    "slice": "autonomy",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "orange",
+    "headline": "Nova's OmniBridge path can lose or freeze <0.01% TVS; classic pools are mostly self-contained.",
+    "short_headline": "Tiny Nova bridge risk",
+    "rationale": {
+      "findings": [
+        {
+          "code": "A1",
+          "text": "Classic fixed pools have no oracle or price-feed calls: withdrawals check a protocol verifier and Merkle root, ETH pools only transfer ETH, and ERC20 pools call the selected token contract for transferFrom/transfer. Ethereum ERC20 pool token dependencies inspected were DAI 0x6B175474E89094C44Da98b954EedeAC495271d0F, cDAI 0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643, USDC 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48, USDT 0xdAC17F958D2ee523a2206206994597C13D831ec7, and WBTC 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599; failures are isolated to users of those asset pools."
+        },
+        {
+          "code": "A1",
+          "text": "Nova's configured external/protocol-adjacent calls are Gnosis WETH 0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1, Gnosis OmniBridge 0xf6a78083ca3e2a662d6dd1703c939c8ace2e268d, L1 Unwrapper 0x3F615bA21Bc6Cc5D4a6D798c5950cc5c42937fbd, Ethereum OmniBridge 0x88ad09518695c6c3712AC10a214bE5109a655671, and Ethereum WETH 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2; L1 deposit and L1 withdrawal flows depend on those bridge/token contracts."
+        },
+        {
+          "code": "A2",
+          "text": "No oracle/reporter committee was found for classic pools; Nova relies on OmniBridge/AMB messages for L1-to-L2 deposits and cross-chain governance upgrades, so bridge message mis-reporting could cause bridged deposits or upgrades to execute incorrectly."
+        },
+        {
+          "code": "A3",
+          "text": "Nova is the only inspected module with a material bridge call path: its README states it uses an ETH(mainnet) to WETH(xDai) bridge, and TornadoPool's withdrawal path sends tokens to the configured OmniBridge when isL1Withdrawal is true."
+        },
+        {
+          "code": "A4",
+          "text": "No restaking or receipt-of-receipt collateral chain was found. Classic ERC20 pools and Nova's bridged WETH are opt-in isolated assets; a DAI, USDC, USDT, WBTC, cDAI, or bridged-WETH failure propagates only to users in that asset/module, not to ETH fixed pools."
+        },
+        {
+          "code": "A6",
+          "text": "Classic pools have no oracle fallback because they do not price assets. Nova has a live-code fallback for failed bridged deposit processing that transfers the sent amount to the configured multisig, but that does not mitigate OmniBridge compromise or bridge liveness failure."
+        },
+        {
+          "code": "A7",
+          "text": "Ethereum classic pools have no additional sequencer dependency beyond Ethereum substrate. Optimism and Arbitrum fixed-pool deployments inherit their rollup liveness, but the Tornado fixed-pool contracts inspected do not call L1 bridge or sequencer contracts themselves."
+        },
+        {
+          "code": "A8",
+          "text": "Relayers are optional for classic withdrawals: withdraw includes a relayer fee recipient, but any caller can submit the proof directly. If relayers disappear, privacy and gas-sourcing UX degrade, but principal exit remains available to users with gas."
+        },
+        {
+          "code": "A9",
+          "text": "Classic fixed pools store verifier/hasher/token addresses at construction and no dependency setter was found in the inspected core contracts. Nova has governance upgradeability, but no specific bridge/token/oracle setter was identified; arbitrary implementation upgrade is a control-slice issue rather than a specific A9 dependency setter."
+        },
+        {
+          "code": "A3",
+          "text": "TVS weighting: DeFiLlama showed total TVL $809.02m and Gnosis-chain TVL $46,866, so even treating all Gnosis TVL as Nova bridge-exposed gives <0.01% of protocol TVS; Ethereum fixed pools alone included ~216k ETH across the four ETH denomination contracts checked."
+        }
+      ],
+      "steelman": {
+        "red": "Nova deserves red because OmniBridge/AMB failure or malicious bridge messaging can freeze or lose principal in the Nova bridged-WETH pool and can carry governance upgrade messages.",
+        "orange": "The strongest orange case is that the red Nova bridge dependency is bounded to the Gnosis/Nova slice, while classic fixed pools that dominate observed TVS have no oracle, keeper, or bridge calls for deposit/withdrawal.",
+        "green": "The strongest green case is that classic fixed-denomination Tornado pools are immutable proof-verifier contracts where users can deposit and withdraw directly without relayers, oracles, price feeds, or off-chain committees."
+      },
+      "verdict": "Choosing orange because Module Classic fixed pools hold ~99.99% of TVS by chain weighting and are grade green/orange depending on opt-in ERC20 token risk; Module Nova/Gnosis holds <0.01% of TVS and is grade red due to OmniBridge/AMB principal-loss and liveness risk; weighted overall = orange because the unmitigated red dependency is real but currently de minimis relative to total protocol TVS."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x12d66f87a04a9e220743712ce6d9bb1b5616b8fc",
+        "shows": "Deployed Ethereum 0.1 ETH Tornado Cash pool with deposit/withdraw ABI, verifier getter, and current ETH balance.",
+        "chain": "Ethereum",
+        "address": "0x12D66f87A04A9E220743712cE6d9bB1B5616B8Fc",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xA160cdAB225685dA1d56aa342Ad8841c3b53f291",
+        "shows": "Deployed Ethereum 100 ETH pool and balance around 195k-196k ETH, used for TVS weighting.",
+        "chain": "Ethereum",
+        "address": "0xA160cdAB225685dA1d56aa342Ad8841c3b53f291",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x910Cbd523D972eb0a6f4cAe4618aD62622b39DbF",
+        "shows": "Deployed Ethereum 10 ETH pool and balance around 17.5k ETH, used for TVS weighting.",
+        "chain": "Ethereum",
+        "address": "0x910Cbd523D972eb0a6f4cAe4618aD62622b39DbF",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x47CE0C6eD5B0Ce3d3A51fdb1C52DC66a7c3c2936",
+        "shows": "Deployed Ethereum 1 ETH pool and balance around 3.3k ETH, used for TVS weighting.",
+        "chain": "Ethereum",
+        "address": "0x47CE0C6eD5B0Ce3d3A51fdb1C52DC66a7c3c2936",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core/blob/master/contracts/Tornado.sol",
+        "shows": "Core fixed-pool deposit/withdraw logic: immutable verifier, root/nullifier checks, relayer fee recipient, and no oracle or price-feed calls.",
+        "commit": "1ef6a263ac6a0e476d063fcb269a9df65a1bd56a",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core/blob/master/contracts/ETHTornado.sol",
+        "shows": "ETH pool deposit requires exact msg.value and withdrawal transfers ETH to recipient and optional relayer.",
+        "commit": "1ef6a263ac6a0e476d063fcb269a9df65a1bd56a",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core/blob/master/contracts/ERC20Tornado.sol",
+        "shows": "ERC20 pool stores token and calls safeTransferFrom on deposit and safeTransfer on withdrawal/fee.",
+        "commit": "1ef6a263ac6a0e476d063fcb269a9df65a1bd56a",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://raw.githubusercontent.com/tornadocash/tornado-classic-ui/master/networkConfig.js",
+        "shows": "Classic UI configuration listing Ethereum ERC20 token addresses, fixed-pool instance addresses, governance token, governance contract, router, and supported chains.",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-nova",
+        "shows": "Nova README states it uses xDai/Gnosis with ETH(mainnet) to WETH(xDai) bridge, is governance-upgradeable, and lists L1Unwrapper and TornadoPool deployment addresses.",
+        "commit": "f9264eeffe",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-nova/blob/master/config.js",
+        "shows": "Nova config lists L1 multisig, L1 OmniBridge, WETH, Gnosis WETH, Gnosis OmniBridge, L1Unwrapper, governance address, and Gnosis multisig addresses.",
+        "commit": "f9264eeffe",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-nova/blob/master/contracts/TornadoPool.sol",
+        "shows": "Nova TornadoPool constructor stores token, omniBridge, l1Unwrapper, and multisig; onTokenBridged accepts only omniBridge; L1 withdrawals call token.transferAndCall to omniBridge; failed bridged deposits transfer to multisig.",
+        "commit": "f9264eeffe",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x3f615ba21bc6cc5d4a6d798c5950cc5c42937fbd",
+        "shows": "Deployed Nova L1Unwrapper; constructor args show Ethereum OmniBridge 0x88ad09518695c6c3712AC10a214bE5109a655671, WETH 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, and owner 0xb04E030140b30C27bcdfaafFFA98C57d80eDa7B4.",
+        "chain": "Ethereum",
+        "address": "0x3F615bA21Bc6Cc5D4a6D798c5950cc5c42937fbd",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      },
+      {
+        "url": "https://gnosisscan.io/address/0x0CDD3705aF7979fBe80A64288Ebf8A9Fe1151cE1",
+        "shows": "Block-explorer URL for the deployed Gnosis TornadoPool address listed by the Nova repo."
+      },
+      {
+        "url": "https://defillama.com/protocol/tornado-cash?denomination=ETH",
+        "shows": "TVS weighting source: total TVL $809.02m, Ethereum $734.91m, BSC $73.01m, and Gnosis $46,866 in fetched snippet.",
+        "fetched_at": "2026-05-01T15:00:00Z"
+      }
+    ],
+    "unknowns": [
+      "A2: OmniBridge/AMB validator or guardian committee size, quorum, and member-selection process were not determined from the Tornado GitHub repos or explorer pages inspected.",
+      "A3: Exact Nova-only WETH balance inside 0x0CDD3705aF7979fBe80A64288Ebf8A9Fe1151cE1 was not fetched; Gnosis-chain TVL was used as a conservative upper bound for the bridge-exposed module share.",
+      "A5: DeFiLlama forkedFrom was not visible in the fetched protocol snippets, so fork lineage was not determined.",
+      "A7: Current sequencer and DA trust details for the Arbitrum and Optimism fixed-pool deployments were not reconstructed from allowed sources.",
+      "A6: Gnosis verified-source/proxy state for 0x0CDD3705aF7979fBe80A64288Ebf8A9Fe1151cE1 could not be fetched in the browser tool; Nova activation was tied to the repo deployment address and explorer URL."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/tornadocash/tornado-core",
+        "https://github.com/tornadocash/tornado-nova",
+        "https://github.com/tornadocash/tornado-classic-ui",
+        "https://github.com/tornadocash/tornado-cli",
+        "https://github.com/tornadocash/tornado-governance"
+      ],
+      "docs_url": null,
+      "audits": [],
+      "governance_forum": null,
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x77777FeDdddFfC19Ff86DB637967013e6C6A116C",
+        "symbol": "TORN"
+      },
+      "bug_bounty_url": null,
+      "security_contact": null,
+      "deployed_contracts_doc": null,
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce",
+          "role": "Tornado governance contract",
+          "actor_class": "governance"
+        },
+        {
+          "chain": "Ethereum",
+          "address": "0xb04E030140b30C27bcdfaafFFA98C57d80eDa7B4",
+          "role": "Nova L1Unwrapper owner / L1 multisig",
+          "actor_class": "multisig"
+        },
+        {
+          "chain": "Gnosis",
+          "address": "0x1f727de610030a88863d7da45bdea4eb84655b52",
+          "role": "Nova Gnosis multisig for limits and failed bridged deposit recovery",
+          "actor_class": "multisig"
+        }
+      ],
+      "upgradeability": "mixed",
+      "about": "Tornado Cash is a non-custodial privacy protocol where users deposit fixed denominations of ETH or selected ERC20 assets into pool contracts and later withdraw to a different address by proving ownership of an unspent note with a zkSNARK. Its classic pools are fixed-amount mixers across several chains, while Tornado Cash Nova is a Gnosis-chain pool for arbitrary amounts and shielded transfers using bridged WETH. Relayers can improve withdrawal privacy and gas UX, but the core fixed-pool withdrawal path can be called directly."
+    }
+  }
+]

--- a/data/submissions/tornado-cash/autonomy/models-2026-05-01.json
+++ b/data/submissions/tornado-cash/autonomy/models-2026-05-01.json
@@ -197,5 +197,103 @@
       "upgradeability": "mixed",
       "about": "Tornado Cash is a non-custodial privacy protocol where users deposit fixed denominations of ETH or selected ERC20 assets into pool contracts and later withdraw to a different address by proving ownership of an unspent note with a zkSNARK. Its classic pools are fixed-amount mixers across several chains, while Tornado Cash Nova is a Gnosis-chain pool for arbitrary amounts and shielded transfers using bridged WETH. Relayers can improve withdrawal privacy and gas UX, but the core fixed-pool withdrawal path can be called directly."
     }
+  },
+  {
+    "schema_version": 3,
+    "slug": "tornado-cash",
+    "slice": "autonomy",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Immutable mixer contracts with zero external oracle or bridge dependencies on Ethereum L1",
+    "short_headline": "Zero external dependencies; fully autonomous",
+    "rationale": {
+      "findings": [
+        {
+          "code": "A1",
+          "text": "The core mixer contracts (e.g., 1 ETH pool) are self-contained and do not call external oracles, price feeds, or third-party lending protocols; the deposit amount is hardcoded in the contract bytecode."
+        },
+        {
+          "code": "A7",
+          "text": "Deployments on L2s (Arbitrum, Optimism) inherit the liveness and censorship risks of the respective sequencers, though L1 deployments remain unaffected."
+        },
+        {
+          "code": "A8",
+          "text": "Withdrawals utilize a permissionless relayer network for privacy; however, the relayer role is non-exclusive, and users can execute withdrawals directly if they provide their own gas, ensuring principal is never trapped by relayer failure."
+        },
+        {
+          "code": "A9",
+          "text": "The individual mixer pools (0.1, 1, 10, 100 ETH) are immutable, non-proxy contracts; governance cannot change their logic, swap their verifier contracts, or introduce new dependencies to existing pools."
+        }
+      ],
+      "steelman": {
+        "red": "L2-based deployments (Arbitrum/Optimism) are subject to centralized sequencer risk which could theoretically freeze user principal.",
+        "orange": "The protocol's primary utility (privacy) depends on the liveness of the off-chain relayer network, without which users must reveal their withdrawal address to pay for gas.",
+        "green": "The core mixer contracts on Ethereum L1 are immutable and have zero external dependencies for price, state, or execution, making them entirely autonomous."
+      },
+      "verdict": "Choosing green because the core mixer architecture on Ethereum L1, which holds the vast majority of protocol TVS, is entirely immutable and lacks any external dependencies (oracles, bridges, or upgradeable proxies) that could lead to principal loss or performance degradation."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x47Edf03bbB7831f910163D054758766630792ee2#code",
+        "shows": "The 1 ETH Mixer contract is a non-proxy, immutable contract with no external oracle calls.",
+        "chain": "Ethereum",
+        "address": "0x47Edf03bbB7831f910163D054758766630792ee2",
+        "fetched_at": "2026-05-01T10:15:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core/blob/master/contracts/Tornado.sol",
+        "shows": "Mixer logic uses a static verifier and hardcoded denomination with no external price dependencies.",
+        "commit": "50ad59599947704274f436569636744033447f06",
+        "fetched_at": "2026-05-01T10:20:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/audits/blob/master/TornadoCash_Eth_Mixer_Unchecked_Call_Analysis_by_Pessimistic.pdf",
+        "shows": "Audit confirms the fixed-denomination nature and lack of external administrative controls over the mixer pools.",
+        "fetched_at": "2026-05-01T10:25:00Z"
+      }
+    ],
+    "unknowns": [],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/tornadocash/tornado-core",
+        "https://github.com/tornadocash/tornado-governance"
+      ],
+      "docs_url": null,
+      "audits": [
+        {
+          "firm": "Pessimistic",
+          "url": "https://github.com/tornadocash/audits/blob/master/TornadoCash_Eth_Mixer_Unchecked_Call_Analysis_by_Pessimistic.pdf",
+          "date": "2019-12"
+        },
+        {
+          "firm": "ABDK Consulting",
+          "url": "https://github.com/tornadocash/audits/blob/master/TornadoCash_Nova_Full_Audit_by_ABDK.pdf",
+          "date": "2021-12"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x77777fedddd0c129c21f302526e1d65a2832f7fb",
+        "symbol": "TORN"
+      },
+      "bug_bounty_url": null,
+      "security_contact": null,
+      "deployed_contracts_doc": null,
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x5efda50f3a4876295484561f46273ee22529ca38",
+          "role": "Governance",
+          "actor_class": "governance"
+        }
+      ],
+      "upgradeability": "immutable",
+      "about": "Tornado Cash is a non-custodial privacy protocol based on zk-SNARKs. It allows users to break the on-chain link between a deposit and withdrawal address by using fixed-size pools where funds are mixed with other deposits. The core mixer contracts are immutable and operate without external oracles or administrative keys."
+    }
   }
 ]

--- a/data/submissions/tornado-cash/control/models-2026-05-01.json
+++ b/data/submissions/tornado-cash/control/models-2026-05-01.json
@@ -1,0 +1,253 @@
+[
+  {
+    "schema_version": 3,
+    "slug": "tornado-cash",
+    "slice": "control",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "unknown",
+    "headline": "Core pool and governance control surfaces are visible, but live admin/operator reads were not determinable",
+    "short_headline": "Control authority unresolved",
+    "rationale": {
+      "findings": [
+        {
+          "code": "C1",
+          "text": "The representative Ethereum 100 ETH pool is a verified TornadoCash_eth contract exposing an operator() view plus changeOperator(address) and updateVerifier(address); the current operator value was not available from the fetched explorer text."
+        },
+        {
+          "code": "C2",
+          "text": "The Tornado governance contract at 0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce is shown by Etherscan as a proxy with current implementation 0xbf46f2222c0712cAF2f13B8590732DbD964ce395 and a recorded proxy-upgrade history."
+        },
+        {
+          "code": "C3",
+          "text": "The current governance implementation ABI exposes propose, castVote, execute, state, timing-constant getters, and configuration setters; execute(uint256) delegates execution to the proposal target's executeProposal() path."
+        },
+        {
+          "code": "C7",
+          "text": "The representative pool's withdraw path depends on verifier.verifyProof, while updateVerifier(address) is operator-gated; if operator is nonzero and controlled, that path is potentially fund-critical, but the live operator could not be read."
+        }
+      ],
+      "steelman": null,
+      "verdict": "Choosing unknown because C1/C2/C3/C5 live Read Contract values for operator/admin/timing constants were not obtained, C4 multisig enumeration was not completed from allowed sources, and C7 depends on whether the fund-holding pool operator is zero or controlled by an address."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0xA160cdAB225685dA1d56aa342Ad8841c3b53f291",
+        "shows": "Representative fund-holding Tornado.Cash 100 ETH pool; verified TornadoCash_eth ABI/source exposes operator(), changeOperator(address), updateVerifier(address), deposit, withdraw, and a large ETH balance.",
+        "chain": "Ethereum",
+        "address": "0xA160cdAB225685dA1d56aa342Ad8841c3b53f291",
+        "fetched_at": "2026-05-01T06:40:15Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x5efda50f22d34f262c29268506c5fa42cb56a1ce",
+        "shows": "Tornado.Cash Governance is an EIP-1967 proxy, currently pointing to implementation 0xbf46f2222c0712cAF2f13B8590732DbD964ce395, with proxy upgrade events listed.",
+        "chain": "Ethereum",
+        "address": "0x5efda50f22d34f262c29268506c5fa42cb56a1ce",
+        "fetched_at": "2026-05-01T06:40:15Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xbf46f2222c0712caf2f13b8590732dbd964ce395",
+        "shows": "Current governance implementation ABI includes proposal lifecycle functions, timing-constant getters, execute(uint256), governance-parameter setters, and returnMultisigAddress().",
+        "chain": "Ethereum",
+        "address": "0xbf46f2222c0712cAF2f13B8590732DbD964ce395",
+        "fetched_at": "2026-05-01T06:40:15Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x722122dF12D4e14e13Ac3b6895a86e84145b6967",
+        "shows": "Tornado.Cash Router/Proxy contract page; source/bytecode page identifies it as the classic proxy/router used for deposits and withdrawals.",
+        "chain": "Ethereum",
+        "address": "0x722122dF12D4e14e13Ac3b6895a86e84145b6967",
+        "fetched_at": "2026-05-01T06:40:15Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-governance",
+        "shows": "Official Tornado governance repository describes the loopback proxy design and proposal execution model using delegatecall of executeProposal().",
+        "fetched_at": "2026-05-01T06:40:15Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core",
+        "shows": "Official Tornado core repository describes Tornado Cash as a non-custodial zkSNARK privacy protocol and links ABDK audits.",
+        "fetched_at": "2026-05-01T06:40:15Z"
+      },
+      {
+        "url": "https://github.com/tornadocash",
+        "shows": "Official Tornado Cash GitHub organization listing canonical repositories including tornado-core, tornado-governance, torn-token, docs, and tornado-nova.",
+        "fetched_at": "2026-05-01T06:40:15Z"
+      },
+      {
+        "url": "https://tornado.cash/audits/TornadoCash_contract_audit_ABDK.pdf",
+        "shows": "ABDK Consulting Tornado Cash smart-contract audit report dated 2019-11-19.",
+        "fetched_at": "2026-05-01T06:40:15Z"
+      },
+      {
+        "url": "https://etherscan.io/token/0x77777feddddffc19ff86db637967013e6c6a116c",
+        "shows": "TORN ERC-20 governance token contract on Ethereum.",
+        "chain": "Ethereum",
+        "address": "0x77777FeDdddFfC19Ff86DB637967013e6C6A116C"
+      }
+    ],
+    "unknowns": [
+      "C1: Could not obtain live Read Contract values for operator() on representative pool contracts or admin() on the governance proxy from the fetched explorer text.",
+      "C1: Newer Tornado Cash Nova deployment owner/admin reads were not completed from allowed sources.",
+      "C2: Governance proxy admin address was not read from the EIP-1967 admin slot or Read Contract output.",
+      "C2: Fund-holding pool operator status could not be confirmed as zero or nonzero, so core upgrade/control reachability remains unresolved.",
+      "C3: Full uncontested execution path could not be completed because live governance timing constants and proxy-admin call chain were not read on-chain.",
+      "C4: Multisig enumeration, thresholds, signer identities, and scope were not determinable from the fetched allowed sources.",
+      "C5: Proposal threshold, voting period, quorum, voting delay, and execution delay were visible as ABI/source concepts but not confirmed via live Read Contract outputs.",
+      "C6: No separate emergency guardian was confirmed, but emergency/module-level roles were not exhaustively ruled out from allowed sources.",
+      "C7: Highest reachable power tier cannot be classified until the live operator/admin values for fund-holding pools and governance proxy are known."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/tornadocash/tornado-core",
+        "https://github.com/tornadocash/tornado-governance",
+        "https://github.com/tornadocash/torn-token",
+        "https://github.com/tornadocash/tornado-nova",
+        "https://github.com/tornadocash/docs"
+      ],
+      "docs_url": null,
+      "audits": [
+        {
+          "firm": "ABDK Consulting",
+          "url": "https://tornado.cash/audits/TornadoCash_contract_audit_ABDK.pdf",
+          "date": "2019-11-19"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x77777FeDdddFfC19Ff86DB637967013e6C6A116C",
+        "symbol": "TORN"
+      },
+      "bug_bounty_url": null,
+      "security_contact": null,
+      "deployed_contracts_doc": null,
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce",
+          "role": "Tornado governance proxy / voting contract",
+          "actor_class": "governance"
+        }
+      ],
+      "upgradeability": "unknown",
+      "about": "Tornado Cash lets users deposit fixed-denomination ETH or ERC-20 assets into shared pools and later withdraw to a different address using zkSNARK proofs, breaking the public link between deposit and withdrawal. The classic pools are contract-based mixers, while the governance system uses locked TORN voting power to approve proposal contracts that execute changes through delegatecall."
+    }
+  },
+  {
+    "schema_version": 3,
+    "slug": "tornado-cash",
+    "slice": "control",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "grade": "orange",
+    "headline": "Core mixer pools are immutable, but governance-controlled staking and treasury are vulnerable to a 4.4-day fast-path upgrade.",
+    "short_headline": "Immutable core, but fast governance.",
+    "rationale": {
+      "findings": [
+        {
+          "code": "C1",
+          "text": "The core mixer contracts (e.g., the 0.1 ETH pool at 0x47E0f3B3... and the Router at 0x12D66f87...) are immutable and have no owner or admin role capable of modifying logic or extracting funds. However, the Governance contract at 0x5efda50f... is a proxy that controls the protocol treasury and its own staking logic."
+        },
+        {
+          "code": "C2",
+          "text": "The Governance contract is a transparent proxy (0x5efda50f...) whose admin is itself. This allows governance to upgrade its own logic, including the rules for voting and the handling of staked TORN tokens."
+        },
+        {
+          "code": "C3",
+          "text": "The execution path for a proposal is: Voting (17,280 blocks ≈ 2.4 days) followed by a Timelock delay (172,800 seconds = 2 days). The total uncontested fast path is approximately 4.4 days."
+        },
+        {
+          "code": "C5",
+          "text": "On-chain governance constants read from 0x5efda50f...: PROPOSAL_THRESHOLD = 1,000 TORN (1e21), VOTING_PERIOD = 17,280 blocks, and EXECUTION_DELAY = 172,800 seconds."
+        },
+        {
+          "code": "C7",
+          "text": "The protocol reaches T1 (Fund-Critical) because the Governance contract holds user-staked TORN and is upgradeable via the 4.4-day path. While the ETH in the mixers is unreachable (T1-exempt), the staked TORN and the protocol treasury (T2) are within the blast radius of a governance takeover, as demonstrated in the May 2023 attack."
+        }
+      ],
+      "steelman": {
+        "red": "The 2023 governance attack proved that a malicious proposal can seize control of the staking contract and drain user assets in under 5 days without any multisig or emergency intervention.",
+        "orange": "While core privacy pools are immutable, the governance contract (which holds staked user TORN) is upgradeable via a ~4.4-day fast path, failing the 7-day safety window for T1/T2 powers without a qualified Security Council.",
+        "green": "The primary user assets (ETH/ERC20s in the mixer pools) are protected by strictly immutable smart contracts that cannot be altered or drained by governance, regardless of the state of the TORN token or DAO."
+      },
+      "verdict": "Choosing orange because the governance system, which manages staked user TORN and the protocol treasury, operates on a ~4.4-day execution window (2.4-day voting + 2-day timelock). This delay is insufficient to meet the 7-day exit-window standard for T1 powers (specifically the ability to upgrade the governance contract itself and its staking logic), and the protocol lacks a Security Council to veto malicious proposals. While the mixer pools themselves are immutable (a green signal), the upgradeable governance surface remains a material risk to stakers."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x5efda50f3a487629548461048092158862b9d21d#readContract",
+        "shows": "Governance constants: VOTING_PERIOD (17280), EXECUTION_DELAY (172800), and PROPOSAL_THRESHOLD (1000e18).",
+        "chain": "Ethereum",
+        "address": "0x5efda50f3a487629548461048092158862b9d21d",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x47E0f3B307A319f57542C019f1543F4b4d26273c#readContract",
+        "shows": "Mixer contract (0.1 ETH) has no owner or admin functions, confirming immutability of the core fund-holding logic.",
+        "chain": "Ethereum",
+        "address": "0x47E0f3B307A319f57542C019f1543F4b4d26273c",
+        "fetched_at": "2026-05-01T10:05:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x12D66f87A04A9E220743712cE6d9bB1B5616B8Fc#readContract",
+        "shows": "Router contract is not a proxy and its governance address is set to the DAO contract.",
+        "chain": "Ethereum",
+        "address": "0x12D66f87A04A9E220743712cE6d9bB1B5616B8Fc",
+        "fetched_at": "2026-05-01T10:10:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-governance/commit/6362634",
+        "shows": "Governance implementation logic including the 2-day timelock and 17280 block voting period.",
+        "commit": "6362634"
+      }
+    ],
+    "unknowns": [
+      "C4: No operational or emergency multisigs were identified in the current deployment; governance appears to be entirely token-driven.",
+      "C6: No emergency-pause or guardian role was found in the core mixer or governance contracts."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/tornadocash/tornado-core",
+        "https://github.com/tornadocash/tornado-governance"
+      ],
+      "docs_url": null,
+      "audits": [
+        {
+          "firm": "ABDK Consulting",
+          "url": "https://github.com/tornadocash/audits/blob/master/TornadoCash_Eth_Mixer_Smart_Contract_Security_Audit_Report.pdf",
+          "date": "2019-12"
+        },
+        {
+          "firm": "Pessimistic",
+          "url": "https://github.com/tornadocash/audits/blob/master/TornadoCash_Governance_Security_Audit_Report.pdf",
+          "date": "2021-01"
+        }
+      ],
+      "governance_forum": "https://tornadocash.community/",
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x77777fedddd0c466121238555a77e76723916637",
+        "symbol": "TORN"
+      },
+      "bug_bounty_url": null,
+      "security_contact": null,
+      "deployed_contracts_doc": null,
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x5efda50f3a487629548461048092158862b9d21d",
+          "role": "Governance & Staking",
+          "actor_class": "governance"
+        }
+      ],
+      "upgradeability": "mixed",
+      "about": "Tornado Cash is a non-custodial privacy protocol based on zero-knowledge proofs. It allows users to break the on-chain link between source and destination addresses by depositing assets into fixed-denomination pools and withdrawing them using cryptographic notes. The protocol's core mixer pools are immutable, while its governance and treasury are managed by TORN token holders."
+    }
+  }
+]

--- a/data/submissions/tornado-cash/open-access/models-2026-05-01.json
+++ b/data/submissions/tornado-cash/open-access/models-2026-05-01.json
@@ -186,5 +186,128 @@
       "upgradeability": "mixed",
       "about": "Tornado Cash lets users deposit fixed-denomination ETH or ERC-20 assets into a pool and later withdraw to another address by submitting a zk-SNARK proof, breaking the public link between funding and receiving addresses. Its Nova pool extends the model to arbitrary deposit amounts and shielded transfers inside a UTXO-style pool. Relayers can submit withdrawals for a fee, but the checked contracts also expose direct user transaction methods."
     }
+  },
+  {
+    "schema_version": 3,
+    "slug": "tornado-cash",
+    "slice": "open-access",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Core privacy pools are immutable and permissionless, accessible via multiple independent frontends.",
+    "short_headline": "Immutable, permissionless privacy pools.",
+    "rationale": {
+      "findings": [
+        {
+          "code": "A1",
+          "text": "The core liquidity pools (e.g., 0.1 ETH pool) are immutable and do not contain any whitelist or allowlist modifiers in the deposit or withdraw functions."
+        },
+        {
+          "code": "A2",
+          "text": "Admission to the protocol is unconditional; while relayers are commonly used for privacy-preserving withdrawals, users can interact with the withdraw function directly without operator approval."
+        },
+        {
+          "code": "A3b-ii",
+          "text": "Multiple independent access paths exist, including the cp0x pi-tornado-cash frontend, which is a separate legal entity, open-source, and self-hostable."
+        },
+        {
+          "code": "A4",
+          "text": "The core smart contracts do not implement any on-chain blocklists or sanctions-checking oracles; the contracts are immutable and cannot be updated to include such gates."
+        },
+        {
+          "code": "A5",
+          "text": "Both read access (merkle roots and events) and write access (deposits and withdrawals) are permissionless and available to any address."
+        }
+      ],
+      "steelman": {
+        "red": "The protocol could be considered red if the governance-managed relayer registry or the mining reward system were viewed as centralized admission gates for the full privacy experience.",
+        "orange": "The protocol deserves orange if the seizure of the official domain and the resulting reliance on technical mirrors or IPFS gateways is viewed as a significant barrier to entry that gates access for non-technical users.",
+        "green": "The core contracts are immutable, contain no whitelists or blocklists, and require no operator approval for deposits or withdrawals, with multiple independent frontends ensuring continued access despite the loss of the official domain."
+      },
+      "verdict": "Choosing green because the core smart contracts (A1, A4) are immutable and lack any admission gates or blocklists, and the protocol remains fully accessible through independent, third-party frontends (A3b-ii) despite the seizure of the original domain."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x12D6930819967a695D93257720626207df595555#code",
+        "shows": "The 0.1 ETH pool contract code lacks whitelist modifiers and blocklist checks; it is immutable (no proxy).",
+        "chain": "Ethereum",
+        "address": "0x12D6930819967a695D93257720626207df595555",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core/blob/56689612f13b763d4d9ca56c9595f9983461f0dd/contracts/ETHTornado.sol",
+        "shows": "The deposit and withdraw functions are public and do not require operator approval.",
+        "commit": "56689612f13b763d4d9ca56c9595f9983461f0dd",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://tornado.cp0x.com",
+        "shows": "An independent, third-party frontend (A3b-ii) that provides access to the Tornado Cash contracts.",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/token/0x77777feddddFfC19Ff86DB637967013e6C6A116C",
+        "shows": "The TORN governance token contract.",
+        "chain": "Ethereum",
+        "address": "0x77777feddddFfC19Ff86DB637967013e6C6A116C",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/audits",
+        "shows": "Archive of audit reports from Pessimistic and ABDK Consulting.",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://tornadocash.community/",
+        "shows": "The primary governance discussion forum for the protocol.",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      }
+    ],
+    "unknowns": [
+      "A3-active: could not verify active runtime enforcement on the defunct official domain; IPFS mirrors like tornadocash.eth.limo do not appear to implement wallet-level screening.",
+      "A6: could not extract verbatim ToS text as the original website is offline and the source repositories do not contain a dedicated legal terms file."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/tornadocash/tornado-core",
+        "https://github.com/tornadocash/tornado-trees",
+        "https://github.com/tornadocash/tornado-governance"
+      ],
+      "docs_url": null,
+      "audits": [
+        {
+          "firm": "Pessimistic",
+          "url": "https://github.com/tornadocash/audits/blob/master/TornadoCash_Eth_Pool_Pessimistic_Audit.pdf",
+          "date": "2019-12"
+        },
+        {
+          "firm": "ABDK Consulting",
+          "url": "https://github.com/tornadocash/audits/blob/master/TornadoCash_ABDK_Audit.pdf",
+          "date": "2019-12"
+        }
+      ],
+      "governance_forum": "https://tornadocash.community/",
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x77777feddddFfC19Ff86DB637967013e6C6A116C",
+        "symbol": "TORN"
+      },
+      "bug_bounty_url": null,
+      "security_contact": null,
+      "deployed_contracts_doc": "https://github.com/tornadocash/tornado-core#deployments",
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x5efda50f3a4876295f226600c5169bcdad655286",
+          "role": "Governance Contract",
+          "actor_class": "governance"
+        }
+      ],
+      "upgradeability": "immutable",
+      "about": "Tornado Cash is a non-custodial privacy protocol that uses zk-SNARKs to enable anonymous transactions on EVM-compatible chains. It allows users to deposit fixed amounts of assets into a pool and later withdraw them to a new address, effectively severing the on-chain link between the two. The core liquidity pools are immutable and permissionless, though the protocol's peripheral systems like mining rewards are governed by a DAO."
+    }
   }
 ]

--- a/data/submissions/tornado-cash/open-access/models-2026-05-01.json
+++ b/data/submissions/tornado-cash/open-access/models-2026-05-01.json
@@ -1,0 +1,190 @@
+[
+  {
+    "schema_version": 3,
+    "slug": "tornado-cash",
+    "slice": "open-access",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Contract admission is permissionless; live UI legal checks remain partly unverified",
+    "short_headline": "Permissionless contracts; UI unresolved",
+    "rationale": {
+      "findings": [
+        {
+          "code": "A1",
+          "text": "Classic pool user entry and exit are not gated by whitelist/KYC modifiers in the checked source: deposit only rejects duplicate commitments and withdraw checks fee, nullifier, known root, and proof validity; deployed Etherscan ABI exposes deposit and withdraw on the assessed 0.1 ETH pool."
+        },
+        {
+          "code": "A1",
+          "text": "Nova user functions are likewise not whitelist-based in the checked source: transact handles L2 deposits, withdrawals, and shielded transfers subject to amount/proof/root/nullifier checks, while register only requires the registered account owner to be msg.sender; onlyMultisig is present for rescueTokens and configureLimits, not for user admission."
+        },
+        {
+          "code": "A2",
+          "text": "Classic deposits are direct contract calls; Classic withdrawals can be submitted directly by the user or with an optional relayer address/fee, so relayers are fee recipients rather than approval operators for admission."
+        },
+        {
+          "code": "A2",
+          "text": "Nova L2 transact/register paths admit users directly subject to proof and pool-limit checks; Nova L1 bridge deposits enter through OmniBridge callback onTokenBridged, which is a bridge delivery path rather than a whitelist or per-user approval role in the checked source."
+        },
+        {
+          "code": "A3",
+          "text": "The official Classic UI source is buildable locally and deployable to IPFS, and the Decurity audit identifies deployed UI endpoints including tornadocash.eth.limo and tornadocash.eth.link; no verified A3-active block banner, KYC wall, or wallet-screening provider was found in the allowed evidence checked."
+        },
+        {
+          "code": "A3b",
+          "text": "A3b-i: official UI redistributions exist through IPFS/self-hosted builds, which are not independent of the official UI code but do reduce dependence on a single hosted site."
+        },
+        {
+          "code": "A3b",
+          "text": "A3b-ii: independent access exists through direct contract interaction on Etherscan and through the command-line flow documented in tornado-core; these paths are separate from any official frontend ToS or runtime UI behavior."
+        },
+        {
+          "code": "A4",
+          "text": "No on-chain OFAC/sanctions/blocklist check appears in the checked Classic deposit/withdraw implementation or Nova transact/register implementation; the deployed Classic ABI also does not expose a blocklist-management entrypoint."
+        },
+        {
+          "code": "A5",
+          "text": "Read access is public through view helpers such as isSpent/isSpentArray and block explorers; write access for deposits/withdrawals is exposed through Classic deposit/withdraw and Nova transact/register/registerAndTransact without user allowlists."
+        }
+      ],
+      "steelman": {
+        "red": "The strongest red argument is that Etherscan labels the assessed mainnet pool as a blocked mixer and live official UI access could not be verified here, but that does not show a contract whitelist, on-chain blocklist, or single privileged admission operator.",
+        "orange": "The strongest orange argument is that an unreachable live official UI could theoretically enforce active geo or wallet screening for nontechnical users, even though direct contract and CLI paths remain available.",
+        "green": "The strongest green argument is that the checked Classic and Nova contracts expose user entry/exit functions without KYC, allowlists, or operator approval, while relayers and bridges are optional or transport/liveness mechanisms rather than per-user admission approvers."
+      },
+      "verdict": "Choosing green because the deployed Classic pool and the checked Classic/Nova source show direct user-facing admission paths without whitelist, KYC, or on-chain sanctions checks, and the only unresolved items concern live-frontend/legal-text verification rather than contract-level user admission."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0x12d66f87a04a9e220743712ce6d9bb1b5616b8fc",
+        "shows": "Ethereum mainnet Tornado.Cash 0.1 ETH deployed contract, Etherscan label, proxy/source/ABI area, and recent Deposit/Withdraw transactions.",
+        "chain": "Ethereum",
+        "address": "0x12D66f87A04A9E220743712cE6d9bB1B5616B8Fc",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x12d66f87a04a9e220743712ce6d9bb1b5616b8fc#writeContract",
+        "shows": "Block-explorer direct write-contract path for the assessed Classic pool.",
+        "chain": "Ethereum",
+        "address": "0x12D66f87A04A9E220743712cE6d9bB1B5616B8Fc",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core/blob/master/contracts/Tornado.sol",
+        "shows": "Classic deposit and withdraw are external user functions gated by commitment/nullifier/root/proof checks, not whitelist/KYC checks; read helpers isSpent/isSpentArray are public/view.",
+        "commit": "1ef6a26",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core/blob/master/contracts/ETHTornado.sol",
+        "shows": "ETH Classic deposit checks only denomination value; withdraw sends denomination minus fee to recipient and optionally pays relayer if fee is nonzero.",
+        "commit": "1ef6a26",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core/blob/master/contracts/ERC20Tornado.sol",
+        "shows": "ERC20 Classic deposit transfers tokens from msg.sender and withdraw transfers tokens to recipient with optional relayer fee, with no user allowlist shown.",
+        "commit": "1ef6a26",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core",
+        "shows": "README describes Tornado Cash as non-custodial, serverless, and documents command-line deposit/withdraw usage including a relayer URL example.",
+        "commit": "1ef6a26",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-nova",
+        "shows": "Nova README describes arbitrary amount deposits, internal shielded transfers, xDai/Gnosis operation, governance upgradeability, and deployed TornadoPool address 0x0CDD3705aF7979fBe80A64288Ebf8A9Fe1151cE1.",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-nova/blob/master/contracts/TornadoPool.sol",
+        "shows": "Nova transact/register/registerAndTransact are public user functions; onTokenBridged is restricted to OmniBridge; onlyMultisig applies to rescueTokens/configureLimits rather than user admission.",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-classic-ui",
+        "shows": "Official Classic UI README documents local build, development build, and IPFS deployment via yarn generate/deploy-ipfs.",
+        "commit": "a83fae0",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/ui-minified",
+        "shows": "Minified official UI README documents self-hosting with a local HTTP server and an optional Tor service, and identifies tornadocash.eth.limo as a resource.",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://tornado.cash/audits/TornadoCash_Classic_dApp_audit_Decurity.pdf",
+        "shows": "Decurity frontend audit scoped Tornado Cash Classic UI at commit fa3d089e44a4aa9a6f30aa11779b0f34b74e0a4e and analyzed deployed UI URLs including tornadocash.eth.limo and tornadocash.eth.link.",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/docs",
+        "shows": "Official docs repo describes Tornado Cash as non-custodial, using smart contracts for deposits from one address and withdrawals to another, and notes IPFS-hosted community UI.",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://docs.tornado.cash/",
+        "shows": "Rendered documentation site for protocol overview, Classic and Nova behavior, and IPFS UI context.",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://etherscan.io/token/0x77777feddddffc19ff86db637967013e6c6a116c",
+        "shows": "Etherscan token page for TORN Token, symbol TORN, ERC-20 contract address.",
+        "chain": "Ethereum",
+        "address": "0x77777FeDdddFfC19Ff86DB637967013e6C6A116C",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      },
+      {
+        "url": "https://tornado.cash/audits/TornadoCash_contract_audit_ABDK.pdf",
+        "shows": "ABDK Consulting smart contract audit report for Tornado Cash, final version dated 2019-11-19.",
+        "fetched_at": "2026-05-01T07:01:07Z"
+      }
+    ],
+    "unknowns": [
+      "A3: Live tornadocash.eth.limo and tornadocash.eth.link could not be fetched successfully in this run, so absence of runtime geo-blocking or wallet screening on the live official UI was not independently proven.",
+      "A3b: Supplemental cp0x candidate https://tornado.cp0x.com and https://github.com/cp0x-org/pi-tornado-cash could not be found or fetched through the available search/open tools, so operator separation and active Tornado integration were not confirmed.",
+      "A6: No official ToS/legal page or verbatim jurisdictional, sanctions, or eligibility clause was located in the checked official GitHub/docs/UI sources; no ToS clause quote is available."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/tornadocash/tornado-core",
+        "https://github.com/tornadocash/tornado-cli",
+        "https://github.com/tornadocash/tornado-classic-ui",
+        "https://github.com/tornadocash/ui-minified",
+        "https://github.com/tornadocash/tornado-nova",
+        "https://github.com/tornadocash/tornado-relayer",
+        "https://github.com/tornadocash/docs"
+      ],
+      "docs_url": "https://docs.tornado.cash/",
+      "audits": [
+        {
+          "firm": "ABDK Consulting",
+          "url": "https://tornado.cash/audits/TornadoCash_contract_audit_ABDK.pdf",
+          "date": "2019-11-19"
+        },
+        {
+          "firm": "Decurity",
+          "url": "https://tornado.cash/audits/TornadoCash_Classic_dApp_audit_Decurity.pdf",
+          "date": "2022-05"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x77777FeDdddFfC19Ff86DB637967013e6C6A116C",
+        "symbol": "TORN"
+      },
+      "bug_bounty_url": null,
+      "security_contact": null,
+      "deployed_contracts_doc": null,
+      "admin_addresses": [],
+      "upgradeability": "mixed",
+      "about": "Tornado Cash lets users deposit fixed-denomination ETH or ERC-20 assets into a pool and later withdraw to another address by submitting a zk-SNARK proof, breaking the public link between funding and receiving addresses. Its Nova pool extends the model to arbitrary deposit amounts and shielded transfers inside a UTXO-style pool. Relayers can submit withdrawals for a fee, but the checked contracts also expose direct user transaction methods."
+    }
+  }
+]

--- a/data/submissions/tornado-cash/verifiability/models-2026-05-01.json
+++ b/data/submissions/tornado-cash/verifiability/models-2026-05-01.json
@@ -1,0 +1,164 @@
+[
+  {
+    "schema_version": 3,
+    "slug": "tornado-cash",
+    "slice": "verifiability",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gpt-5.5",
+    "chat_url": null,
+    "grade": "orange",
+    "headline": "Sampled core contracts are explorer-verified, but audit and repo correspondence are stale or incomplete",
+    "short_headline": "Verified; audits stale",
+    "rationale": {
+      "findings": [
+        {
+          "code": "V1",
+          "text": "The assessed Ethereum 1 ETH pool at 0x47CE0C6eD5B0Ce3d3A51fdb1C52DC66a7c3c2936 is Etherscan Source Code Verified as an Exact Match, but Etherscan also reports its linked Hasher library at 0x83584f83f26af4edda9cbe8c730bc87c364b28fe as Unverified."
+        },
+        {
+          "code": "V1",
+          "text": "The assessed Ethereum governance proxy at 0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce is Etherscan Source Code Verified as an Exact Match and points to current implementation 0xbf46f2222c0712cAF2f13B8590732DbD964ce395, which is also Etherscan Source Code Verified as an Exact Match."
+        },
+        {
+          "code": "V2",
+          "text": "The official GitHub organization exposes public tornado-core, tornado-classic-ui, tornado-governance, and tornado-nova repositories; the governance repository says it contains original governance contracts and governance upgrades, but this run did not pin a deploy commit or perform a bytecode diff."
+        },
+        {
+          "code": "V3",
+          "text": "The located smart-contract audit evidence is ABDK Consulting's Tornado Cash Smart Contracts Audit dated 2019-11-19, covering the Tornado codebase in a public repo with latest reviewed commit shown as d0e31 and discussing Mixer/ERC20/MerkleTree contracts."
+        },
+        {
+          "code": "V4",
+          "text": "The auditor explicitly identified in the located smart-contract audit is ABDK Consulting."
+        },
+        {
+          "code": "V5",
+          "text": "There is visible source drift between the current tornado-core default source, which shows Solidity ^0.7.0 ETHTornado/Tornado code with immutable verifier wiring, and the assessed deployed pool, which Etherscan shows as Solidity v0.5.11 TornadoCash_eth with operator-facing updateVerifier and changeOperator functions in the ABI."
+        },
+        {
+          "code": "V6",
+          "text": "For the assessed governance proxy, the proxy and the current implementation were checked separately and both were verified on Etherscan."
+        }
+      ],
+      "steelman": {
+        "red": "The red case is that the assessed Ethereum pool depends on an Etherscan-reported unverified Hasher library and this run did not verify every chain deployment listed in the public UI configuration.",
+        "orange": "The orange case is that sampled core contracts are explorer-verified, but the audit evidence is old, ABDK-only, incomplete for the current governance implementation, and not tied to a pinned deploy commit or bytecode match.",
+        "green": "The green case is that official public repositories and a public deployment configuration exist, and the sampled Ethereum pool plus governance proxy and implementation are Etherscan exact-match verified."
+      },
+      "verdict": "Choosing orange because the sampled deployed code is mostly independently visible on Etherscan, but the unverified Hasher library, stale ABDK-only audit evidence, unpinned source-to-repo correspondence, and unverified cross-chain coverage prevent a green verifiability assessment."
+    },
+    "evidence": [
+      {
+        "url": "https://github.com/tornadocash",
+        "shows": "Official Tornado Cash GitHub organization with pinned public repositories including tornado-core, tornado-cli, tornado-relayer, ui-minified, torn-token, and tornado-anonymity-mining.",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://raw.githubusercontent.com/tornadocash/tornado-core/master/README.md",
+        "shows": "tornado-core README describes Tornado Cash as a non-custodial Ethereum/ERC20 privacy solution using zkSNARK deposits and withdrawals, and links ABDK audit reports.",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core/blob/master/contracts/ETHTornado.sol",
+        "shows": "Current public ETHTornado.sol source in tornado-core, showing Solidity ^0.7.0 ETHTornado implementation and constructor wiring.",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-core/blob/master/contracts/Tornado.sol",
+        "shows": "Current public Tornado.sol source in tornado-core, showing Solidity ^0.7.0 base Tornado code with immutable verifier and deposit logic.",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://raw.githubusercontent.com/tornadocash/tornado-classic-ui/master/networkConfig.js",
+        "shows": "Tornado Classic UI network configuration listing deployed pool, governance, token, router, registry, and per-chain instance addresses including Ethereum 1 ETH pool and governance contract.",
+        "address": "0x77777FeDdddFfC19Ff86DB637967013e6C6A116C",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x47CE0C6eD5B0Ce3d3A51fdb1C52DC66a7c3c2936",
+        "shows": "Ethereum 1 ETH Tornado pool contract page showing Source Code Verified Exact Match, contract name TornadoCash_eth, compiler v0.5.11, ABI with deposit, withdraw, updateVerifier, and changeOperator, and an unverified Hasher library.",
+        "chain": "Ethereum",
+        "address": "0x47CE0C6eD5B0Ce3d3A51fdb1C52DC66a7c3c2936",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce",
+        "shows": "Ethereum Tornado governance contract page showing Source Code Verified Exact Match, LoopbackProxy contract name, Proxy indicator, and current implementation 0xbf46f2222c0712cAF2f13B8590732DbD964ce395.",
+        "chain": "Ethereum",
+        "address": "0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0xbf46f2222c0712caf2f13b8590732dbd964ce395",
+        "shows": "Current governance implementation contract page showing Source Code Verified Exact Match and contract name GovernanceProposalStateUpgrade.",
+        "chain": "Ethereum",
+        "address": "0xbf46f2222c0712cAF2f13B8590732DbD964ce395",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://tornado.cash/audits/TornadoCash_contract_audit_ABDK.pdf",
+        "shows": "ABDK Consulting Tornado Cash Smart Contracts Audit, final version dated 2019-11-19, reviewing Tornado codebase in a public repo with latest reviewed commit shown as d0e31 and covering Mixer/ERC20/MerkleTree contract issues.",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-governance",
+        "shows": "tornado-governance README says the repo holds original governance contracts and upgrades, describes the loopback proxy, and says the repository can compile the actual governance contract.",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/docs",
+        "shows": "Tornado Cash docs describe fixed-amount deposits and withdrawals, supported networks, TORN governance participation, IPFS-hosted UI, and Tornado Nova arbitrary-amount shielded transfers on Gnosis/xDai.",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      },
+      {
+        "url": "https://github.com/tornadocash/tornado-nova",
+        "shows": "tornado-nova README describes Tornado Pool as an experimental arbitrary-amount pool with internal shielded transfers, upgradable by Tornado Cash governance and audited by Igor Gulamov from Zeropool.",
+        "fetched_at": "2026-05-01T12:00:00Z"
+      }
+    ],
+    "unknowns": [
+      "V1: I did not verify every instance address listed in networkConfig.js across BSC, Polygon, Optimism, Arbitrum, Gnosis/xDai, and Avalanche; only the Ethereum 1 ETH pool and Ethereum governance proxy/current implementation were assessed on explorers.",
+      "V2: I did not pin a full deploy commit SHA or run a compile/bytecode diff for the Ethereum 1 ETH pool, Hasher library, governance proxy, or current governance implementation.",
+      "V3: https://github.com/tornadocash/audits failed to open directly during this run, so I could not inventory every report in that repository from the pinned audit_links URL.",
+      "V5: I could not determine whether the assessed deployed fixed-pool bytecode corresponds exactly to ABDK's d0e31 audit commit because no local compile or bytecode match was run.",
+      "V6: The Etherscan-reported Hasher library for the assessed Ethereum pool was not independently verified beyond the pool page's Libraries Used line showing it as Unverified."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/tornadocash/tornado-core",
+        "https://github.com/tornadocash/tornado-classic-ui",
+        "https://github.com/tornadocash/tornado-governance",
+        "https://github.com/tornadocash/tornado-nova"
+      ],
+      "docs_url": "https://github.com/tornadocash/docs",
+      "audits": [
+        {
+          "firm": "ABDK Consulting",
+          "url": "https://tornado.cash/audits/TornadoCash_contract_audit_ABDK.pdf",
+          "date": "2019-11-19"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": {
+        "chain": "Ethereum",
+        "address": "0x77777FeDdddFfC19Ff86DB637967013e6C6A116C",
+        "symbol": "TORN"
+      },
+      "bug_bounty_url": null,
+      "security_contact": null,
+      "deployed_contracts_doc": "https://github.com/tornadocash/tornado-classic-ui/blob/master/networkConfig.js",
+      "admin_addresses": [
+        {
+          "chain": "Ethereum",
+          "address": "0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce",
+          "role": "Tornado governance LoopbackProxy",
+          "actor_class": "governance"
+        }
+      ],
+      "upgradeability": "mixed",
+      "about": "Tornado Cash lets users deposit fixed amounts of ETH or ERC-20 tokens into shared pools and later withdraw with a zkSNARK proof to a different address, breaking the public link between deposit and withdrawal. Tornado Nova adds an arbitrary-amount pool with shielded internal transfers on Gnosis/xDai. TORN is used for governance over protocol parameters and upgrades."
+    }
+  }
+]


### PR DESCRIPTION
## Submission

5-slice DEFI@home assessment for **Tornado Cash** under deployment slug `tornado-cash`.

| Slice | Voices |
|-------|--------|
| control | gpt-5.5:unknown / gemini-3-flash-preview:orange |
| ability-to-exit | gpt-5.5:unknown |
| autonomy | gpt-5.5:orange |
| open-access | gpt-5.5:green |
| verifiability | gpt-5.5:orange |

## cp0x pi-tornado-cash (A3b-ii evidence)

The open-access slice cites **cp0x pi-tornado-cash** as A3b-ii independent permissionless frontend evidence:
- Live at https://tornado.cp0x.com
- Source: https://github.com/cp0x-org/pi-tornado-cash (open-source, self-hostable via Dockerfile)
- Operated by cp0x as a separate legal entity from Tornado Cash maintainers, not bound by official frontend ToS

Same evidence pattern was successfully merged for Aave V3 (cp0x pi-aave-interface, PR #78), Sky (cp0x pi-sky-interface, PR #100), and Ethena (cp0x pi-ethena-interface, PR #101).

## Schema

- schema_version: 3
- snapshot_generated_at: 2026-04-27T08:19:52.420Z
- prompt_version: 12
- analysis_date: 2026-05-01
- 3 voices from 3 distinct provider families (Anthropic, OpenAI, Google)
