### PR TITLE
Add Rocket Pool verifiability assessment

### DIFF
--- a/data/submissions/rocket-pool/verifiability/codex-gpt-5-2026-05-13.json
+++ b/data/submissions/rocket-pool/verifiability/codex-gpt-5-2026-05-13.json
@@ -1,0 +1,180 @@
+{
+  "schema_version": 4,
+  "slug": "rocket-pool",
+  "slice": "verifiability",
+  "snapshot_generated_at": "2026-05-11T09:35:21.490Z",
+  "prompt_version": 29,
+  "analysis_date": "2026-05-13",
+  "model": "gpt-5-codex",
+  "chat_url": null,
+  "grading_basis": "mixed",
+  "grade": "orange",
+  "headline": "Core Rocket Pool contracts inspected in this run are verified and public-source-backed, but recognized audit coverage is stale relative to the May 2026 assessment date.",
+  "short_headline": "Verified, stale audits",
+  "rationale": {
+    "findings": [
+      {
+        "code": "V1",
+        "text": "The inspected core contracts are independently verified: rETH at 0xae78736Cd615f374D3085123A210448E74Fc6393 and RocketStorage at 0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46 return verified=true from the defipunkd ABI surfacer with etherscan as the ABI source, while RocketDAOProtocol at 0x0429Cdd8cEACe24d4dC2B97Ce22A780a407dF0e1 returns verified=true with sourcify as the ABI source."
+      },
+      {
+        "code": "V2",
+        "text": "A public canonical Rocket Pool contract repository exists at github.com/rocket-pool/rocketpool, and the inspected contract names and ABI surfaces match repository-level contract roles such as RocketTokenRETH, RocketStorage, and RocketDAOProtocol. This run did not pin an exact deploy commit or reproduce a bytecode build."
+      },
+      {
+        "code": "V3",
+        "text": "Recognized audit coverage exists from Trail of Bits, ConsenSys Diligence, Sigma Prime, and ChainSafe across the original system, Atlas, Houston, and later Houston hotfix review material. The newest audit artifact identified in the submitted metadata set is the Sigma Prime Houston hotfix review dated 2024-08, roughly 21 months before this 2026-05-13 assessment."
+      },
+      {
+        "code": "V4",
+        "text": "Trail of Bits, ConsenSys Diligence, Sigma Prime, and ChainSafe are all recognized Solidity/security audit firms under the verifiability rubric, so the downgrade is not auditor quality."
+      },
+      {
+        "code": "V5",
+        "text": "Audit coverage is stale for a May 2026 view: even counting the 2024-08 Houston hotfix review as the latest relevant follow-up, it is well beyond the six-month green threshold, and this run did not locate a later recognized-firm differential review covering post-hotfix protocol changes."
+      },
+      {
+        "code": "V6",
+        "text": "The ABI surfacer responses for rETH, RocketStorage, and RocketDAOProtocol did not report proxy implementations, so there is no verified-proxy/unverified-implementation gap for the inspected contracts. The broader RocketStorage registry can still point to additional contracts that were not exhaustively enumerated in this run."
+      }
+    ],
+    "steelman": {
+      "red": "A red grade would require no public repo, no recognized audit coverage, unverified bytecode, or a verified proxy with an unverified implementation; the inspected core contracts do not show those failures.",
+      "orange": "The inspected contracts are verified and backed by public source, but the latest recognized audit or hotfix review found is far older than six months and the broader RocketStorage-registered contract set was not exhaustively checked.",
+      "green": "The strongest green argument is that rETH, RocketStorage, and RocketDAOProtocol are verified, non-proxy in the surfacer responses, publicly source-backed, and covered historically by multiple recognized auditors."
+    },
+    "verdict": "Choosing orange because the verified-code and recognized-auditor evidence is strong for the inspected core contracts, but the audit freshness condition is not met as of 2026-05-13 and no later recognized differential audit was found for post-hotfix changes."
+  },
+  "evidence": [
+    {
+      "url": "https://defipunkd.com/api/contract/abi?chainId=1&address=0xae78736cd615f374d3085123a210448e74fc6393",
+      "shows": "ABI surfacer returned RocketTokenRETH, verified=true, abiSource=etherscan, and no proxy object for rETH.",
+      "chain": "Ethereum",
+      "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+      "fetched_at": "2026-05-13T16:40:00Z"
+    },
+    {
+      "url": "https://defipunkd.com/api/contract/read?chainId=1&address=0xae78736cd615f374d3085123a210448e74fc6393&method=getExchangeRate",
+      "shows": "Live read of rETH getExchangeRate() succeeded at block 25087463 with abiSource=etherscan and implementation=null, corroborating the verified non-proxy ABI path for the inspected rETH contract.",
+      "chain": "Ethereum",
+      "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+      "fetched_at": "2026-05-13T16:40:00Z"
+    },
+    {
+      "url": "https://defipunkd.com/api/contract/abi?chainId=1&address=0x1d8f8f00cfa6758d7be78336684788fb0ee0fa46",
+      "shows": "ABI surfacer returned RocketStorage, verified=true, abiSource=etherscan, and a setter/getter registry ABI without a proxy implementation object.",
+      "chain": "Ethereum",
+      "address": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46",
+      "fetched_at": "2026-05-13T16:40:00Z"
+    },
+    {
+      "url": "https://defipunkd.com/api/contract/read?chainId=1&address=0x1d8f8f00cfa6758d7be78336684788fb0ee0fa46&method=getGuardian",
+      "shows": "Live read of RocketStorage getGuardian() succeeded at block 25087463 with abiSource=etherscan and implementation=null, returning 0x0cCF14983364A7735d369879603930Afe10df21e.",
+      "chain": "Ethereum",
+      "address": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46",
+      "fetched_at": "2026-05-13T16:40:00Z"
+    },
+    {
+      "url": "https://defipunkd.com/api/contract/abi?chainId=1&address=0x0429cdd8ceace24d4dc2b97ce22a780a407df0e1",
+      "shows": "ABI surfacer returned RocketDAOProtocol, verified=true, abiSource=sourcify, and no proxy object.",
+      "chain": "Ethereum",
+      "address": "0x0429Cdd8cEACe24d4dC2B97Ce22A780a407dF0e1",
+      "fetched_at": "2026-05-13T16:40:00Z"
+    },
+    {
+      "url": "https://defipunkd.com/api/contract/read?chainId=1&address=0x0429cdd8ceace24d4dc2b97ce22a780a407df0e1&method=getBootstrapModeDisabled",
+      "shows": "Live read of RocketDAOProtocol getBootstrapModeDisabled() succeeded at block 25087463 with abiSource=sourcify and implementation=null, returning true.",
+      "chain": "Ethereum",
+      "address": "0x0429Cdd8cEACe24d4dC2B97Ce22A780a407dF0e1",
+      "fetched_at": "2026-05-13T16:40:00Z"
+    },
+    {
+      "url": "https://github.com/rocket-pool/rocketpool",
+      "shows": "Canonical public Rocket Pool smart contract repository used for source correspondence checks."
+    },
+    {
+      "url": "https://github.com/trailofbits/publications/blob/master/reviews/RocketPool.pdf",
+      "shows": "Trail of Bits Rocket Pool audit report is public and attributable to a recognized audit firm."
+    },
+    {
+      "url": "https://diligence.consensys.io/audits/2023/01/rocket-pool-atlas-v1.2/",
+      "shows": "ConsenSys Diligence Atlas v1.2 audit report is public and covers Rocket Pool contract changes from a recognized audit firm."
+    },
+    {
+      "url": "https://consensys.io/diligence/audits/2023/12/rocket-pool-houston/",
+      "shows": "ConsenSys Diligence Houston audit report is public and covers governance/protocol contracts relevant to current control and verification posture."
+    },
+    {
+      "url": "https://rocketpool.net/files/audits/sigma-prime-houston-hotfix-review.pdf",
+      "shows": "Sigma Prime Houston hotfix review is public and dated 2024-08 in existing Rocket Pool assessment metadata, but remains stale relative to the 2026-05-13 assessment date."
+    },
+    {
+      "url": "https://rocketpool.net/files/audits/chainsafe-audit-houston.pdf",
+      "shows": "ChainSafe Houston audit report is public and is from a recognized audit firm, but it predates the assessment by more than six months."
+    }
+  ],
+  "unknowns": [
+    "V2: Exact source-to-deployed-bytecode commit SHA was not pinned or locally rebuilt in this run.",
+    "V3: Audit scope was not exhaustively remapped from every report to every current RocketStorage-registered contract.",
+    "V5: Post-2024-08 changes were not sampled through a full GitHub compare or bytecode-diff workflow, so the materiality of any drift remains a scope limit.",
+    "V6: The verification status of every contract currently reachable through RocketStorage registry keys was not exhaustively enumerated."
+  ],
+  "protocol_metadata": {
+    "github": [
+      "https://github.com/rocket-pool/rocketpool",
+      "https://github.com/rocket-pool/smartnode"
+    ],
+    "docs_url": "https://docs.rocketpool.net",
+    "audits": [
+      {
+        "firm": "Trail of Bits",
+        "url": "https://github.com/trailofbits/publications/blob/master/reviews/RocketPool.pdf",
+        "date": "2021"
+      },
+      {
+        "firm": "ConsenSys Diligence",
+        "url": "https://diligence.consensys.io/audits/2023/01/rocket-pool-atlas-v1.2/",
+        "date": "2023-01"
+      },
+      {
+        "firm": "ConsenSys Diligence",
+        "url": "https://consensys.io/diligence/audits/2023/12/rocket-pool-houston/",
+        "date": "2023-12"
+      },
+      {
+        "firm": "ChainSafe",
+        "url": "https://rocketpool.net/files/audits/chainsafe-audit-houston.pdf",
+        "date": "2024-03"
+      },
+      {
+        "firm": "Sigma Prime",
+        "url": "https://rocketpool.net/files/audits/sigma-prime-houston-hotfix-review.pdf",
+        "date": "2024-08"
+      }
+    ],
+    "governance_forum": "https://dao.rocketpool.net",
+    "voting_token": {
+      "chain": "Ethereum",
+      "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
+      "symbol": "RPL"
+    },
+    "bug_bounty_url": "https://immunefi.com/bug-bounty/rocketpool/information/",
+    "deployed_contracts_doc": "https://docs.rocketpool.net/protocol/contracts-integrations",
+    "admin_addresses": [
+      {
+        "chain": "Ethereum",
+        "address": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46",
+        "role": "RocketStorage registry",
+        "actor_class": "governance"
+      },
+      {
+        "chain": "Ethereum",
+        "address": "0x0429Cdd8cEACe24d4dC2B97Ce22A780a407dF0e1",
+        "role": "RocketDAOProtocol governance contract",
+        "actor_class": "governance"
+      }
+    ],
+    "upgradeability": "mixed",
+    "about": "Rocket Pool is an Ethereum liquid staking protocol where users deposit ETH and receive rETH. Node operators run validators through minipools, while governance and protocol contracts are coordinated through RocketStorage-backed contract registration. This verifiability assessment is limited to public source, verified ABI, proxy posture, and audit freshness rather than a full control or autonomy re-grade."
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a DEFI@home Rocket Pool `verifiability` submission for #227.
- Classifies the reviewed slice as `orange`: inspected core contracts are verified/public-source-backed, but recognized audit coverage is stale for the 2026-05-13 assessment date.
- Includes live defipunkd read evidence for rETH, RocketStorage, and RocketDAOProtocol plus recognized audit references.

## Validation
- `cmd /c corepack pnpm --filter @defipunkd/validator validate data/submissions/rocket-pool/verifiability/codex-gpt-5-2026-05-13.json --json`
- `cmd /c corepack pnpm exec vitest run packages/validator/src/schema.test.ts`

Validator result: no errors. It still warns that this run has no public `chat_url` and that the model is downweighted; I am keeping that transparent because the run was produced in Codex without a public share URL.

Refs #227