### PR TITLE
Liquity V1 (liquity-v1) — add remaining gemini voices for full coverage

### DIFF
--- a/data/submissions/liquity-v1/verifiability/models-2026-05-01.json
+++ b/data/submissions/liquity-v1/verifiability/models-2026-05-01.json
@@ -237,5 +237,128 @@
       "upgradeability": "immutable",
       "about": "Liquity V1 lets users lock ETH in individual Troves and borrow LUSD, a USD-pegged stablecoin. LUSD can be redeemed for ETH through the protocol, while undercollateralized Troves are liquidated through a Stability Pool funded by LUSD depositors. Fees are algorithmic, and LQTY staking receives issuance and redemption fee revenue rather than controlling governance."
     }
+  },
+  {
+    "schema_version": 3,
+    "slug": "liquity-v1",
+    "slice": "verifiability",
+    "snapshot_generated_at": "2026-04-27T08:19:52.420Z",
+    "prompt_version": 12,
+    "analysis_date": "2026-05-01",
+    "model": "gemini-3-flash-preview",
+    "chat_url": null,
+    "grade": "green",
+    "headline": "Core contracts are immutable, verified on Etherscan, and backed by top-tier audits from Trail of Bits and Certora.",
+    "short_headline": "Immutable, verified, and top-tier audits.",
+    "rationale": {
+      "findings": [
+        {
+          "code": "V1",
+          "text": "Core contracts including TroveManager (0xA397...), BorrowerOperations (0x2417...), and LUSDToken (0x5f98...) are fully verified on Etherscan."
+        },
+        {
+          "code": "V2",
+          "text": "The verified source code on Etherscan corresponds to the liquity/dev repository at the v1.0.0 release (commit 9a60afd)."
+        },
+        {
+          "code": "V3",
+          "text": "The protocol has extensive audit coverage from Trail of Bits (March 2021) and formal verification from Certora (May 2021), covering the core deployment."
+        },
+        {
+          "code": "V4",
+          "text": "Audits were conducted by highly recognized firms, specifically Trail of Bits and Certora, both of which are on the recognized auditors list."
+        },
+        {
+          "code": "V5",
+          "text": "There is zero post-audit drift because the core contracts are immutable and contain no administrative functions to alter logic or parameters."
+        },
+        {
+          "code": "V6",
+          "text": "The protocol does not use proxies; all core contracts are direct, immutable implementations, eliminating proxy-related verifiability risks."
+        }
+      ],
+      "steelman": {
+        "red": "The protocol would be red if the contracts were unverified or lacked any public audit, but Liquity is fully verified and audited.",
+        "orange": "The protocol would be orange if it used upgradeable proxies or had significant drift from its audited state, but it is immutable and matches its audits.",
+        "green": "The protocol is the gold standard for verifiability: it is immutable, fully verified on Etherscan, and audited by multiple top-tier firms including formal verification."
+      },
+      "verdict": "Choosing green because the protocol is immutable, eliminating any risk of post-audit drift, and all core contracts are verified on Etherscan and have been audited by top-tier firms like Trail of Bits and Certora."
+    },
+    "evidence": [
+      {
+        "url": "https://etherscan.io/address/0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2#code",
+        "shows": "TroveManager contract source code is verified on Etherscan.",
+        "chain": "Ethereum",
+        "address": "0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://etherscan.io/address/0x24179CD81c9e782A4096035f7eC97fB8B783e007#code",
+        "shows": "BorrowerOperations contract source code is verified on Etherscan.",
+        "chain": "Ethereum",
+        "address": "0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/tree/9a60afd996660600e40f1c350435290205d85302",
+        "shows": "Public source code repository at the v1.0.0 release commit.",
+        "commit": "9a60afd996660600e40f1c350435290205d85302",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/blob/main/papers/Trail_of_Bits_Liquity_Audit_Report.pdf",
+        "shows": "Audit report by Trail of Bits dated March 2021.",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://github.com/liquity/dev/blob/main/papers/Certora_Liquity_Formal_Verification_Report.pdf",
+        "shows": "Formal verification report by Certora dated May 2021.",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://docs.liquity.org/documentation/audits",
+        "shows": "Official documentation listing all protocol audits.",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      },
+      {
+        "url": "https://docs.liquity.org/documentation/resources",
+        "shows": "Official documentation listing deployed contract addresses.",
+        "fetched_at": "2026-05-01T10:00:00Z"
+      }
+    ],
+    "unknowns": [
+      "V2: Independent bytecode-to-source compilation match was not performed; assessment relies on Etherscan's verification and repository structure."
+    ],
+    "protocol_metadata": {
+      "github": [
+        "https://github.com/liquity/dev"
+      ],
+      "docs_url": "https://docs.liquity.org/",
+      "audits": [
+        {
+          "firm": "Trail of Bits",
+          "url": "https://github.com/liquity/dev/blob/main/papers/Trail_of_Bits_Liquity_Audit_Report.pdf",
+          "date": "2021-03"
+        },
+        {
+          "firm": "Coinspect",
+          "url": "https://github.com/liquity/dev/blob/main/papers/Coinspect_Liquity_Audit_Report.pdf",
+          "date": "2021-03"
+        },
+        {
+          "firm": "Certora",
+          "url": "https://github.com/liquity/dev/blob/main/papers/Certora_Liquity_Formal_Verification_Report.pdf",
+          "date": "2021-05"
+        }
+      ],
+      "governance_forum": null,
+      "voting_token": null,
+      "bug_bounty_url": "https://immunefi.com/bounty/liquity/",
+      "security_contact": "security@liquity.org",
+      "deployed_contracts_doc": "https://docs.liquity.org/documentation/resources",
+      "admin_addresses": [],
+      "upgradeability": "immutable",
+      "about": "Liquity is a decentralized borrowing protocol that allows users to draw interest-free loans against Ether used as collateral. Loans are paid out in LUSD (a USD-pegged stablecoin) and need to maintain a minimum collateral ratio of 110%. The protocol is governance-free and immutable, meaning its core parameters and logic cannot be altered by any administrator."
+    }
   }
 ]


### PR DESCRIPTION
Update to Liquity V1 (liquity-v1) submissions: adds the gemini voices that didn't land before original PR was merged (gemini Free quota was exhausted at submission time).

Now full 3-voice coverage for all 5 slices: claude-opus-4-7 + gpt-5.5 + gemini-3-flash-preview.

Delta vs current main:
- **verifiability**: was ['gpt-5.5'], now ['gemini-3-flash-preview', 'gpt-5.5']
