### PR TITLE
api: replace Cloudflare-blocked public RPCs; log catch paths

### DIFF
--- a/apps/web/src/lib/onchain/chains.ts
+++ b/apps/web/src/lib/onchain/chains.ts
@@ -26,7 +26,10 @@ export interface ChainEntry {
 }
 
 const SUPPORTED: Record<number, ChainEntry> = {
-  1: { name: "ethereum", viemChain: viemChains.mainnet, alchemySlug: "eth-mainnet", publicRpc: "https://eth.llamarpc.com" },
+  // PublicNode used for the chains where the obvious public RPC sits behind
+  // Cloudflare bot protection (eth.llamarpc.com returns a JS challenge to
+  // datacenter IPs, which makes it useless as a Vercel-side fallback).
+  1: { name: "ethereum", viemChain: viemChains.mainnet, alchemySlug: "eth-mainnet", publicRpc: "https://ethereum-rpc.publicnode.com" },
   10: { name: "optimism", viemChain: viemChains.optimism, alchemySlug: "opt-mainnet", publicRpc: "https://mainnet.optimism.io" },
   137: { name: "polygon", viemChain: viemChains.polygon, alchemySlug: "polygon-mainnet", publicRpc: "https://polygon-rpc.com" },
   42161: { name: "arbitrum", viemChain: viemChains.arbitrum, alchemySlug: "arb-mainnet", publicRpc: "https://arb1.arbitrum.io/rpc" },
@@ -36,7 +39,7 @@ const SUPPORTED: Record<number, ChainEntry> = {
   81457: { name: "blast", viemChain: viemChains.blast, alchemySlug: "blast-mainnet", publicRpc: "https://rpc.blast.io" },
   324: { name: "zksync", viemChain: viemChains.zksync, alchemySlug: "zksync-mainnet", publicRpc: "https://mainnet.era.zksync.io" },
   43114: { name: "avalanche", viemChain: viemChains.avalanche, alchemySlug: "avax-mainnet", publicRpc: "https://api.avax.network/ext/bc/C/rpc" },
-  56: { name: "bsc", viemChain: viemChains.bsc, alchemySlug: "bnb-mainnet", publicRpc: "https://bsc-dataseed.bnbchain.org" },
+  56: { name: "bsc", viemChain: viemChains.bsc, alchemySlug: "bnb-mainnet", publicRpc: "https://bsc-rpc.publicnode.com" },
   130: { name: "unichain", viemChain: viemChains.unichain, alchemySlug: "unichain-mainnet", publicRpc: "https://mainnet.unichain.org" },
   11155111: { name: "sepolia", viemChain: viemChains.sepolia, alchemySlug: "eth-sepolia", publicRpc: "https://ethereum-sepolia-rpc.publicnode.com" },
 };

--- a/apps/web/src/pages/api/contract/read.ts
+++ b/apps/web/src/pages/api/contract/read.ts
@@ -116,9 +116,11 @@ export const GET: APIRoute = async ({ url }) => {
     blockNumber = block.number!;
     blockHash = block.hash!;
   } catch (err) {
+    console.error("[/api/contract/read] rpc-block-failed", { rpcLabel, err });
     return errorResponse(502, {
       error: "rpc-block-failed",
       message: `failed to fetch block: ${(err as Error).message}`,
+      hint: `RPC providers tried: ${rpcLabel}`,
     });
   }
 
@@ -152,6 +154,7 @@ export const GET: APIRoute = async ({ url }) => {
   try {
     decoded = decodeFunctionResult({ abi: [fn], functionName: fn.name, data: rawReturnData });
   } catch (err) {
+    console.error("[/api/contract/read] decode-failed", { method: methodRaw, rawReturnData, err });
     return errorResponse(502, {
       error: "decode-failed",
       message: `decode failed: ${(err as Error).message}`,

--- a/apps/web/src/pages/api/safe/owners.ts
+++ b/apps/web/src/pages/api/safe/owners.ts
@@ -51,9 +51,11 @@ export const GET: APIRoute = async ({ url }) => {
     blockNumber = block.number!;
     blockHash = block.hash!;
   } catch (err) {
+    console.error("[/api/safe/owners] rpc-block-failed", { rpcLabel, err });
     return errorResponse(502, {
       error: "rpc-block-failed",
       message: `failed to fetch block: ${(err as Error).message}`,
+      hint: `RPC providers tried: ${rpcLabel}`,
     });
   }
 


### PR DESCRIPTION
In production a request from ChatGPT-User hitting WBTC's paused() returned 502 rpc-block-failed; the response body showed the public-RPC fallback (eth.llamarpc.com) returning Cloudflare's "Just a moment..." JS challenge to Vercel's datacenter IPs. That makes LlamaRPC unusable as a server-side fallback, regardless of whether Alchemy is also failing.

Switch the Ethereum + BSC public RPCs to publicnode.com, which doesn't front through Cloudflare and accepts datacenter traffic. Other chains (Optimism, Polygon, Arbitrum, Base, Linea, Scroll, Blast, zkSync, Avalanche, Unichain, Sepolia) keep their official sequencer / public endpoints — those are not Cloudflare-fronted.

Also: console.error on every catch path in /api/contract/read and /api/safe/owners so future production failures surface their stack traces in Vercel logs instead of forcing us to reproduce them via curl. The error response now also includes the rpcLabel under hint so the caller sees which providers were tried.