### PR TITLE
fix(web): copy button fails for protocol slugs containing a period

### DIFF
--- a/apps/web/src/components/RiskAnalysis.astro
+++ b/apps/web/src/components/RiskAnalysis.astro
@@ -558,7 +558,20 @@ function partialFillGrade(s: SliceAssessment): string {
     let text = btn.getAttribute("data-copy-text") ?? "";
     if (!text) {
       const sel = btn.getAttribute("data-copy-target");
-      const target = sel ? (document.querySelector(sel) as HTMLElement | null) : null;
+      // querySelector parses "." as a class-selector boundary, so an id
+      // selector like "#prompt-ether.fi-stake-control" matches an element
+      // with id "prompt-ether" AND class "fi-stake-control" — never the
+      // intended element. Protocol slugs can contain periods (ether.fi,
+      // ether.fi-stake, ether.fi-liquid), so resolve plain "#id" selectors
+      // via getElementById, which accepts any valid HTML5 id.
+      let target: HTMLElement | null = null;
+      if (sel) {
+        if (sel.startsWith("#")) {
+          target = document.getElementById(sel.slice(1));
+        } else {
+          target = document.querySelector(sel) as HTMLElement | null;
+        }
+      }
       if (!target) return;
       text = target.textContent ?? "";
     }


### PR DESCRIPTION
document.querySelector parses '.' as a class-selector boundary, so when a protocol slug contains a period (ether.fi, ether.fi-stake, ether.fi-liquid) the RiskAnalysis copy-prompt buttons resolved their data-copy-target as e.g. '#prompt-ether.fi-stake-control' = id 'prompt-ether' AND class 'fi-stake-control' — never matching any element, so nothing was copied.

Resolve plain '#id' targets via document.getElementById, which accepts any valid HTML5 id (including periods). querySelector remains the fallback for non-id selectors.